### PR TITLE
fix: correct included_workout resource paths so workouts load on Ubuntu

### DIFF
--- a/src/persistence/file/xmlutil.cpp
+++ b/src/persistence/file/xmlutil.cpp
@@ -544,18 +544,18 @@ QList<Course> XmlUtil::parseCourseLstPath(QStringList lstPath, Course::COURSE_TY
 QList<Workout> XmlUtil::getLstWorkoutRachel() {
 
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-01.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-02.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-03.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-04.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-05.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-06.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-07.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-08.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-09.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-10.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-11.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-12.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-01.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-02.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-03.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-04.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-05.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-06.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-07.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-08.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-09.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-10.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-11.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-12.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 
 }
@@ -564,7 +564,7 @@ QList<Workout> XmlUtil::getLstWorkoutRachel() {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/sufferfest/included_workout/Sufferfest/ISLAGIATT.workout");
+    lstWorkoutPat.append(":/included_workout/sufferfest/resources/included_workout/Sufferfest/ISLAGIATT.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::SUFFERFEST_WORKOUT);
 }
 
@@ -573,88 +573,88 @@ QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
 QList<Workout>  XmlUtil::getLstWorkoutBt16WeeksPlan() {
 
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
 
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 }
@@ -672,7 +672,7 @@ QList<Workout> XmlUtil::getLstUserWorkout() {
 QList<Course> XmlUtil::getLstCourseIncluded() {
 //todo remove dropbox ref
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
     lstWorkoutPat.append("C:/Dropbox/MT/3a.tcx");
     lstWorkoutPat.append("C:/Dropbox/MT/Boucle_Brebeuf_Mont-Tremblant.tcx");
 


### PR DESCRIPTION
## Summary
- The `Rachel`, `Sufferfest`, and `BT 16wk Power Based` lookups in `XmlUtil` built Qt resource paths that omitted the `resources/` segment between the `.qrc` prefix and the file path, so every QFile open in `parseWorkoutLstPath` silently failed and the workouts list ended up empty.
- Reproduced on **Ubuntu**: the app **crashed when double-clicking a workout** because the empty list was then indexed without bounds checks.
- Adds the missing `resources/` segment to the paths in `getLstWorkoutRachel`, `getLstWorkoutSufferfest`, and `getLstWorkoutBt16WeeksPlan` (matching the layout declared in `MyResources.qrc`).

## Test plan
- [ ] Build on Ubuntu
- [ ] Open the included-workout list — Rachel/Sufferfest/BT entries are populated
- [ ] Double-click an included workout — it opens correctly instead of crashing