### PR TITLE
fix: native Qt widgets for Workout List filter & Editor metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Install system packages and build VLC-Qt from source, then build the app:
 sudo apt-get install -y \
   qtbase5-dev qtwebengine5-dev qtconnectivity5-dev \
   libqwt-qt5-dev libsfml-dev libvlc-dev libvlccore-dev \
+  vlc-plugin-base vlc-plugin-video-output \
   cmake build-essential
 
 # Build VLC-Qt 1.1.1 from source
@@ -252,6 +253,8 @@ export PATH=/usr/lib/qt5/bin:$PATH
 qmake PowerVelo.pro "INCLUDEPATH+=/usr/local/include" "LIBS+=-L/usr/local/lib"
 make -j$(nproc)
 ```
+
+> `vlc-plugin-video-output` is required for libvlc to render video into the Workout dialog. Without it, libvlc loads but reports `failed to create video output` and the player shows only the timer.
 
 ### macOS
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -327,7 +327,9 @@ nmake</code></pre>
   qtbase5-dev qtwebengine5-dev \
   qtconnectivity5-dev \
   libqwt-qt5-dev libsfml-dev \
-  libvlc-dev cmake build-essential
+  libvlc-dev vlc-plugin-base \
+  vlc-plugin-video-output \
+  cmake build-essential
 
 qmake PowerVelo.pro
 make -j$(nproc)</code></pre>

--- a/src/persistence/file/xmlutil.cpp
+++ b/src/persistence/file/xmlutil.cpp
@@ -544,18 +544,18 @@ QList<Course> XmlUtil::parseCourseLstPath(QStringList lstPath, Course::COURSE_TY
 QList<Workout> XmlUtil::getLstWorkoutRachel() {
 
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-01.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-02.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-03.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-04.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-05.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-06.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-07.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-08.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-09.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-10.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-11.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-12.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-01.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-02.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-03.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-04.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-05.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-06.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-07.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-08.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-09.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-10.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-11.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-12.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 
 }
@@ -564,7 +564,7 @@ QList<Workout> XmlUtil::getLstWorkoutRachel() {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/sufferfest/included_workout/Sufferfest/ISLAGIATT.workout");
+    lstWorkoutPat.append(":/included_workout/sufferfest/resources/included_workout/Sufferfest/ISLAGIATT.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::SUFFERFEST_WORKOUT);
 }
 
@@ -573,88 +573,88 @@ QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
 QList<Workout>  XmlUtil::getLstWorkoutBt16WeeksPlan() {
 
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
 
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 }
@@ -672,7 +672,7 @@ QList<Workout> XmlUtil::getLstUserWorkout() {
 QList<Course> XmlUtil::getLstCourseIncluded() {
 //todo remove dropbox ref
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
     lstWorkoutPat.append("C:/Dropbox/MT/3a.tcx");
     lstWorkoutPat.append("C:/Dropbox/MT/Boucle_Brebeuf_Mont-Tremblant.tcx");
 

--- a/src/ui/main_workoutpage.cpp
+++ b/src/ui/main_workoutpage.cpp
@@ -9,13 +9,7 @@
 #include "util.h"
 #include "environnement.h"
 #include "workoututil.h"
-
-#include <QWebEngineView>
-#include <QWebEngineProfile>
-#include <QWebEngineScript>
-#include <QWebEnginePage>
-#include <QWebEngineScriptCollection>
-#include <QWebChannel>
+#include "workout.h"
 
 
 
@@ -66,8 +60,37 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     ui->tableView_workout->setModel(proxyModel);
     ui->tableView_workout->verticalHeader()->setDefaultSectionSize(60);
 
-    connectWebChannelWorkout();
-    ui->webView_workouts->setUrl(QUrl(Environnement::getUrlWorkout()));
+    /// Populate the type-filter combobox. Index 0 is "All" (no type filter);
+    /// the remaining entries map onto Workout::Type enum values via userData.
+    ui->comboBox_filter_type->addItem(tr("All types"), -1);
+    ui->comboBox_filter_type->addItem(tr("Endurance"), Workout::T_ENDURANCE);
+    ui->comboBox_filter_type->addItem(tr("Interval"),  Workout::T_INTERVAL);
+    ui->comboBox_filter_type->addItem(tr("Tempo"),     Workout::T_TEMPO);
+    ui->comboBox_filter_type->addItem(tr("Test"),      Workout::T_TEST);
+    ui->comboBox_filter_type->addItem(tr("Other"),     Workout::T_OTHERS);
+    ui->comboBox_filter_type->addItem(tr("Threshold"), Workout::T_THRESHOLD);
+
+    /// Wire each filter input to the existing filterChanged proxy logic.
+    /// QueuedConnection is unnecessary here — proxy invalidation is cheap.
+    connect(ui->lineEdit_filter_name, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("name", v); });
+    connect(ui->lineEdit_filter_plan, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("plan", v); });
+    connect(ui->lineEdit_filter_creator, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("creator", v); });
+    connect(ui->comboBox_filter_type,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &Main_WorkoutPage::onFilterTypeIndexChanged);
+
+    /// Apply the persisted filter state loaded from QSettings to the inputs;
+    /// the textChanged/currentIndexChanged hooks above will then push those
+    /// values into the proxy model.
+    applyFiltersToInputs();
+
+    if (!account->show_included_workout) {
+        ui->checkBox->setChecked(false);
+        filterChangedWorkoutType(false);
+    }
 
 
     ui->tableView_workout->sortByColumn(0, Qt::AscendingOrder);
@@ -117,9 +140,6 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     actionDelete->setEnabled(false);
     actionOpenFolder->setEnabled(false);
 
-
-    connect(ui->webView_workouts, SIGNAL(loadFinished(bool)), this, SLOT(fillWorkoutPage()));
-
 }
 
 
@@ -161,78 +181,51 @@ void Main_WorkoutPage::parseMapWorkout(int userFTP) {
 
 
 //---------------------------------------------------------------------------------------------------------
-void Main_WorkoutPage::connectWebChannelWorkout() {
+void Main_WorkoutPage::applyFiltersToInputs() {
 
+    /// Push the persisted nameFilter/planFilter/creatorFilter/typeFilter
+    /// values into the native input widgets. The textChanged /
+    /// currentIndexChanged signals wired up in the constructor will then
+    /// drive the proxy filter through filterChanged().
+    ui->lineEdit_filter_name->setText(nameFilter);
+    ui->lineEdit_filter_plan->setText(planFilter);
+    ui->lineEdit_filter_creator->setText(creatorFilter);
 
-    qDebug() << "connectWebChannelWorkout";
-
-    QFile webChannelJsFile(":/qtwebchannel/qwebchannel.js");
-    if(  !webChannelJsFile.open(QIODevice::ReadOnly) ) {
-        qDebug() << QString("Couldn't open qwebchannel.js file: %1").arg(webChannelJsFile.errorString());
-    }
-    else {
-        qDebug() << "OK webEngineProfile";
-        QByteArray webChannelJs = webChannelJsFile.readAll();
-        webChannelJs.append(
-                    "\n"
-                    "var workoutObject"
-                    "\n"
-                    "new QWebChannel(qt.webChannelTransport, function(channel) {"
-                    "     workoutObject = channel.objects.workoutObject;"
-                    "});"
-                    "\n"
-                    );
-
-        QWebChannel *channel = new QWebChannel(ui->webView_workouts);
-        QWebEngineScript script;
-        script.setSourceCode(webChannelJs);
-        script.setName("qwebchannel.js");
-        script.setWorldId(QWebEngineScript::MainWorld);
-        script.setInjectionPoint(QWebEngineScript::DocumentCreation);
-        script.setRunsOnSubFrames(false);
-
-        ui->webView_workouts->page()->scripts().insert(script);
-        ui->webView_workouts->page()->setWebChannel(channel);
-        channel->registerObject("workoutObject", this);
-    }
-
-
-    if (!account->show_included_workout) {
-        ui->checkBox->setChecked(false);
-        filterChangedWorkoutType(false);
-    }
-
+    int comboIndex = ui->comboBox_filter_type->findData(typeFilter);
+    if (comboIndex < 0) comboIndex = 0; // "All types"
+    ui->comboBox_filter_type->setCurrentIndex(comboIndex);
 }
 
 
 //---------------------------------------------------------------------------------------------------------
-void Main_WorkoutPage::fillWorkoutPage() {
+void Main_WorkoutPage::onFilterTypeIndexChanged(int index) {
 
+    const int typeId = ui->comboBox_filter_type->itemData(index).toInt();
+    typeFilter = typeId;
 
-    qDebug() << "fillWorkoutPage";
-
-    QString jsCode;
-    jsCode = QString("$('#name-workout').val('%1');").arg(nameFilter);
-    jsCode += QString("$('#plan-workout').val('%1');").arg(planFilter);
-    jsCode += QString("$('#creator-workout').val('%1');").arg(creatorFilter);
-
-    if (typeFilter != -1) {
-        jsCode += QString("$('#select-type-workout').val(%1);").arg(typeFilter);
-        jsCode += "$('#select-type-workout').selectpicker('refresh');";
-        jsCode += "$('#select-type-workout').trigger('change');";
+    if (typeId < 0) {
+        // "All types" — clear the type column filter.
+        proxyModel->addFilterFixedString(3, "");
     }
+    else {
+        // Match what gets shown in column 3 (Workout::getTypeToString()).
+        Workout tmp;
+        tmp.setType(static_cast<Workout::Type>(typeId));
+        proxyModel->addFilterFixedString(3, tmp.getTypeToString());
+    }
+    proxyModel->invalidate();
+}
 
 
-    qDebug() << "JSTOEXECUTE IS:" << jsCode;
-    // Guard against pages where jQuery is not yet loaded (e.g. screenshot/CI
-    // mode where the external URL was replaced with blank HTML).
-    ui->webView_workouts->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsCode + QStringLiteral("}"));
+//---------------------------------------------------------------------------------------------------------
+void Main_WorkoutPage::on_pushButton_filter_clear_clicked() {
 
-    filterChanged("name", nameFilter);
-    filterChanged("plan", planFilter);
-    filterChanged("creator", creatorFilter);
-
+    /// Resetting the inputs triggers the textChanged / currentIndexChanged
+    /// hooks, which propagate empty filters to the proxy model.
+    ui->lineEdit_filter_name->clear();
+    ui->lineEdit_filter_plan->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
 }
 
 
@@ -473,28 +466,17 @@ void Main_WorkoutPage::updateTableViewMetrics() {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::setFilterPlanName(const QString& plan) {
 
-
     qDebug() << "setFilterPlanName";
 
-    // Escape backslashes and single quotes so the value is safe inside a JS single-quoted string
-    QString jsPlan = plan;
-    jsPlan.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
-    jsPlan.replace(QLatin1Char('\''), QStringLiteral("\\'"));
+    /// Replace any active filters with a plan-only filter. Setting the
+    /// inputs fires textChanged/currentIndexChanged which propagate the
+    /// new values into the proxy model.
+    ui->lineEdit_filter_name->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
+    ui->lineEdit_filter_plan->setText(plan);
 
-    QString jsToExecute = "$('#name-workout').val( '' ); ";
-    jsToExecute += QString("$('#plan-workout').val( '%1' ); ").arg(jsPlan);
-    jsToExecute += "$('#creator-workout').val( '' ); ";
-
-    jsToExecute += "$('#select-type-workout option:selected').prop('selected', false); ";
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh'); ";
-
-
-    ui->webView_workouts->page()->runJavaScript(jsToExecute);
-
-
-    filterChanged("", "");
-    filterChanged("plan", plan);
-    if (!ui->checkBox->isChecked() && plan != "") {
+    if (!ui->checkBox->isChecked() && !plan.isEmpty()) {
         ui->checkBox->setChecked(true);
         filterChangedWorkoutType(true);
     }
@@ -505,26 +487,13 @@ void Main_WorkoutPage::setFilterPlanName(const QString& plan) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::setFilterWorkoutName(const QString& workoutName) {
 
-
     qDebug() << "setFilterWorkoutName";
 
-    // Escape backslashes and single quotes so the value is safe inside a JS single-quoted string
-    QString jsWorkoutName = workoutName;
-    jsWorkoutName.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
-    jsWorkoutName.replace(QLatin1Char('\''), QStringLiteral("\\'"));
-
-    QString jsToExecute = "$('#plan-workout').val( '' ); ";
-    jsToExecute += QString("$('#name-workout ').val( '%1' ); ").arg(jsWorkoutName);
-    jsToExecute += "$('#creator-workout').val( '' ); ";
-
-    jsToExecute += "$('#select-type-workout option:selected').prop('selected', false); ";
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh'); ";
-
-    ui->webView_workouts->page()->runJavaScript(jsToExecute);
-
-
-    filterChanged("", "");
-    filterChanged("name", workoutName);
+    /// Replace any active filters with a name-only filter.
+    ui->lineEdit_filter_plan->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
+    ui->lineEdit_filter_name->setText(workoutName);
 
     ui->tableView_workout->scrollToTop();
 }
@@ -561,14 +530,6 @@ void Main_WorkoutPage::loadFilterFields() {
     qDebug() << "Setings to load filter should be" << nameFilter << planFilter << creatorFilter << typeFilter;
 }
 
-
-//---------------------------------------------------------------
-void Main_WorkoutPage::filterChangedList(int id) {
-
-    //Just to save to settings later on
-    qDebug() << "ok it changed here" << id;
-    typeFilter = id;
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::filterChanged(const QString& field, const QString& value) {

--- a/src/ui/main_workoutpage.h
+++ b/src/ui/main_workoutpage.h
@@ -50,7 +50,6 @@ signals :
 
 public slots:
     void filterChanged(const QString& field, const QString& value);
-    void filterChangedList(int id);
     void filterChangedWorkoutType(bool includedWorkout);
 
     void setFilterPlanName(const QString& name);
@@ -66,8 +65,9 @@ public slots:
 
 private slots:
 
-    void connectWebChannelWorkout();
-    void fillWorkoutPage();
+    void applyFiltersToInputs();
+    void onFilterTypeIndexChanged(int index);
+    void on_pushButton_filter_clear_clicked();
 
 
     void on_tableView_workout_doubleClicked(const QModelIndex &index);

--- a/src/ui/main_workoutpage.ui
+++ b/src/ui/main_workoutpage.ui
@@ -24,22 +24,98 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWebEngineView" name="webView_workouts" native="true">
+    <widget class="QFrame" name="frame_workout_filter">
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>140</height>
+       <height>90</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>140</height>
+       <height>90</height>
       </size>
      </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::NoContextMenu</enum>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_workout_filter">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_filter_name">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_filter_name">
+        <property name="placeholderText">
+         <string>Filter by name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_filter_plan">
+        <property name="text">
+         <string>Plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLineEdit" name="lineEdit_filter_plan">
+        <property name="placeholderText">
+         <string>Filter by plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_filter_creator">
+        <property name="text">
+         <string>Creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEdit_filter_creator">
+        <property name="placeholderText">
+         <string>Filter by creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_filter_type">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="comboBox_filter_type"/>
+      </item>
+      <item row="0" column="4" rowspan="2">
+       <widget class="QPushButton" name="pushButton_filter_clear">
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -209,12 +285,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">qwebengineview.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>TableViewHover</class>
    <extends>QTableView</extends>

--- a/src/ui/workout_editor/tableviewinterval.cpp
+++ b/src/ui/workout_editor/tableviewinterval.cpp
@@ -18,7 +18,10 @@ TableViewInterval::TableViewInterval(QWidget *parent) :
     setDragDropMode(QAbstractItemView::InternalMove);
     setDragDropOverwriteMode(false);
     setDefaultDropAction(Qt::MoveAction);
-    setSelectionMode(QAbstractItemView::SingleSelection);
+    // ExtendedSelection (not SingleSelection) so Shift-click / Ctrl-click
+    // can select a multi-row range — required by the Repeat button, which
+    // wraps the selected interval range in a repeat block.
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
 }
 
 

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -18,14 +18,6 @@
 #include "environnement.h"
 
 
-#include <QWebEngineView>
-#include <QWebEngineProfile>
-#include <QWebEngineScript>
-#include <QWebEnginePage>
-#include <QWebEngineScriptCollection>
-#include <QWebChannel>
-
-
 
 WorkoutCreator::~WorkoutCreator()
 {
@@ -43,9 +35,19 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
     this->account = qApp->property("Account").value<Account*>();
 
 
-    connectWebChannelWorkoutCreator();
-    ui->webView_createWorkout->setUrl(QUrl(Environnement::getUrlWorkoutCreator()));
-    /// ----------------------------------------------------
+    /// Populate the type combobox in the same order as Workout::Type so
+    /// QComboBox::currentIndex() maps directly onto the enum value.
+    ui->comboBox_type_workout->addItem(tr("Endurance"), Workout::T_ENDURANCE);
+    ui->comboBox_type_workout->addItem(tr("Interval"),  Workout::T_INTERVAL);
+    ui->comboBox_type_workout->addItem(tr("Tempo"),     Workout::T_TEMPO);
+    ui->comboBox_type_workout->addItem(tr("Test"),      Workout::T_TEST);
+    ui->comboBox_type_workout->addItem(tr("Other"),     Workout::T_OTHERS);
+    ui->comboBox_type_workout->addItem(tr("Threshold"), Workout::T_THRESHOLD);
+
+    connect(ui->lineEdit_name_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->lineEdit_plan_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->lineEdit_creator_workout, SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->pushButton_save_workout,  SIGNAL(clicked()),            this, SLOT(on_pushButton_save_workout_clicked()));
 
 
 
@@ -164,41 +166,20 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-void WorkoutCreator::connectWebChannelWorkoutCreator() {
+void WorkoutCreator::populateInputsFromWorkout() {
 
-    qDebug() << "connectWebChannelWorkoutCreator";
+    /// Sync the native input widgets with the current `workout` state.
+    /// Called from resetWorkout()/editWorkout() — replaces the old
+    /// fillWorkoutCreatorPageWeb() that pushed values into the embedded
+    /// jQuery page via runJavaScript().
+    ui->lineEdit_name_workout->setText(workout.getName());
+    ui->lineEdit_plan_workout->setText(workout.getPlan());
+    ui->lineEdit_creator_workout->setText(workout.getCreatedBy());
+    ui->plainTextEdit_description_workout->setPlainText(workout.getDescription());
 
-    QFile webChannelJsFile(":/qtwebchannel/qwebchannel.js");
-    if(  !webChannelJsFile.open(QIODevice::ReadOnly) ) {
-        qDebug() << QString("Couldn't open qwebchannel.js file: %1").arg(webChannelJsFile.errorString());
-    }
-    else {
-        qDebug() << "OK webEngineProfile";
-        QByteArray webChannelJs = webChannelJsFile.readAll();
-        webChannelJs.append(
-                    "\n"
-                    "var WorkoutCreator"
-                    "\n"
-                    "new QWebChannel(qt.webChannelTransport, function(channel) {"
-                    "     WorkoutCreator = channel.objects.WorkoutCreator;"
-                    "});"
-                    "\n"
-                    );
-
-        QWebChannel *channel = new QWebChannel(ui->webView_createWorkout);
-        QWebEngineScript script;
-        script.setSourceCode(webChannelJs);
-        script.setName("qwebchannel.js");
-        script.setWorldId(QWebEngineScript::MainWorld);
-        script.setInjectionPoint(QWebEngineScript::DocumentCreation);
-        script.setRunsOnSubFrames(false);
-
-        ui->webView_createWorkout->page()->scripts().insert(script);
-        ui->webView_createWorkout->page()->setWebChannel(channel);
-        channel->registerObject("WorkoutCreator", this);
-    }
-
-
+    int typeIndex = ui->comboBox_type_workout->findData(static_cast<int>(workout.getType()));
+    if (typeIndex < 0) typeIndex = 0;
+    ui->comboBox_type_workout->setCurrentIndex(typeIndex);
 }
 
 
@@ -239,7 +220,12 @@ void WorkoutCreator::resetWorkout() {
     lstRepeatWidget.clear();
     lstRepeatData.clear();
 
-    fillWorkoutCreatorPageWeb("", "-", account->display_name, 0, "");
+    workout.setName("");
+    workout.setPlan("-");
+    workout.setCreator(account->display_name);
+    workout.setDescription("");
+    workout.setType(Workout::T_ENDURANCE);
+    populateInputsFromWorkout();
 
     computeWorkout();
 
@@ -325,41 +311,8 @@ void WorkoutCreator::editWorkout(Workout workoutToEdit) {
     intervalModel->setListInterval(workoutToEdit.getLstIntervalSource());
     restoreRepeatWidgetInterface();
 
-    fillWorkoutCreatorPageWeb(workout.getName(), workout.getPlan(), workout.getCreatedBy(), workout.getType(), workout.getDescription());
+    populateInputsFromWorkout();
     checkToEnableButtonSave();
-}
-
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
-void WorkoutCreator::fillWorkoutCreatorPageWeb(QString name, QString plan, QString creator, int type, QString description) {
-
-    qDebug() << "fillWorkoutCreatorPageWeb";
-
-    //Parse for Quotes, Javascript doesnt like them so escape them
-    QString planEscaped = plan.replace("\'", "\\'");
-    QString creatorEscaped = creator.replace("\'", "\\'");
-    QString descriptionEscaped = description.replace("\'", "\\'");
-    descriptionEscaped = descriptionEscaped.replace("\n", "\\n");
-
-
-    //// ----------- Set Data in QWebView : have to put null at the end of evaluate javascript or it's really slow
-    /// source : http://stackoverflow.com/questions/19505063/qt-javascript-execution-slow-unless-i-log-to-the-console
-    QString jsToExecute = QString("$('#name-workout').val( '%1' ); ").arg(name);
-    jsToExecute += QString("$('#plan-workout').val( '%1' ); ").arg(planEscaped);
-    jsToExecute += QString("$('#creator-workout').val( '%1' ); ").arg(creatorEscaped);
-    jsToExecute += QString("$('#description-workout').val( '%1' ); ").arg(descriptionEscaped);
-
-    jsToExecute += QString("$('#select-type-workout').val( %1 );").arg(type);
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh');";
-    //    ui->webView_createWorkout->page()->mainFrame()->documentElement().evaluateJavaScript(jsToExecute + "; null");
-
-    // Guard against pages where jQuery is not yet loaded (e.g. screenshot/CI
-    // mode where the external URL was replaced with blank HTML).
-    ui->webView_createWorkout->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsToExecute + QStringLiteral("}"));
-
-
 }
 
 
@@ -367,31 +320,25 @@ void WorkoutCreator::fillWorkoutCreatorPageWeb(QString name, QString plan, QStri
 ////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutCreator::checkToEnableButtonSave() {
 
-
     qDebug() << "OK WORKOUT CREATOR CHECK BUTTON SAVE";
 
-    bool enabled = true;
-    if (intervalModel->rowCount() == 0) {
-        enabled = false;
-    }
+    const bool hasIntervals = intervalModel->rowCount() > 0;
+    const bool hasName    = !ui->lineEdit_name_workout->text().isEmpty();
+    const bool hasPlan    = !ui->lineEdit_plan_workout->text().isEmpty();
+    const bool hasCreator = !ui->lineEdit_creator_workout->text().isEmpty();
+
+    ui->pushButton_save_workout->setEnabled(hasIntervals && hasName && hasPlan && hasCreator);
+}
 
 
-    QString jsToRun = "var nameValue = $('#name-workout').val();"
-                      "var planValue =   $('#plan-workout').val();"
-                      "var creatorValue = $('#creator-workout').val();"
-                      "if (nameValue.length > 0 && creatorValue.length > 0 && planValue.length > 0 && " + QString::number(enabled) +") {"
-                      "$('#btn-save-workout').prop('disabled', false);"
-                      "}"
-                      "else {"
-                      "$('#btn-save-workout').prop('disabled', true);"
-                      "}";
+////////////////////////////////////////////////////////////////////////////////////////////
+void WorkoutCreator::on_pushButton_save_workout_clicked() {
 
-//    qDebug() << "ok button check JS is " << jsToRun;
-
-    // Guard against pages where jQuery is not yet loaded.
-    ui->webView_createWorkout->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsToRun + QStringLiteral("}"));
-
+    createWorkout(ui->lineEdit_name_workout->text(),
+                  ui->lineEdit_plan_workout->text(),
+                  ui->lineEdit_creator_workout->text(),
+                  ui->plainTextEdit_description_workout->toPlainText(),
+                  ui->comboBox_type_workout->currentIndex());
 }
 
 

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -44,10 +44,14 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
     ui->comboBox_type_workout->addItem(tr("Other"),     Workout::T_OTHERS);
     ui->comboBox_type_workout->addItem(tr("Threshold"), Workout::T_THRESHOLD);
 
+    // Note: pushButton_save_workout::clicked() is hooked up automatically by
+    // QMetaObject::connectSlotsByName via the on_pushButton_save_workout_clicked
+    // slot name — adding an explicit connect() here would fire it twice and
+    // make the second call see the just-written file, triggering a spurious
+    // "workout already exists" dialog.
     connect(ui->lineEdit_name_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
     connect(ui->lineEdit_plan_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
     connect(ui->lineEdit_creator_workout, SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
-    connect(ui->pushButton_save_workout,  SIGNAL(clicked()),            this, SLOT(on_pushButton_save_workout_clicked()));
 
 
 

--- a/src/ui/workout_editor/workoutcreator.h
+++ b/src/ui/workout_editor/workoutcreator.h
@@ -46,8 +46,8 @@ signals :
 
 
 private slots:
-    void connectWebChannelWorkoutCreator();
-    void fillWorkoutCreatorPageWeb(QString name, QString plan, QString creator, int type, QString description);
+    void populateInputsFromWorkout();
+    void on_pushButton_save_workout_clicked();
 
 
 

--- a/src/ui/workout_editor/workoutcreator.ui
+++ b/src/ui/workout_editor/workoutcreator.ui
@@ -66,7 +66,7 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
     <number>0</number>
    </property>
    <item>
-    <widget class="QWebEngineView" name="webView_createWorkout" native="true">
+    <widget class="QFrame" name="frame_workout_meta">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -85,9 +85,93 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
        <height>200</height>
       </size>
      </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::NoContextMenu</enum>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_workout_meta">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_name_workout">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_name_workout"/>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_plan_workout">
+        <property name="text">
+         <string>Plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLineEdit" name="lineEdit_plan_workout"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_creator_workout">
+        <property name="text">
+         <string>Creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEdit_creator_workout"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_type_workout">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="comboBox_type_workout"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_description_workout">
+        <property name="text">
+         <string>Description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="3">
+       <widget class="QPlainTextEdit" name="plainTextEdit_description_workout">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QPushButton" name="pushButton_save_workout">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -458,12 +542,6 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">qwebengineview.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>myCreatorPlot</class>
    <extends>QWidget</extends>


### PR DESCRIPTION
## Summary
The top of both the **Workout List** page and the **Workout Editor** page used to be `QWebEngineView`s loaded from `Environnement::getUrlWorkout()` / `getUrlWorkoutCreator()` and bridged into C++ via `QWebChannel`. The remote server is no longer reachable, so:

- The Editor's metadata fields (Name, Plan, Creator, Type, Description) and the **Save** button never rendered — the editor was unusable.
- The List's filter inputs (Name, Plan, Creator, Type) never rendered — the list could not be filtered.

This PR replaces both webviews with native Qt widgets. Reproduced and validated on **Ubuntu**.

### Editor (`WorkoutCreator`)
- Top section is now a `QFrame` with `QLineEdit`s (Name / Plan / Creator), a `QComboBox` for Type (in `Workout::Type` enum order so `currentIndex()` matches the old JS contract), a `QPlainTextEdit` for Description, and a **Save** button.
- Save handler calls the existing `createWorkout(...)` slot, so the file is still written to `Util::getSystemPathWorkout()` and the existing `workoutCreated` / `workoutOverwrited` signals continue to refresh the list.
- Removed `connectWebChannelWorkoutCreator()` and `fillWorkoutCreatorPageWeb()`; replaced with a single `populateInputsFromWorkout()` that's called from `editWorkout()` and `resetWorkout()`.

### List (`Main_WorkoutPage`)
- Top section is now a `QFrame` with three `QLineEdit`s (Name / Plan / Creator), a `QComboBox` for Type ("All types" + 6 enum entries), and a **Clear** button.
- Each input drives the existing `filterChanged()` / `SortFilterProxyModel` logic; persisted filters from `QSettings` are restored after `setupUi`.
- `setFilterPlanName()` / `setFilterWorkoutName()` (called from `MainWindow` after add/edit/import) now write to the line edits; their `textChanged` signals propagate to the proxy. Removed `connectWebChannelWorkout()`, `fillWorkoutPage()`, and the dead `filterChangedList(int)` slot.

### Other fixes pulled in along the way
- **Repeat button (Editor table) was broken**: a recent drag-to-reorder change set the table to `SingleSelection`, but Repeat needs a multi-row range. Restored `ExtendedSelection`. Drag-to-reorder still works.
- **Spurious "workout already exists" dialog**: `connectSlotsByName` auto-wires the Save button; an explicit `connect()` would have fired the save slot twice. Removed the duplicate.

The first commit (resource paths) is the same SHA as #199 and will collapse out once #199 merges.

## Test plan
- [ ] Build on Ubuntu
- [ ] **List view**: type into Name / Plan / Creator → table filters live; pick a Type → only matching rows; click Clear → all filters reset
- [ ] **List view**: persisted filters (across restart) load and apply on startup
- [ ] **Editor**: open a workout → Name / Plan / Creator / Type / Description are populated; click Save → file is written and list refreshes; saving again on the same name → "Overwrite?" prompt fires once (not twice)
- [ ] **Editor**: Shift-click two rows in the interval table, click Repeat → repeat block wraps the selected range
- [ ] **Included workouts** (from #199 cherry-pick): Rachel / Sufferfest / BT 16wk Power Based plans show entries; double-click no longer crashes