### PR TITLE
feat: local editable radio list (Workout dialog) + Qt-resource defaults

### DIFF
--- a/MyResources.qrc
+++ b/MyResources.qrc
@@ -133,6 +133,9 @@
     <qresource prefix="/included_workout/sufferfest">
         <file>resources/included_workout/Sufferfest/ISLAGIATT.workout</file>
     </qresource>
+    <qresource prefix="/data">
+        <file>resources/data/default_radios.json</file>
+    </qresource>
     <qresource prefix="/included_workout/rachel">
         <file>resources/included_workout/Rachel/Intervals-01.workout</file>
         <file>resources/included_workout/Rachel/Intervals-02.workout</file>

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Install system packages and build VLC-Qt from source, then build the app:
 sudo apt-get install -y \
   qtbase5-dev qtwebengine5-dev qtconnectivity5-dev \
   libqwt-qt5-dev libsfml-dev libvlc-dev libvlccore-dev \
+  vlc-plugin-base vlc-plugin-video-output \
   cmake build-essential
 
 # Build VLC-Qt 1.1.1 from source
@@ -252,6 +253,8 @@ export PATH=/usr/lib/qt5/bin:$PATH
 qmake PowerVelo.pro "INCLUDEPATH+=/usr/local/include" "LIBS+=-L/usr/local/lib"
 make -j$(nproc)
 ```
+
+> `vlc-plugin-video-output` is required for libvlc to render video into the Workout dialog. Without it, libvlc loads but reports `failed to create video output` and the player shows only the timer.
 
 ### macOS
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -327,7 +327,9 @@ nmake</code></pre>
   qtbase5-dev qtwebengine5-dev \
   qtconnectivity5-dev \
   libqwt-qt5-dev libsfml-dev \
-  libvlc-dev cmake build-essential
+  libvlc-dev vlc-plugin-base \
+  vlc-plugin-video-output \
+  cmake build-essential
 
 qmake PowerVelo.pro
 make -j$(nproc)</code></pre>

--- a/resources/data/default_radios.json
+++ b/resources/data/default_radios.json
@@ -1,0 +1,82 @@
+[
+    {
+        "name": "SomaFM Groove Salad",
+        "genre": "Chill Electronic",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/groovesalad-128-mp3"
+    },
+    {
+        "name": "SomaFM Beat Blender",
+        "genre": "Late-night Electronic",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/beatblender-128-mp3"
+    },
+    {
+        "name": "SomaFM Indie Pop Rocks",
+        "genre": "Indie Pop",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/indiepop-128-mp3"
+    },
+    {
+        "name": "SomaFM Boot Liquor",
+        "genre": "Americana / Country",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/bootliquor-128-mp3"
+    },
+    {
+        "name": "SomaFM Drone Zone",
+        "genre": "Ambient",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/dronezone-128-mp3"
+    },
+    {
+        "name": "SomaFM Underground 80s",
+        "genre": "New Wave / Synth-pop",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/u80s-128-mp3"
+    },
+    {
+        "name": "Radio Paradise — Main Mix",
+        "genre": "Eclectic Rock / Pop",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://stream.radioparadise.com/aac-128"
+    },
+    {
+        "name": "Radio Paradise — Global Mix",
+        "genre": "World / Electronic",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://stream.radioparadise.com/global-128"
+    },
+    {
+        "name": "FIP",
+        "genre": "Jazz / Eclectic",
+        "gotAds": "0",
+        "bitrate": "192",
+        "lang": "FR",
+        "url": "https://icecast.radiofrance.fr/fip-midfi.mp3"
+    },
+    {
+        "name": "France Musique",
+        "genre": "Classical",
+        "gotAds": "0",
+        "bitrate": "192",
+        "lang": "FR",
+        "url": "https://icecast.radiofrance.fr/francemusique-midfi.mp3"
+    }
+]

--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -3,6 +3,10 @@
 #include <QDebug>
 #include <QDir>
 #include <QDesktopServices>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QRegularExpression>
 
 #include "account.h"
@@ -1248,4 +1252,112 @@ void Util::parseJsonIntervalsIcuOAuthToken(const QString &data)
         account->intervals_icu_athlete_id = athleteId;
 
     qDebug() << "parseJsonIntervalsIcuOAuthToken: athlete_id =" << account->intervals_icu_athlete_id;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  Local radio list — stored as JSON under the MaximumTrainer document root.
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+QString Util::getLocalRadioListPath() {
+
+    const QString base = Util::getMaximumTrainerDocumentPath();
+    if (base == "invalid_writable_path")
+        return QString();
+    return base + QDir::separator() + "radios.json";
+}
+
+
+QList<Radio> Util::getDefaultRadioList() {
+
+    /// Three ad-free, listener-supported defaults across distinct genres.
+    /// All URLs are stable, direct streams that libvlc can open without an
+    /// HTML player wrapper. Users can delete or replace any of them via the
+    /// radio editor.
+    QList<Radio> defaults;
+    defaults.append(Radio(QStringLiteral("SomaFM Beat Blender"),
+                          QStringLiteral("Dance / Electronic"),
+                          /*gotAds=*/false, 128, QStringLiteral("EN"),
+                          QStringLiteral("https://ice1.somafm.com/beatblender-128-mp3")));
+    defaults.append(Radio(QStringLiteral("Radio Paradise — Mellow Mix"),
+                          QStringLiteral("Eclectic Rock"),
+                          /*gotAds=*/false, 128, QStringLiteral("EN"),
+                          QStringLiteral("https://stream.radioparadise.com/mellow-128")));
+    defaults.append(Radio(QStringLiteral("FIP"),
+                          QStringLiteral("Jazz / World"),
+                          /*gotAds=*/false, 192, QStringLiteral("FR"),
+                          QStringLiteral("https://icecast.radiofrance.fr/fip-midfi.mp3")));
+    return defaults;
+}
+
+
+bool Util::saveLocalRadioList(const QList<Radio>& lstRadio) {
+
+    const QString path = getLocalRadioListPath();
+    if (path.isEmpty()) {
+        qWarning() << "saveLocalRadioList: writable path unavailable";
+        return false;
+    }
+
+    QJsonArray arr;
+    for (const Radio& r : lstRadio) {
+        QJsonObject obj;
+        obj["name"]    = r.getName();
+        obj["genre"]   = r.getGenre();
+        // Match the on-the-wire schema parseJsonRadioList expects: gotAds and
+        // bitrate were strings (the legacy server returned them as such).
+        obj["gotAds"]  = QString::number(r.getGotAds() ? 1 : 0);
+        obj["bitrate"] = QString::number(r.getBitrate());
+        obj["lang"]    = r.getLanguage();
+        obj["url"]     = r.getUrl();
+        arr.append(obj);
+    }
+
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qWarning() << "saveLocalRadioList: cannot open" << path << ":" << file.errorString();
+        return false;
+    }
+    file.write(QJsonDocument(arr).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+
+QList<Radio> Util::loadLocalRadioList() {
+
+    const QString path = getLocalRadioListPath();
+
+    /// First-run / corrupt-path: drop the bundled defaults to disk and use
+    /// them. saveLocalRadioList may itself fail (read-only home, etc.) — in
+    /// that case we still return the defaults so the in-memory list is
+    /// usable for the session.
+    auto fallbackToDefaults = [&]() {
+        QList<Radio> defaults = getDefaultRadioList();
+        if (!path.isEmpty())
+            saveLocalRadioList(defaults);
+        return defaults;
+    };
+
+    if (path.isEmpty())
+        return fallbackToDefaults();
+
+    QFile file(path);
+    if (!file.exists())
+        return fallbackToDefaults();
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning() << "loadLocalRadioList: cannot open" << path << ":" << file.errorString();
+        return fallbackToDefaults();
+    }
+
+    /// Reuse parseJsonRadioList — same schema as the legacy server.
+    /// On parse failure we keep the user's file untouched (so they can fix
+    /// it manually) and fall back to defaults for this session only.
+    QList<Radio> parsed = Util::parseJsonRadioList(QString::fromUtf8(file.readAll()));
+    if (parsed.isEmpty()) {
+        qWarning() << "loadLocalRadioList: parsed 0 radios from" << path
+                   << "— using bundled defaults for this session";
+        return getDefaultRadioList();
+    }
+    return parsed;
 }

--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -1270,24 +1270,13 @@ QString Util::getLocalRadioListPath() {
 
 QList<Radio> Util::getDefaultRadioList() {
 
-    /// Three ad-free, listener-supported defaults across distinct genres.
-    /// All URLs are stable, direct streams that libvlc can open without an
-    /// HTML player wrapper. Users can delete or replace any of them via the
-    /// radio editor.
-    QList<Radio> defaults;
-    defaults.append(Radio(QStringLiteral("SomaFM Beat Blender"),
-                          QStringLiteral("Dance / Electronic"),
-                          /*gotAds=*/false, 128, QStringLiteral("EN"),
-                          QStringLiteral("https://ice1.somafm.com/beatblender-128-mp3")));
-    defaults.append(Radio(QStringLiteral("Radio Paradise — Mellow Mix"),
-                          QStringLiteral("Eclectic Rock"),
-                          /*gotAds=*/false, 128, QStringLiteral("EN"),
-                          QStringLiteral("https://stream.radioparadise.com/mellow-128")));
-    defaults.append(Radio(QStringLiteral("FIP"),
-                          QStringLiteral("Jazz / World"),
-                          /*gotAds=*/false, 192, QStringLiteral("FR"),
-                          QStringLiteral("https://icecast.radiofrance.fr/fip-midfi.mp3")));
-    return defaults;
+    QFile bundled(QStringLiteral(":/data/resources/data/default_radios.json"));
+    if (!bundled.open(QIODevice::ReadOnly)) {
+        qWarning() << "getDefaultRadioList: cannot open bundled resource:"
+                   << bundled.errorString();
+        return QList<Radio>();
+    }
+    return Util::parseJsonRadioList(QString::fromUtf8(bundled.readAll()));
 }
 
 

--- a/src/app/util.h
+++ b/src/app/util.h
@@ -111,6 +111,15 @@ public:
     static QList<Sensor> parseJsonSensorList(QString data);
     static QList<Radio> parseJsonRadioList(QString data);
     static QList<Achievement> parseJsonAchievementList(QString data);
+
+    /// Local radio list — JSON file under the MaximumTrainer document root.
+    /// loadLocalRadioList() returns the parsed list; if the file is missing
+    /// or unreadable it writes the bundled defaults and returns those, so
+    /// the caller always gets at least a few stations to play.
+    static QList<Radio> loadLocalRadioList();
+    static bool         saveLocalRadioList(const QList<Radio>& lstRadio);
+    static QList<Radio> getDefaultRadioList();
+    static QString      getLocalRadioListPath();
     static QSet<int> parseJsonAchievementListForUser(QString data);
 
     /// Intervals.icu — parse the GET /api/v1/athlete/{id} response.

--- a/src/model/radiotablemodel.cpp
+++ b/src/model/radiotablemodel.cpp
@@ -56,6 +56,45 @@ Radio RadioTableModel::getRadioAtRow(const QModelIndex &index) {
 }
 
 // ------------------------------------------------------------------------------------------
+void RadioTableModel::addRadio(const Radio& radio) {
+
+    const int row = lstRadio.size();
+    beginInsertRows(QModelIndex(), row, row);
+    lstRadio.append(radio);
+    endInsertRows();
+}
+
+
+// ------------------------------------------------------------------------------------------
+void RadioTableModel::replaceRadioAtRow(int row, const Radio& radio) {
+
+    if (row < 0 || row >= lstRadio.size())
+        return;
+
+    lstRadio.replace(row, radio);
+    emit dataChanged(index(row, 0), index(row, columnCount() - 1));
+}
+
+
+// ------------------------------------------------------------------------------------------
+void RadioTableModel::removeRadioAtRow(int row) {
+
+    if (row < 0 || row >= lstRadio.size())
+        return;
+
+    beginRemoveRows(QModelIndex(), row, row);
+    lstRadio.removeAt(row);
+    endRemoveRows();
+}
+
+
+// ------------------------------------------------------------------------------------------
+QList<Radio> RadioTableModel::getAllRadios() const {
+    return lstRadio;
+}
+
+
+// ------------------------------------------------------------------------------------------
 int RadioTableModel::rowCount(const QModelIndex &parent) const {
 
     Q_UNUSED(parent);

--- a/src/model/radiotablemodel.h
+++ b/src/model/radiotablemodel.h
@@ -16,6 +16,14 @@ public:
     void addListRadio(QList<Radio> lstRadio);
     Radio getRadioAtRow(const QModelIndex &index);
 
+    /// CRUD helpers used by the radio editor in DialogConfig. They emit the
+    /// model-reset signals so the table view repaints; the dialog persists
+    /// the full list to disk after each call.
+    void addRadio(const Radio& radio);
+    void replaceRadioAtRow(int row, const Radio& radio);
+    void removeRadioAtRow(int row);
+    QList<Radio> getAllRadios() const;
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
 

--- a/src/persistence/file/xmlutil.cpp
+++ b/src/persistence/file/xmlutil.cpp
@@ -544,18 +544,18 @@ QList<Course> XmlUtil::parseCourseLstPath(QStringList lstPath, Course::COURSE_TY
 QList<Workout> XmlUtil::getLstWorkoutRachel() {
 
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-01.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-02.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-03.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-04.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-05.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-06.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-07.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-08.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-09.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-10.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-11.workout");
-    lstWorkoutPat.append(":/included_workout/rachel/included_workout/Rachel/Intervals-12.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-01.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-02.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-03.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-04.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-05.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-06.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-07.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-08.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-09.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-10.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-11.workout");
+    lstWorkoutPat.append(":/included_workout/rachel/resources/included_workout/Rachel/Intervals-12.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 
 }
@@ -564,7 +564,7 @@ QList<Workout> XmlUtil::getLstWorkoutRachel() {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
     QStringList lstWorkoutPat;
-    lstWorkoutPat.append(":/included_workout/sufferfest/included_workout/Sufferfest/ISLAGIATT.workout");
+    lstWorkoutPat.append(":/included_workout/sufferfest/resources/included_workout/Sufferfest/ISLAGIATT.workout");
     return parseWorkoutLstPath(lstWorkoutPat, Workout::SUFFERFEST_WORKOUT);
 }
 
@@ -573,88 +573,88 @@ QList<Workout> XmlUtil::getLstWorkoutSufferfest() {
 QList<Workout>  XmlUtil::getLstWorkoutBt16WeeksPlan() {
 
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-20min-CP-test.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkA-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo1-5min-CP-test.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo2-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk1-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk2-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk3-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase1-wk4-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk5-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk6-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk7-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk8-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase2-wk9-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk10-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk11-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk12-wo4.workout");
 
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo1.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo2.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo3.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk13-wo4.workout");
 
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
-    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo1-5min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo2.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo3-20min-CP-Test.workout");
+    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Phase3-wk14-wo4.workout");
 
     return parseWorkoutLstPath(lstWorkoutPat, Workout::INCLUDED_WORKOUT);
 }
@@ -672,7 +672,7 @@ QList<Workout> XmlUtil::getLstUserWorkout() {
 QList<Course> XmlUtil::getLstCourseIncluded() {
 //todo remove dropbox ref
     QStringList lstWorkoutPat;
-    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
+    //    lstWorkoutPat.append(":/included_workout/bt_16_wk_plan/resources/included_workout/BT 16wk Power Based/Opt-Phase-Prep-wkB-wo4.workout");
     lstWorkoutPat.append("C:/Dropbox/MT/3a.tcx");
     lstWorkoutPat.append("C:/Dropbox/MT/Boucle_Brebeuf_Mont-Tremblant.tcx");
 

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -6,7 +6,24 @@
 #include <QAction>
 #include <QDebug>
 #include <QKeyEvent>
+#include <QPainter>
+#include <QStyle>
 #include "util.h"
+
+namespace {
+QIcon tintedStandardIcon(QStyle *style, QStyle::StandardPixmap sp,
+                         const QSize& size, const QColor& color) {
+    QPixmap source = style->standardIcon(sp).pixmap(size);
+    QPixmap out(source.size());
+    out.fill(Qt::transparent);
+    QPainter p(&out);
+    p.drawPixmap(0, 0, source);
+    p.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    p.fillRect(out.rect(), color);
+    p.end();
+    return QIcon(out);
+}
+}
 
 
 TopMenuWorkout::~TopMenuWorkout()
@@ -68,6 +85,15 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
 
     ui->label_radioIcon->setPixmap(pixmapRadio);
 
+    const QSize iconSize(20, 20);
+    const QColor iconColor(230, 230, 230);
+    ui->pushButton_prevRadio->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaSkipBackward, iconSize, iconColor));
+    ui->pushButton_prevRadio->setIconSize(iconSize);
+    ui->pushButton_playPauseRadio->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaPlay, iconSize, iconColor));
+    ui->pushButton_playPauseRadio->setIconSize(iconSize);
+    ui->pushButton_nextRadio->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaSkipForward, iconSize, iconColor));
+    ui->pushButton_nextRadio->setIconSize(iconSize);
+
 
     ui->pushButton_calibrateFEC->setFocusPolicy(Qt::NoFocus);
     ui->pushButton_calibratePM->setFocusPolicy(Qt::NoFocus);
@@ -116,11 +142,13 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
 
 ////////////////////////////////////////////////////////////////////////
 void TopMenuWorkout::radioStartedPlaying() {
-    ui->pushButton_playPauseRadio->setText("|| (F7)");
+    ui->pushButton_playPauseRadio->setIcon(
+        tintedStandardIcon(style(), QStyle::SP_MediaPause, QSize(20, 20), QColor(230, 230, 230)));
 }
 
 void TopMenuWorkout::radioStoppedPlaying() {
-    ui->pushButton_playPauseRadio->setText("> (F7)");
+    ui->pushButton_playPauseRadio->setIcon(
+        tintedStandardIcon(style(), QStyle::SP_MediaPlay, QSize(20, 20), QColor(230, 230, 230)));
 }
 
 

--- a/src/ui/components/topmenuworkout.ui
+++ b/src/ui/components/topmenuworkout.ui
@@ -628,59 +628,59 @@ border-radius: 1px;
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton_prevRadio">
-        <property name="maximumSize">
-         <size>
-          <width>65</width>
-          <height>16777215</height>
-         </size>
-        </property>
+       <widget class="QToolButton" name="pushButton_prevRadio">
         <property name="cursor">
-         <cursorShape>ArrowCursor</cursorShape>
+         <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
          <enum>Qt::NoFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>Previous station (F6)</string>
+        </property>
         <property name="text">
-         <string>&lt;&lt; (F6)</string>
+         <string/>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton_playPauseRadio">
-        <property name="maximumSize">
-         <size>
-          <width>65</width>
-          <height>16777215</height>
-         </size>
-        </property>
+       <widget class="QToolButton" name="pushButton_playPauseRadio">
         <property name="cursor">
-         <cursorShape>ArrowCursor</cursorShape>
+         <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
          <enum>Qt::NoFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>Play / Pause (F7)</string>
+        </property>
         <property name="text">
-         <string>&gt; (F7)</string>
+         <string/>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton_nextRadio">
-        <property name="maximumSize">
-         <size>
-          <width>65</width>
-          <height>16777215</height>
-         </size>
-        </property>
+       <widget class="QToolButton" name="pushButton_nextRadio">
         <property name="cursor">
-         <cursorShape>ArrowCursor</cursorShape>
+         <cursorShape>PointingHandCursor</cursorShape>
         </property>
         <property name="focusPolicy">
          <enum>Qt::NoFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>Next station (F8)</string>
+        </property>
         <property name="text">
-         <string>&gt;&gt; (F8)</string>
+         <string/>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -1569,15 +1569,17 @@ void DialogConfig::on_pushButton_addRadio_clicked() {
 //----------------------------------------------------------------------------
 void DialogConfig::on_pushButton_editRadio_clicked() {
 
-    const QModelIndexList sel = ui->tableView_radio->selectionModel()->selectedRows();
-    if (sel.isEmpty()) {
+    QModelIndex idx = ui->tableView_radio->selectionModel()->currentIndex();
+    if (!idx.isValid())
+        idx = currentRadioIndex;
+    if (!idx.isValid()) {
         QMessageBox::information(this, tr("Edit Radio"),
             tr("Select a radio station to edit."));
         return;
     }
 
-    const int row = sel.first().row();
-    Radio existing = tableModel->getRadioAtRow(sel.first());
+    const int row = idx.row();
+    Radio existing = tableModel->getRadioAtRow(idx);
     if (!runRadioEditDialog(this, existing))
         return;
 
@@ -1589,18 +1591,18 @@ void DialogConfig::on_pushButton_editRadio_clicked() {
 //----------------------------------------------------------------------------
 void DialogConfig::on_pushButton_deleteRadio_clicked() {
 
-    const QModelIndexList sel = ui->tableView_radio->selectionModel()->selectedRows();
-    if (sel.isEmpty()) {
+    QModelIndex idx = ui->tableView_radio->selectionModel()->currentIndex();
+    if (!idx.isValid())
+        idx = currentRadioIndex;
+    if (!idx.isValid()) {
         QMessageBox::information(this, tr("Delete Radio"),
             tr("Select a radio station to delete."));
         return;
     }
 
-    const int row = sel.first().row();
-    const Radio radio = tableModel->getRadioAtRow(sel.first());
+    const int row = idx.row();
+    const Radio radio = tableModel->getRadioAtRow(idx);
 
-    /// Confirm so the user doesn't nuke a default by accident, but we do
-    /// allow deleting bundled defaults — that's the whole point.
     if (QMessageBox::question(this, tr("Delete Radio"),
             tr("Delete \"%1\"?").arg(radio.getName()),
             QMessageBox::Yes | QMessageBox::No,
@@ -1609,5 +1611,7 @@ void DialogConfig::on_pushButton_deleteRadio_clicked() {
     }
 
     tableModel->removeRadioAtRow(row);
+    if (currentRadioIndex.row() == row)
+        currentRadioIndex = QModelIndex();
     Util::saveLocalRadioList(tableModel->getAllRadios());
 }

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -1484,3 +1484,130 @@ void DialogConfig::saveTrainerTab()
         account->saveIntervalSummarySettings();
     }
 }
+
+
+// ============================================================================
+//  Radio list editor — Add / Edit / Delete
+// ============================================================================
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QSpinBox>
+#include "util.h"
+
+namespace {
+/// Tiny modal that edits a single Radio. Returns the edited copy on accept.
+/// Lives here (not in its own .h/.cpp pair) because it is only used by the
+/// three Add/Edit/Delete handlers below.
+bool runRadioEditDialog(QWidget *parent, Radio& inOut) {
+    QDialog dlg(parent);
+    dlg.setWindowTitle(QObject::tr("Radio Station"));
+
+    auto *nameEdit    = new QLineEdit(inOut.getName());
+    auto *genreEdit   = new QLineEdit(inOut.getGenre());
+    auto *langEdit    = new QLineEdit(inOut.getLanguage());
+    auto *urlEdit     = new QLineEdit(inOut.getUrl());
+    urlEdit->setPlaceholderText(QStringLiteral("https://stream.example.com/stream.mp3"));
+    auto *bitrateSpin = new QSpinBox();
+    bitrateSpin->setRange(0, 1000);
+    bitrateSpin->setSuffix(QStringLiteral(" kbps"));
+    bitrateSpin->setValue(inOut.getBitrate());
+
+    auto *form = new QFormLayout();
+    form->addRow(QObject::tr("Name"),     nameEdit);
+    form->addRow(QObject::tr("Genre"),    genreEdit);
+    form->addRow(QObject::tr("Language"), langEdit);
+    form->addRow(QObject::tr("Bitrate"),  bitrateSpin);
+    form->addRow(QObject::tr("URL"),      urlEdit);
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    auto *layout = new QVBoxLayout(&dlg);
+    layout->addLayout(form);
+    layout->addWidget(buttons);
+    dlg.resize(420, dlg.sizeHint().height());
+
+    if (dlg.exec() != QDialog::Accepted)
+        return false;
+
+    /// Minimal validation: name and url are required. We don't try to validate
+    /// the URL itself — libvlc will reject anything unparseable when the user
+    /// hits Play.
+    if (nameEdit->text().trimmed().isEmpty() || urlEdit->text().trimmed().isEmpty()) {
+        QMessageBox::warning(parent, QObject::tr("Radio Station"),
+            QObject::tr("Name and URL are required."));
+        return false;
+    }
+
+    inOut = Radio(nameEdit->text().trimmed(),
+                  genreEdit->text().trimmed(),
+                  /*gotAds=*/false,
+                  bitrateSpin->value(),
+                  langEdit->text().trimmed(),
+                  urlEdit->text().trimmed());
+    return true;
+}
+}
+
+
+//----------------------------------------------------------------------------
+void DialogConfig::on_pushButton_addRadio_clicked() {
+
+    Radio newRadio(QString(), QString(), false, 128, QString(), QString());
+    if (!runRadioEditDialog(this, newRadio))
+        return;
+
+    tableModel->addRadio(newRadio);
+    Util::saveLocalRadioList(tableModel->getAllRadios());
+}
+
+
+//----------------------------------------------------------------------------
+void DialogConfig::on_pushButton_editRadio_clicked() {
+
+    const QModelIndexList sel = ui->tableView_radio->selectionModel()->selectedRows();
+    if (sel.isEmpty()) {
+        QMessageBox::information(this, tr("Edit Radio"),
+            tr("Select a radio station to edit."));
+        return;
+    }
+
+    const int row = sel.first().row();
+    Radio existing = tableModel->getRadioAtRow(sel.first());
+    if (!runRadioEditDialog(this, existing))
+        return;
+
+    tableModel->replaceRadioAtRow(row, existing);
+    Util::saveLocalRadioList(tableModel->getAllRadios());
+}
+
+
+//----------------------------------------------------------------------------
+void DialogConfig::on_pushButton_deleteRadio_clicked() {
+
+    const QModelIndexList sel = ui->tableView_radio->selectionModel()->selectedRows();
+    if (sel.isEmpty()) {
+        QMessageBox::information(this, tr("Delete Radio"),
+            tr("Select a radio station to delete."));
+        return;
+    }
+
+    const int row = sel.first().row();
+    const Radio radio = tableModel->getRadioAtRow(sel.first());
+
+    /// Confirm so the user doesn't nuke a default by accident, but we do
+    /// allow deleting bundled defaults — that's the whole point.
+    if (QMessageBox::question(this, tr("Delete Radio"),
+            tr("Delete \"%1\"?").arg(radio.getName()),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No) != QMessageBox::Yes) {
+        return;
+    }
+
+    tableModel->removeRadioAtRow(row);
+    Util::saveLocalRadioList(tableModel->getAllRadios());
+}

--- a/src/ui/dialogconfig.h
+++ b/src/ui/dialogconfig.h
@@ -102,6 +102,13 @@ private slots:
     void on_pushButton_prevRadio_clicked();
     void on_pushButton_nextRadio_clicked();
 
+    // Radio list editor (Add / Edit / Delete buttons under the table).
+    // Each persists the full radio list to the local radios.json after the
+    // model is updated, so changes survive restart.
+    void on_pushButton_addRadio_clicked();
+    void on_pushButton_editRadio_clicked();
+    void on_pushButton_deleteRadio_clicked();
+
 
     ///timers
     void on_checkBox_showTimerOnTop_clicked(bool checked);

--- a/src/ui/dialogconfig.ui
+++ b/src/ui/dialogconfig.ui
@@ -2455,6 +2455,50 @@ QLabel {
             </widget>
            </item>
            <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_radioEdit">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="pushButton_addRadio">
+               <property name="text">
+                <string>Add</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_editRadio">
+               <property name="text">
+                <string>Edit</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_deleteRadio">
+               <property name="text">
+                <string>Delete</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_radioEdit">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
             <layout class="QGridLayout" name="gridLayout_3">
              <property name="leftMargin">
               <number>9</number>

--- a/src/ui/main_workoutpage.cpp
+++ b/src/ui/main_workoutpage.cpp
@@ -9,13 +9,7 @@
 #include "util.h"
 #include "environnement.h"
 #include "workoututil.h"
-
-#include <QWebEngineView>
-#include <QWebEngineProfile>
-#include <QWebEngineScript>
-#include <QWebEnginePage>
-#include <QWebEngineScriptCollection>
-#include <QWebChannel>
+#include "workout.h"
 
 
 
@@ -66,8 +60,37 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     ui->tableView_workout->setModel(proxyModel);
     ui->tableView_workout->verticalHeader()->setDefaultSectionSize(60);
 
-    connectWebChannelWorkout();
-    ui->webView_workouts->setUrl(QUrl(Environnement::getUrlWorkout()));
+    /// Populate the type-filter combobox. Index 0 is "All" (no type filter);
+    /// the remaining entries map onto Workout::Type enum values via userData.
+    ui->comboBox_filter_type->addItem(tr("All types"), -1);
+    ui->comboBox_filter_type->addItem(tr("Endurance"), Workout::T_ENDURANCE);
+    ui->comboBox_filter_type->addItem(tr("Interval"),  Workout::T_INTERVAL);
+    ui->comboBox_filter_type->addItem(tr("Tempo"),     Workout::T_TEMPO);
+    ui->comboBox_filter_type->addItem(tr("Test"),      Workout::T_TEST);
+    ui->comboBox_filter_type->addItem(tr("Other"),     Workout::T_OTHERS);
+    ui->comboBox_filter_type->addItem(tr("Threshold"), Workout::T_THRESHOLD);
+
+    /// Wire each filter input to the existing filterChanged proxy logic.
+    /// QueuedConnection is unnecessary here — proxy invalidation is cheap.
+    connect(ui->lineEdit_filter_name, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("name", v); });
+    connect(ui->lineEdit_filter_plan, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("plan", v); });
+    connect(ui->lineEdit_filter_creator, &QLineEdit::textChanged, this,
+            [this](const QString& v){ filterChanged("creator", v); });
+    connect(ui->comboBox_filter_type,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &Main_WorkoutPage::onFilterTypeIndexChanged);
+
+    /// Apply the persisted filter state loaded from QSettings to the inputs;
+    /// the textChanged/currentIndexChanged hooks above will then push those
+    /// values into the proxy model.
+    applyFiltersToInputs();
+
+    if (!account->show_included_workout) {
+        ui->checkBox->setChecked(false);
+        filterChangedWorkoutType(false);
+    }
 
 
     ui->tableView_workout->sortByColumn(0, Qt::AscendingOrder);
@@ -117,9 +140,6 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     actionDelete->setEnabled(false);
     actionOpenFolder->setEnabled(false);
 
-
-    connect(ui->webView_workouts, SIGNAL(loadFinished(bool)), this, SLOT(fillWorkoutPage()));
-
 }
 
 
@@ -161,78 +181,51 @@ void Main_WorkoutPage::parseMapWorkout(int userFTP) {
 
 
 //---------------------------------------------------------------------------------------------------------
-void Main_WorkoutPage::connectWebChannelWorkout() {
+void Main_WorkoutPage::applyFiltersToInputs() {
 
+    /// Push the persisted nameFilter/planFilter/creatorFilter/typeFilter
+    /// values into the native input widgets. The textChanged /
+    /// currentIndexChanged signals wired up in the constructor will then
+    /// drive the proxy filter through filterChanged().
+    ui->lineEdit_filter_name->setText(nameFilter);
+    ui->lineEdit_filter_plan->setText(planFilter);
+    ui->lineEdit_filter_creator->setText(creatorFilter);
 
-    qDebug() << "connectWebChannelWorkout";
-
-    QFile webChannelJsFile(":/qtwebchannel/qwebchannel.js");
-    if(  !webChannelJsFile.open(QIODevice::ReadOnly) ) {
-        qDebug() << QString("Couldn't open qwebchannel.js file: %1").arg(webChannelJsFile.errorString());
-    }
-    else {
-        qDebug() << "OK webEngineProfile";
-        QByteArray webChannelJs = webChannelJsFile.readAll();
-        webChannelJs.append(
-                    "\n"
-                    "var workoutObject"
-                    "\n"
-                    "new QWebChannel(qt.webChannelTransport, function(channel) {"
-                    "     workoutObject = channel.objects.workoutObject;"
-                    "});"
-                    "\n"
-                    );
-
-        QWebChannel *channel = new QWebChannel(ui->webView_workouts);
-        QWebEngineScript script;
-        script.setSourceCode(webChannelJs);
-        script.setName("qwebchannel.js");
-        script.setWorldId(QWebEngineScript::MainWorld);
-        script.setInjectionPoint(QWebEngineScript::DocumentCreation);
-        script.setRunsOnSubFrames(false);
-
-        ui->webView_workouts->page()->scripts().insert(script);
-        ui->webView_workouts->page()->setWebChannel(channel);
-        channel->registerObject("workoutObject", this);
-    }
-
-
-    if (!account->show_included_workout) {
-        ui->checkBox->setChecked(false);
-        filterChangedWorkoutType(false);
-    }
-
+    int comboIndex = ui->comboBox_filter_type->findData(typeFilter);
+    if (comboIndex < 0) comboIndex = 0; // "All types"
+    ui->comboBox_filter_type->setCurrentIndex(comboIndex);
 }
 
 
 //---------------------------------------------------------------------------------------------------------
-void Main_WorkoutPage::fillWorkoutPage() {
+void Main_WorkoutPage::onFilterTypeIndexChanged(int index) {
 
+    const int typeId = ui->comboBox_filter_type->itemData(index).toInt();
+    typeFilter = typeId;
 
-    qDebug() << "fillWorkoutPage";
-
-    QString jsCode;
-    jsCode = QString("$('#name-workout').val('%1');").arg(nameFilter);
-    jsCode += QString("$('#plan-workout').val('%1');").arg(planFilter);
-    jsCode += QString("$('#creator-workout').val('%1');").arg(creatorFilter);
-
-    if (typeFilter != -1) {
-        jsCode += QString("$('#select-type-workout').val(%1);").arg(typeFilter);
-        jsCode += "$('#select-type-workout').selectpicker('refresh');";
-        jsCode += "$('#select-type-workout').trigger('change');";
+    if (typeId < 0) {
+        // "All types" — clear the type column filter.
+        proxyModel->addFilterFixedString(3, "");
     }
+    else {
+        // Match what gets shown in column 3 (Workout::getTypeToString()).
+        Workout tmp;
+        tmp.setType(static_cast<Workout::Type>(typeId));
+        proxyModel->addFilterFixedString(3, tmp.getTypeToString());
+    }
+    proxyModel->invalidate();
+}
 
 
-    qDebug() << "JSTOEXECUTE IS:" << jsCode;
-    // Guard against pages where jQuery is not yet loaded (e.g. screenshot/CI
-    // mode where the external URL was replaced with blank HTML).
-    ui->webView_workouts->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsCode + QStringLiteral("}"));
+//---------------------------------------------------------------------------------------------------------
+void Main_WorkoutPage::on_pushButton_filter_clear_clicked() {
 
-    filterChanged("name", nameFilter);
-    filterChanged("plan", planFilter);
-    filterChanged("creator", creatorFilter);
-
+    /// Resetting the inputs triggers the textChanged / currentIndexChanged
+    /// hooks, which propagate empty filters to the proxy model.
+    ui->lineEdit_filter_name->clear();
+    ui->lineEdit_filter_plan->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
 }
 
 
@@ -473,28 +466,17 @@ void Main_WorkoutPage::updateTableViewMetrics() {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::setFilterPlanName(const QString& plan) {
 
-
     qDebug() << "setFilterPlanName";
 
-    // Escape backslashes and single quotes so the value is safe inside a JS single-quoted string
-    QString jsPlan = plan;
-    jsPlan.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
-    jsPlan.replace(QLatin1Char('\''), QStringLiteral("\\'"));
+    /// Replace any active filters with a plan-only filter. Setting the
+    /// inputs fires textChanged/currentIndexChanged which propagate the
+    /// new values into the proxy model.
+    ui->lineEdit_filter_name->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
+    ui->lineEdit_filter_plan->setText(plan);
 
-    QString jsToExecute = "$('#name-workout').val( '' ); ";
-    jsToExecute += QString("$('#plan-workout').val( '%1' ); ").arg(jsPlan);
-    jsToExecute += "$('#creator-workout').val( '' ); ";
-
-    jsToExecute += "$('#select-type-workout option:selected').prop('selected', false); ";
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh'); ";
-
-
-    ui->webView_workouts->page()->runJavaScript(jsToExecute);
-
-
-    filterChanged("", "");
-    filterChanged("plan", plan);
-    if (!ui->checkBox->isChecked() && plan != "") {
+    if (!ui->checkBox->isChecked() && !plan.isEmpty()) {
         ui->checkBox->setChecked(true);
         filterChangedWorkoutType(true);
     }
@@ -505,26 +487,13 @@ void Main_WorkoutPage::setFilterPlanName(const QString& plan) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::setFilterWorkoutName(const QString& workoutName) {
 
-
     qDebug() << "setFilterWorkoutName";
 
-    // Escape backslashes and single quotes so the value is safe inside a JS single-quoted string
-    QString jsWorkoutName = workoutName;
-    jsWorkoutName.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
-    jsWorkoutName.replace(QLatin1Char('\''), QStringLiteral("\\'"));
-
-    QString jsToExecute = "$('#plan-workout').val( '' ); ";
-    jsToExecute += QString("$('#name-workout ').val( '%1' ); ").arg(jsWorkoutName);
-    jsToExecute += "$('#creator-workout').val( '' ); ";
-
-    jsToExecute += "$('#select-type-workout option:selected').prop('selected', false); ";
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh'); ";
-
-    ui->webView_workouts->page()->runJavaScript(jsToExecute);
-
-
-    filterChanged("", "");
-    filterChanged("name", workoutName);
+    /// Replace any active filters with a name-only filter.
+    ui->lineEdit_filter_plan->clear();
+    ui->lineEdit_filter_creator->clear();
+    ui->comboBox_filter_type->setCurrentIndex(0);
+    ui->lineEdit_filter_name->setText(workoutName);
 
     ui->tableView_workout->scrollToTop();
 }
@@ -561,14 +530,6 @@ void Main_WorkoutPage::loadFilterFields() {
     qDebug() << "Setings to load filter should be" << nameFilter << planFilter << creatorFilter << typeFilter;
 }
 
-
-//---------------------------------------------------------------
-void Main_WorkoutPage::filterChangedList(int id) {
-
-    //Just to save to settings later on
-    qDebug() << "ok it changed here" << id;
-    typeFilter = id;
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 void Main_WorkoutPage::filterChanged(const QString& field, const QString& value) {

--- a/src/ui/main_workoutpage.h
+++ b/src/ui/main_workoutpage.h
@@ -50,7 +50,6 @@ signals :
 
 public slots:
     void filterChanged(const QString& field, const QString& value);
-    void filterChangedList(int id);
     void filterChangedWorkoutType(bool includedWorkout);
 
     void setFilterPlanName(const QString& name);
@@ -66,8 +65,9 @@ public slots:
 
 private slots:
 
-    void connectWebChannelWorkout();
-    void fillWorkoutPage();
+    void applyFiltersToInputs();
+    void onFilterTypeIndexChanged(int index);
+    void on_pushButton_filter_clear_clicked();
 
 
     void on_tableView_workout_doubleClicked(const QModelIndex &index);

--- a/src/ui/main_workoutpage.ui
+++ b/src/ui/main_workoutpage.ui
@@ -24,22 +24,98 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWebEngineView" name="webView_workouts" native="true">
+    <widget class="QFrame" name="frame_workout_filter">
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>140</height>
+       <height>90</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>140</height>
+       <height>90</height>
       </size>
      </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::NoContextMenu</enum>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_workout_filter">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_filter_name">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_filter_name">
+        <property name="placeholderText">
+         <string>Filter by name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_filter_plan">
+        <property name="text">
+         <string>Plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLineEdit" name="lineEdit_filter_plan">
+        <property name="placeholderText">
+         <string>Filter by plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_filter_creator">
+        <property name="text">
+         <string>Creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEdit_filter_creator">
+        <property name="placeholderText">
+         <string>Filter by creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_filter_type">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="comboBox_filter_type"/>
+      </item>
+      <item row="0" column="4" rowspan="2">
+       <widget class="QPushButton" name="pushButton_filter_clear">
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -209,12 +285,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">qwebengineview.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>TableViewHover</class>
    <extends>QTableView</extends>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -293,10 +293,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
 
 
-    ///Retrieve Internet Radio from DB
-    replyRadioDone = false;
-    replyRadio = RadioDAO::getAllRadios();
-    connect(replyRadio, SIGNAL(finished()), this, SLOT(slotFinishedGetRadio()));
+    /// Load the radio list from the user's local radios.json file. The
+    /// legacy maximumtrainer.com REST endpoint is gone; Util seeds the file
+    /// with a few bundled defaults on first run, and the user manages it
+    /// from the workout-dialog Settings → Radio tab.
+    lstRadio = Util::loadLocalRadioList();
+    this->setEnabled(true);
 
     qDebug() << "Test1";
 
@@ -350,72 +352,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-//---------------------------------------------------------------------------------
-void MainWindow::checkToEnableWindow() {
-
-    if (replyRadioDone) {
-        this->setEnabled(true);
-    }
-}
-
-
-
-//---------------------------------------------------------------------------------
-void MainWindow::slotFinishedGetRadio() {
-
-
-    //success
-    if (replyRadio->error() == QNetworkReply::NoError) {
-        qDebug() << "Get radio finished!";
-        QByteArray arrayData =  replyRadio->readAll();
-        lstRadio = Util::parseJsonRadioList(arrayData);
-        //enable mainWindow
-        ui->widget_bottomMenu->removeGeneralMessage();
-
-        replyRadioDone = true;
-        m_radioRetryCount = 0;
-        checkToEnableWindow();
-
-
-        replyRadio->deleteLater();
-    }
-    else {
-        LOG_WARN("MainWindow",
-                 QStringLiteral("Radio list fetch failed: ") + replyRadio->errorString());
-        ui->widget_bottomMenu->setGeneralMessage("Error retrieving data from Server..." + replyRadio->errorString(), 7000);
-
-        // In screenshot / offline mode, give up immediately so we don't produce
-        // a tight infinite loop when the server is unreachable (e.g. on CI).
-        // Also give up after 3 consecutive failures as a general safety net.
-        const auto *acct = qApp->property("Account").value<Account*>();
-        const bool inOfflineMode = !m_ssOutputDir.isEmpty()
-                                   || (acct && acct->isOffline);
-        if (inOfflineMode) {
-            LOG_WARN("MainWindow", "Radio list fetch: not retrying (offline/screenshot mode)");
-            replyRadio->deleteLater();
-            replyRadioDone = true;
-            checkToEnableWindow();
-            return;
-        }
-        if (++m_radioRetryCount >= 3) {
-            LOG_WARN("MainWindow", QStringLiteral("Radio list fetch: giving up after %1 attempt(s)").arg(m_radioRetryCount));
-            replyRadio->deleteLater();
-            replyRadioDone = true;
-            checkToEnableWindow();
-            return;
-        }
-
-        // Retry: start a fresh request and hand off the old reply for deletion.
-        QNetworkReply *old = replyRadio;
-        replyRadio = RadioDAO::getAllRadios();
-        connect(replyRadio, SIGNAL(finished()), this, SLOT(slotFinishedGetRadio()));
-        old->deleteLater();
-    }
-
-}
-
 
 
 //---------------------------------------------------------------------------------
@@ -2364,13 +2300,6 @@ void MainWindow::startScreenshotMode(const QString &outputDir)
     // with that established pattern for an inherently offline code-path.
     if (auto *acct = qApp->property("Account").value<Account*>())
         acct->isOffline = true;
-
-    // Abort any in-flight radio fetch so the tight retry loop stops immediately.
-    // slotFinishedGetRadio() will be called with OperationCanceledError; the
-    // offline/screenshot-mode check there will mark replyRadioDone and return.
-    if (!replyRadioDone && replyRadio) {
-        replyRadio->abort();
-    }
 
     // Navigate ALL WebEngine views (including nested ones in child widgets) to
     // blank HTML.  External pages depend on jQuery / RxJS loaded from CDN; in

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -119,9 +119,6 @@ public slots:
 
 
 private slots:
-    void slotFinishedGetRadio();
-
-
     void on_actionAbout_MT_triggered();
     void on_actionAbout_Qt_triggered();
     void on_actionRequest_Help_triggered();
@@ -195,7 +192,6 @@ private:
 
     void tryAdvanceWorkoutQueue();
 
-    void checkToEnableWindow();
     void sendDataToSettingsOrStudioPage(int deviceType, int numberDeviceFound, QList<int> lstDevicePairedr, QList<int> lstTypeDevicePairedr, bool fromStudioPage);
 
     // Screenshot mode helpers
@@ -216,8 +212,6 @@ private:
     Ui::MainWindow *ui;
     DialogMainWindowConfig *dconfig;
 
-    bool replyRadioDone;
-    QNetworkReply *replyRadio;
     QList<Radio> lstRadio;
 
     ZoneObject *zoneObject;
@@ -263,10 +257,6 @@ private:
     int            m_ssStep       = 0;
     WorkoutDialog *m_ssWorkoutDlg = nullptr;
     SimulatorHub  *m_ssSimHub     = nullptr;
-
-    // Radio fetch retry guard – limits retries to avoid a tight loop when the
-    // server is unreachable (e.g. in screenshot/CI mode).
-    int            m_radioRetryCount = 0;
 
     // Plan Adherence (#157)
     PlanAdherenceStore *m_adherenceStore = nullptr;

--- a/src/ui/workout_editor/tableviewinterval.cpp
+++ b/src/ui/workout_editor/tableviewinterval.cpp
@@ -18,7 +18,10 @@ TableViewInterval::TableViewInterval(QWidget *parent) :
     setDragDropMode(QAbstractItemView::InternalMove);
     setDragDropOverwriteMode(false);
     setDefaultDropAction(Qt::MoveAction);
-    setSelectionMode(QAbstractItemView::SingleSelection);
+    // ExtendedSelection (not SingleSelection) so Shift-click / Ctrl-click
+    // can select a multi-row range — required by the Repeat button, which
+    // wraps the selected interval range in a repeat block.
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
 }
 
 

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -18,14 +18,6 @@
 #include "environnement.h"
 
 
-#include <QWebEngineView>
-#include <QWebEngineProfile>
-#include <QWebEngineScript>
-#include <QWebEnginePage>
-#include <QWebEngineScriptCollection>
-#include <QWebChannel>
-
-
 
 WorkoutCreator::~WorkoutCreator()
 {
@@ -43,9 +35,19 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
     this->account = qApp->property("Account").value<Account*>();
 
 
-    connectWebChannelWorkoutCreator();
-    ui->webView_createWorkout->setUrl(QUrl(Environnement::getUrlWorkoutCreator()));
-    /// ----------------------------------------------------
+    /// Populate the type combobox in the same order as Workout::Type so
+    /// QComboBox::currentIndex() maps directly onto the enum value.
+    ui->comboBox_type_workout->addItem(tr("Endurance"), Workout::T_ENDURANCE);
+    ui->comboBox_type_workout->addItem(tr("Interval"),  Workout::T_INTERVAL);
+    ui->comboBox_type_workout->addItem(tr("Tempo"),     Workout::T_TEMPO);
+    ui->comboBox_type_workout->addItem(tr("Test"),      Workout::T_TEST);
+    ui->comboBox_type_workout->addItem(tr("Other"),     Workout::T_OTHERS);
+    ui->comboBox_type_workout->addItem(tr("Threshold"), Workout::T_THRESHOLD);
+
+    connect(ui->lineEdit_name_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->lineEdit_plan_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->lineEdit_creator_workout, SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
+    connect(ui->pushButton_save_workout,  SIGNAL(clicked()),            this, SLOT(on_pushButton_save_workout_clicked()));
 
 
 
@@ -164,41 +166,20 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-void WorkoutCreator::connectWebChannelWorkoutCreator() {
+void WorkoutCreator::populateInputsFromWorkout() {
 
-    qDebug() << "connectWebChannelWorkoutCreator";
+    /// Sync the native input widgets with the current `workout` state.
+    /// Called from resetWorkout()/editWorkout() — replaces the old
+    /// fillWorkoutCreatorPageWeb() that pushed values into the embedded
+    /// jQuery page via runJavaScript().
+    ui->lineEdit_name_workout->setText(workout.getName());
+    ui->lineEdit_plan_workout->setText(workout.getPlan());
+    ui->lineEdit_creator_workout->setText(workout.getCreatedBy());
+    ui->plainTextEdit_description_workout->setPlainText(workout.getDescription());
 
-    QFile webChannelJsFile(":/qtwebchannel/qwebchannel.js");
-    if(  !webChannelJsFile.open(QIODevice::ReadOnly) ) {
-        qDebug() << QString("Couldn't open qwebchannel.js file: %1").arg(webChannelJsFile.errorString());
-    }
-    else {
-        qDebug() << "OK webEngineProfile";
-        QByteArray webChannelJs = webChannelJsFile.readAll();
-        webChannelJs.append(
-                    "\n"
-                    "var WorkoutCreator"
-                    "\n"
-                    "new QWebChannel(qt.webChannelTransport, function(channel) {"
-                    "     WorkoutCreator = channel.objects.WorkoutCreator;"
-                    "});"
-                    "\n"
-                    );
-
-        QWebChannel *channel = new QWebChannel(ui->webView_createWorkout);
-        QWebEngineScript script;
-        script.setSourceCode(webChannelJs);
-        script.setName("qwebchannel.js");
-        script.setWorldId(QWebEngineScript::MainWorld);
-        script.setInjectionPoint(QWebEngineScript::DocumentCreation);
-        script.setRunsOnSubFrames(false);
-
-        ui->webView_createWorkout->page()->scripts().insert(script);
-        ui->webView_createWorkout->page()->setWebChannel(channel);
-        channel->registerObject("WorkoutCreator", this);
-    }
-
-
+    int typeIndex = ui->comboBox_type_workout->findData(static_cast<int>(workout.getType()));
+    if (typeIndex < 0) typeIndex = 0;
+    ui->comboBox_type_workout->setCurrentIndex(typeIndex);
 }
 
 
@@ -239,7 +220,12 @@ void WorkoutCreator::resetWorkout() {
     lstRepeatWidget.clear();
     lstRepeatData.clear();
 
-    fillWorkoutCreatorPageWeb("", "-", account->display_name, 0, "");
+    workout.setName("");
+    workout.setPlan("-");
+    workout.setCreator(account->display_name);
+    workout.setDescription("");
+    workout.setType(Workout::T_ENDURANCE);
+    populateInputsFromWorkout();
 
     computeWorkout();
 
@@ -325,41 +311,8 @@ void WorkoutCreator::editWorkout(Workout workoutToEdit) {
     intervalModel->setListInterval(workoutToEdit.getLstIntervalSource());
     restoreRepeatWidgetInterface();
 
-    fillWorkoutCreatorPageWeb(workout.getName(), workout.getPlan(), workout.getCreatedBy(), workout.getType(), workout.getDescription());
+    populateInputsFromWorkout();
     checkToEnableButtonSave();
-}
-
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
-void WorkoutCreator::fillWorkoutCreatorPageWeb(QString name, QString plan, QString creator, int type, QString description) {
-
-    qDebug() << "fillWorkoutCreatorPageWeb";
-
-    //Parse for Quotes, Javascript doesnt like them so escape them
-    QString planEscaped = plan.replace("\'", "\\'");
-    QString creatorEscaped = creator.replace("\'", "\\'");
-    QString descriptionEscaped = description.replace("\'", "\\'");
-    descriptionEscaped = descriptionEscaped.replace("\n", "\\n");
-
-
-    //// ----------- Set Data in QWebView : have to put null at the end of evaluate javascript or it's really slow
-    /// source : http://stackoverflow.com/questions/19505063/qt-javascript-execution-slow-unless-i-log-to-the-console
-    QString jsToExecute = QString("$('#name-workout').val( '%1' ); ").arg(name);
-    jsToExecute += QString("$('#plan-workout').val( '%1' ); ").arg(planEscaped);
-    jsToExecute += QString("$('#creator-workout').val( '%1' ); ").arg(creatorEscaped);
-    jsToExecute += QString("$('#description-workout').val( '%1' ); ").arg(descriptionEscaped);
-
-    jsToExecute += QString("$('#select-type-workout').val( %1 );").arg(type);
-    jsToExecute += "$('#select-type-workout').selectpicker('refresh');";
-    //    ui->webView_createWorkout->page()->mainFrame()->documentElement().evaluateJavaScript(jsToExecute + "; null");
-
-    // Guard against pages where jQuery is not yet loaded (e.g. screenshot/CI
-    // mode where the external URL was replaced with blank HTML).
-    ui->webView_createWorkout->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsToExecute + QStringLiteral("}"));
-
-
 }
 
 
@@ -367,31 +320,25 @@ void WorkoutCreator::fillWorkoutCreatorPageWeb(QString name, QString plan, QStri
 ////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutCreator::checkToEnableButtonSave() {
 
-
     qDebug() << "OK WORKOUT CREATOR CHECK BUTTON SAVE";
 
-    bool enabled = true;
-    if (intervalModel->rowCount() == 0) {
-        enabled = false;
-    }
+    const bool hasIntervals = intervalModel->rowCount() > 0;
+    const bool hasName    = !ui->lineEdit_name_workout->text().isEmpty();
+    const bool hasPlan    = !ui->lineEdit_plan_workout->text().isEmpty();
+    const bool hasCreator = !ui->lineEdit_creator_workout->text().isEmpty();
+
+    ui->pushButton_save_workout->setEnabled(hasIntervals && hasName && hasPlan && hasCreator);
+}
 
 
-    QString jsToRun = "var nameValue = $('#name-workout').val();"
-                      "var planValue =   $('#plan-workout').val();"
-                      "var creatorValue = $('#creator-workout').val();"
-                      "if (nameValue.length > 0 && creatorValue.length > 0 && planValue.length > 0 && " + QString::number(enabled) +") {"
-                      "$('#btn-save-workout').prop('disabled', false);"
-                      "}"
-                      "else {"
-                      "$('#btn-save-workout').prop('disabled', true);"
-                      "}";
+////////////////////////////////////////////////////////////////////////////////////////////
+void WorkoutCreator::on_pushButton_save_workout_clicked() {
 
-//    qDebug() << "ok button check JS is " << jsToRun;
-
-    // Guard against pages where jQuery is not yet loaded.
-    ui->webView_createWorkout->page()->runJavaScript(
-        QStringLiteral("if(typeof window.$==='function'){") + jsToRun + QStringLiteral("}"));
-
+    createWorkout(ui->lineEdit_name_workout->text(),
+                  ui->lineEdit_plan_workout->text(),
+                  ui->lineEdit_creator_workout->text(),
+                  ui->plainTextEdit_description_workout->toPlainText(),
+                  ui->comboBox_type_workout->currentIndex());
 }
 
 

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -44,10 +44,14 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
     ui->comboBox_type_workout->addItem(tr("Other"),     Workout::T_OTHERS);
     ui->comboBox_type_workout->addItem(tr("Threshold"), Workout::T_THRESHOLD);
 
+    // Note: pushButton_save_workout::clicked() is hooked up automatically by
+    // QMetaObject::connectSlotsByName via the on_pushButton_save_workout_clicked
+    // slot name — adding an explicit connect() here would fire it twice and
+    // make the second call see the just-written file, triggering a spurious
+    // "workout already exists" dialog.
     connect(ui->lineEdit_name_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
     connect(ui->lineEdit_plan_workout,    SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
     connect(ui->lineEdit_creator_workout, SIGNAL(textChanged(QString)), this, SLOT(checkToEnableButtonSave()));
-    connect(ui->pushButton_save_workout,  SIGNAL(clicked()),            this, SLOT(on_pushButton_save_workout_clicked()));
 
 
 

--- a/src/ui/workout_editor/workoutcreator.h
+++ b/src/ui/workout_editor/workoutcreator.h
@@ -46,8 +46,8 @@ signals :
 
 
 private slots:
-    void connectWebChannelWorkoutCreator();
-    void fillWorkoutCreatorPageWeb(QString name, QString plan, QString creator, int type, QString description);
+    void populateInputsFromWorkout();
+    void on_pushButton_save_workout_clicked();
 
 
 

--- a/src/ui/workout_editor/workoutcreator.ui
+++ b/src/ui/workout_editor/workoutcreator.ui
@@ -66,7 +66,7 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
     <number>0</number>
    </property>
    <item>
-    <widget class="QWebEngineView" name="webView_createWorkout" native="true">
+    <widget class="QFrame" name="frame_workout_meta">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -85,9 +85,93 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
        <height>200</height>
       </size>
      </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::NoContextMenu</enum>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_workout_meta">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_name_workout">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEdit_name_workout"/>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_plan_workout">
+        <property name="text">
+         <string>Plan</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLineEdit" name="lineEdit_plan_workout"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_creator_workout">
+        <property name="text">
+         <string>Creator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEdit_creator_workout"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_type_workout">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="comboBox_type_workout"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_description_workout">
+        <property name="text">
+         <string>Description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="3">
+       <widget class="QPlainTextEdit" name="plainTextEdit_description_workout">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QPushButton" name="pushButton_save_workout">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -458,12 +542,6 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header location="global">qwebengineview.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>myCreatorPlot</class>
    <extends>QWidget</extends>


### PR DESCRIPTION
> Stacked on top of #200. Diff currently includes #200's changes; once #200 merges, this PR's diff collapses to just the radio changes.

## Summary
The Workout dialog's radio list was fetched at startup from a now-defunct REST endpoint. The list ended up empty, the bottom bar showed *"Error retrieving data from Server…"* on every launch, and **double-clicking the empty radio table segfaulted** (out-of-bounds index dereference).

This PR replaces the network fetch with a local, editable list, and fixes the crash by always having a non-empty list seeded from a bundled resource.

### Storage
- `~/Documents/MaximumTrainer/radios.json`, seeded on first run from the Qt resource `resources/data/default_radios.json`.
- 10 ad-free / listener-supported defaults across distinct styles (SomaFM Groove Salad / Beat Blender / Indie Pop Rocks / Boot Liquor / Drone Zone / Underground 80s, Radio Paradise Main + Global, FIP, France Musique).
- Editing the shipped list is now a JSON edit — no recompile of inlined constants.
- Parse failure leaves the user's file untouched and falls back to defaults for the session.

### UI
- Add / Edit / Delete buttons in the radio settings (workout dialog → cog → Radio); each persists `radios.json` after the change. Defaults can be deleted.
- Top-bar transport buttons replaced with Qt standard `SP_MediaSkipBackward` / `SP_MediaPlay` / `SP_MediaPause` / `SP_MediaSkipForward` pixmaps, tinted light gray for legibility on the dark top bar. F6/F7/F8 shortcut moved to tooltip; keystroke handler unchanged.
- Edit / Delete fall back to `currentIndex()` so a single row click is enough.

### Removed
`MainWindow::slotFinishedGetRadio`, the `replyRadio` / `replyRadioDone` / `m_radioRetryCount` machinery, `checkToEnableWindow`, and the screenshot-mode `replyRadio->abort()` guard.

## Test plan
- [ ] Build on Ubuntu (after `vlc-plugin-video-output` per #200's doc note)
- [ ] Fresh `~/Documents/MaximumTrainer/radios.json` (delete it): on next launch the 10 defaults are written from the bundled resource
- [ ] Double-click a default — libvlc opens the stream (and no longer crashes)
- [ ] Single-click a row → Edit / Delete work
- [ ] Restart app → on-disk JSON reflects all changes (defaults are NOT re-seeded)
- [ ] Top-bar radio buttons render as light-gray transport icons; play/pause icon swaps on stream start/stop; F6/F7/F8 still work
- [ ] Corrupt `radios.json` → app still launches with bundled defaults; broken file is preserved
