### PR TITLE
Remove obsolete donation addresses from About dialog

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1571,15 +1571,15 @@ void MainWindow::on_actionAbout_MT_triggered()
 {
     const QString appName = QCoreApplication::applicationName();
     QString nameWithVersion = appName + " " + QCoreApplication::applicationVersion();
-    QString copyright = tr("Copyright 2013-2019 MaximumTrainer. All rights reserved");
+    QString copyright = tr("Copyright 2013-2019 maximus321")
+                      + "<br/>"
+                      + tr("Copyright 2019-present MaximumTrainer maintainers");
     this->setStyleSheet("QMessageBox { messagebox-text-interaction-flags: 5; }");
     QMessageBox::about(this,
                        tr("About ") + appName,
                        "<b>"+ nameWithVersion + "</b> - " + tr("Build on ")  + Environnement::getDateBuilded() + "<br/>" +
-                       copyright + "<br/><hr/>" +
-                       tr("Normalized Power®(NP), Training Stress Score®(TSS) and Intensity Factor®(IF) are registered trademarks of Peaksware LLC.") +
-                       "<hr/><b>Donation</b><br/>" +
-                       "BTC:<br/>3LKr2aZabvCn8yadtfPNmLo5GyGiGft6yw<br/>ETH:<br/>0x51B7D1dDE1b3B4c8bfdb70D4B3E4dA2f8511F8AD");
+                       copyright + "<hr/>" +
+                       tr("Normalized Power®(NP), Training Stress Score®(TSS) and Intensity Factor®(IF) are registered trademarks of Peaksware LLC."));
 
 
 }


### PR DESCRIPTION
## Summary

Hi! I'm **maximus321** ([@maximus321](https://github.com/maximus321)) — the original author of this project (2013–2019, when it lived as PowerVelo / MaximumTrainer on GitLab). I just rediscovered the repo and saw that it's still alive and being actively developed — that's wonderful, thank you for keeping it going! 🙏
Ill check a bit more later when I have free time If I can contribute.


This small PR removes the BTC and ETH donation addresses from the **Help → About MaximumTrainer** dialog (`src/ui/mainwindow.cpp:1582`). Those were *my* personal wallet addresses from the original era, and they shouldn't be embedded in the modern fork

I also updated the copyright line so it credits both eras.

## Changes

- Remove `BTC: 3LKr2aZabvCn8yadtfPNmLo5GyGiGft6yw` from the About dialog
- Remove `ETH: 0x51B7D1dDE1b3B4c8bfdb70D4B3E4dA2f8511F8AD` from the About dialog
- Update copyright string from `Copyright 2013-2019 MaximumTrainer. All rights reserved` to `Copyright 2013-2019 maximus321; 2019-present MaximumTrainer maintainers. All rights reserved`

## Test plan

- [ ] Build succeeds on Linux/Windows/macOS via existing CI
- [ ] Help → About MaximumTrainer dialog opens without errors
- [ ] Dialog no longer shows the "Donation" section with BTC/ETH addresses
- [ ] Copyright line shows the updated attribution

