### PR TITLE
Wayland video fix, embedded web player, and workout-dialog QoL fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: ["**"]
     tags-ignore: ["**"]  # tag pushes are handled by release.yml, not build.yml
+  # Build every PR targeting master so cross-platform breakage (Windows/macOS/
+  # WASM) is caught before merge — including PRs from forks, whose branches do
+  # not trigger the push event on this repo. compute_version is master-only and
+  # skipped here; the build jobs run regardless via `needs + if: always()`.
+  pull_request:
+    branches: [master]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Once a workout starts you will see:
 
 Completed workout data is saved as a FIT activity file and can be uploaded to **Strava**, **TrainingPeaks**, **SelfLoops**, or **Intervals.icu** from the post-workout screen.
 
+> **Video entertainment:** the workout view can show either the built-in VLC player (local files / internet radio) or an embedded web browser (**Preferences → Video Player → WebView**). The web browser is for YouTube and other DRM-free sites — DRM services such as Netflix require the proprietary Widevine module, which cannot be bundled in this open-source build, so they will not play.
+
 ## Screenshots
 
 > **Note:** Screenshots showing the cross-platform UI will be added here. Contributions of high-quality screenshots on each platform are welcome — please open a pull request.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ make -j$(nproc)
 
 > `vlc-plugin-video-output` is required for libvlc to render video into the Workout dialog. Without it, libvlc loads but reports `failed to create video output` and the player shows only the timer.
 
+> **Wayland:** libvlc's Linux video output is X11/XCB-only (VLC 3.0.x ships no native Wayland output), so under a Wayland session it cannot embed video into the Qt widget and spawns a separate window. The app detects Wayland and automatically forces the `xcb` platform (via XWayland) so video stays in the workout frame. Set `QT_QPA_PLATFORM` yourself to override this.
+
 ### macOS
 
 Uses Qt 6.7.3 with Clang. QWT is built from source (non-framework) against Qt 6. VLC-Qt is optional on macOS.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -31,6 +31,23 @@ int main(int argc, char *argv[]) {
     // will override it from QSettings once the application identity is set.
     Logger::install();
 
+#if defined(Q_OS_LINUX) && !defined(Q_OS_WASM)
+    // libvlc embeds video by drawing into the Qt widget's native window handle,
+    // but its Linux video-output plugins are all X11/XCB-based (VLC 3.0.x ships
+    // no native Wayland vout). Under a native Wayland session winId() is a
+    // Wayland surface libvlc cannot draw into, so it spawns its own top-level
+    // window instead of staying in the workout frame. Forcing the xcb platform
+    // routes us through XWayland, giving libvlc a real X11 drawable. Only do
+    // this when we detect Wayland and the user has not pinned a platform.
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        const QByteArray sessionType = qgetenv("XDG_SESSION_TYPE");
+        const bool isWayland = sessionType.compare("wayland", Qt::CaseInsensitive) == 0
+                            || !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY");
+        if (isWayland)
+            qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+#endif
+
     QApplication app(argc, argv);
 
 #ifdef Q_OS_WIN

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -203,6 +203,10 @@ Account::Account(QObject *parent) : QObject(parent)  {
     hashCourseDone = QSet<QString>();
     //------------------------------
 
+    // Override the display/sound defaults above with any locally-persisted
+    // values (the server-side putAccount endpoint is defunct, so these are the
+    // authoritative store now).
+    loadDisplayPrefs();
 }
 
 
@@ -237,6 +241,120 @@ void Account::saveErgSmoothingDuration(int seconds)
     QSettings settings;
     settings.beginGroup("account");
     settings.setValue("erg_smoothing_duration_s", erg_smoothing_duration_s);
+    settings.endGroup();
+}
+
+// Group/key prefix for the locally-persisted display & sound preferences.
+// Kept distinct from the legacy server fields so it is self-contained.
+void Account::loadDisplayPrefs() {
+
+    QSettings settings;
+    settings.beginGroup("displayPrefs");
+
+    // Widget visibility
+    show_hr_widget            = settings.value("show_hr_widget",            show_hr_widget).toBool();
+    show_power_widget         = settings.value("show_power_widget",         show_power_widget).toBool();
+    show_power_balance_widget = settings.value("show_power_balance_widget", show_power_balance_widget).toBool();
+    show_cadence_widget       = settings.value("show_cadence_widget",       show_cadence_widget).toBool();
+    show_speed_widget         = settings.value("show_speed_widget",         show_speed_widget).toBool();
+    show_calories_widget      = settings.value("show_calories_widget",      show_calories_widget).toBool();
+    show_oxygen_widget        = settings.value("show_oxygen_widget",        show_oxygen_widget).toBool();
+    show_trainer_speed        = settings.value("show_trainer_speed",        show_trainer_speed).toBool();
+
+    // Per-metric display mode
+    display_hr            = settings.value("display_hr",            display_hr).toInt();
+    display_power         = settings.value("display_power",         display_power).toInt();
+    display_power_balance = settings.value("display_power_balance", display_power_balance).toInt();
+    display_cadence       = settings.value("display_cadence",       display_cadence).toInt();
+    averaging_power       = settings.value("averaging_power",       averaging_power).toInt();
+    offset_power          = settings.value("offset_power",          offset_power).toInt();
+
+    // Timer display
+    show_timer_on_top       = settings.value("show_timer_on_top",       show_timer_on_top).toBool();
+    show_interval_remaining = settings.value("show_interval_remaining", show_interval_remaining).toBool();
+    show_workout_remaining  = settings.value("show_workout_remaining",  show_workout_remaining).toBool();
+    show_elapsed            = settings.value("show_elapsed",            show_elapsed).toBool();
+
+    // Plot target/curve toggles
+    show_seperator_interval = settings.value("show_seperator_interval", show_seperator_interval).toBool();
+    show_grid               = settings.value("show_grid",               show_grid).toBool();
+    show_hr_target          = settings.value("show_hr_target",          show_hr_target).toBool();
+    show_power_target       = settings.value("show_power_target",       show_power_target).toBool();
+    show_cadence_target     = settings.value("show_cadence_target",     show_cadence_target).toBool();
+    show_speed_target       = settings.value("show_speed_target",       show_speed_target).toBool();
+    show_hr_curve           = settings.value("show_hr_curve",           show_hr_curve).toBool();
+    show_power_curve        = settings.value("show_power_curve",        show_power_curve).toBool();
+    show_cadence_curve      = settings.value("show_cadence_curve",      show_cadence_curve).toBool();
+    show_speed_curve        = settings.value("show_speed_curve",        show_speed_curve).toBool();
+
+    // Video player (0 = VLC, 1 = WebView)
+    display_video = settings.value("display_video", display_video).toInt();
+
+    // Sound
+    sound_player_vol               = settings.value("sound_player_vol",               sound_player_vol).toInt();
+    enable_sound                   = settings.value("enable_sound",                   enable_sound).toBool();
+    sound_interval                 = settings.value("sound_interval",                 sound_interval).toBool();
+    sound_pause_resume_workout     = settings.value("sound_pause_resume_workout",     sound_pause_resume_workout).toBool();
+    sound_achievement              = settings.value("sound_achievement",              sound_achievement).toBool();
+    sound_end_workout              = settings.value("sound_end_workout",              sound_end_workout).toBool();
+    sound_alert_power_under_target = settings.value("sound_alert_power_under_target", sound_alert_power_under_target).toBool();
+    sound_alert_power_above_target = settings.value("sound_alert_power_above_target", sound_alert_power_above_target).toBool();
+    sound_alert_cadence_under_target = settings.value("sound_alert_cadence_under_target", sound_alert_cadence_under_target).toBool();
+    sound_alert_cadence_above_target = settings.value("sound_alert_cadence_above_target", sound_alert_cadence_above_target).toBool();
+
+    settings.endGroup();
+}
+
+void Account::saveDisplayPrefs() {
+
+    QSettings settings;
+    settings.beginGroup("displayPrefs");
+
+    settings.setValue("show_hr_widget",            show_hr_widget);
+    settings.setValue("show_power_widget",         show_power_widget);
+    settings.setValue("show_power_balance_widget", show_power_balance_widget);
+    settings.setValue("show_cadence_widget",       show_cadence_widget);
+    settings.setValue("show_speed_widget",         show_speed_widget);
+    settings.setValue("show_calories_widget",      show_calories_widget);
+    settings.setValue("show_oxygen_widget",        show_oxygen_widget);
+    settings.setValue("show_trainer_speed",        show_trainer_speed);
+
+    settings.setValue("display_hr",            display_hr);
+    settings.setValue("display_power",         display_power);
+    settings.setValue("display_power_balance", display_power_balance);
+    settings.setValue("display_cadence",       display_cadence);
+    settings.setValue("averaging_power",       averaging_power);
+    settings.setValue("offset_power",          offset_power);
+
+    settings.setValue("show_timer_on_top",       show_timer_on_top);
+    settings.setValue("show_interval_remaining", show_interval_remaining);
+    settings.setValue("show_workout_remaining",  show_workout_remaining);
+    settings.setValue("show_elapsed",            show_elapsed);
+
+    settings.setValue("show_seperator_interval", show_seperator_interval);
+    settings.setValue("show_grid",               show_grid);
+    settings.setValue("show_hr_target",          show_hr_target);
+    settings.setValue("show_power_target",       show_power_target);
+    settings.setValue("show_cadence_target",     show_cadence_target);
+    settings.setValue("show_speed_target",       show_speed_target);
+    settings.setValue("show_hr_curve",           show_hr_curve);
+    settings.setValue("show_power_curve",        show_power_curve);
+    settings.setValue("show_cadence_curve",      show_cadence_curve);
+    settings.setValue("show_speed_curve",        show_speed_curve);
+
+    settings.setValue("display_video", display_video);
+
+    settings.setValue("sound_player_vol",               sound_player_vol);
+    settings.setValue("enable_sound",                   enable_sound);
+    settings.setValue("sound_interval",                 sound_interval);
+    settings.setValue("sound_pause_resume_workout",     sound_pause_resume_workout);
+    settings.setValue("sound_achievement",              sound_achievement);
+    settings.setValue("sound_end_workout",              sound_end_workout);
+    settings.setValue("sound_alert_power_under_target", sound_alert_power_under_target);
+    settings.setValue("sound_alert_power_above_target", sound_alert_power_above_target);
+    settings.setValue("sound_alert_cadence_under_target", sound_alert_cadence_under_target);
+    settings.setValue("sound_alert_cadence_above_target", sound_alert_cadence_above_target);
+
     settings.endGroup();
 }
 

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -26,6 +26,13 @@ public:
     void saveIntervalSummarySettings();
     void saveAppTheme();
 
+    /// Display & sound preferences (video player, widget displays, target/curve
+    /// toggles, sound alerts). These were historically stored only server-side
+    /// via the now-defunct putAccount REST endpoint, so they were lost on every
+    /// restart (especially offline). These persist them to local QSettings.
+    void loadDisplayPrefs();
+    void saveDisplayPrefs();
+
     /// Encrypt and persist Strava OAuth2 tokens to QSettings.
     /// Call after a successful token exchange or refresh.
     void saveStravaCredentials();

--- a/src/ui/components/components.pri
+++ b/src/ui/components/components.pri
@@ -26,7 +26,8 @@ SOURCES +=\
     $$PWD/oxygenwidget.cpp \
     $$PWD/dialogcalibrate.cpp \
     $$PWD/dialogcalibratepm.cpp \
-    $$PWD/userstudiowidget.cpp
+    $$PWD/userstudiowidget.cpp \
+    $$PWD/webbrowserview.cpp
 
 
 HEADERS +=\
@@ -55,7 +56,8 @@ HEADERS +=\
     $$PWD/dialogcalibrate.h \
     $$PWD/dialogcalibratepm.h \
     $$PWD/userstudiowidget.h \
-    $$PWD/myqwebenginepage.h
+    $$PWD/myqwebenginepage.h \
+    $$PWD/webbrowserview.h
 
 
 

--- a/src/ui/components/webbrowserview.cpp
+++ b/src/ui/components/webbrowserview.cpp
@@ -1,0 +1,222 @@
+#include "webbrowserview.h"
+
+#include <QWebEngineView>
+#include <QWebEnginePage>
+#include <QWebEngineSettings>
+#include <QWebEngineFullScreenRequest>
+#include <QGridLayout>
+#include <QToolBar>
+#include <QLineEdit>
+#include <QTimer>
+#include <QAction>
+#include <QKeyEvent>
+#include <QSettings>
+
+namespace {
+constexpr int kToolbarHideMs = 7000;
+const char *kDefaultHomePage = "https://www.youtube.com";
+}
+
+WebBrowserView::WebBrowserView(QWidget *parent) : QWidget(parent)
+{
+    gLayout = new QGridLayout(this);
+    gLayout->setContentsMargins(0, 0, 0, 0);
+
+    locationEdit = new QLineEdit(this);
+    locationEdit->setSizePolicy(QSizePolicy::Expanding,
+                                locationEdit->sizePolicy().verticalPolicy());
+
+    webEngineView = new QWebEngineView(this);
+    webEngineView->settings()->setAttribute(QWebEngineSettings::PluginsEnabled, true);
+    // QtWebEngine disables fullscreen by default; enable it and accept the
+    // page's fullscreen requests below so YouTube's fullscreen button works.
+    webEngineView->settings()->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);
+
+#ifndef GC_WASM_BUILD
+    // On WASM the QWebEngineView stub opens URLs in a browser tab and emits none
+    // of these signals, so the connections are desktop-only.
+    connect(webEngineView, &QWebEngineView::loadFinished, this, &WebBrowserView::adjustLocation);
+    connect(webEngineView, &QWebEngineView::urlChanged, this, &WebBrowserView::updateUrlOfLineEdit);
+    connect(webEngineView->page(), &QWebEnginePage::fullScreenRequested,
+            this, &WebBrowserView::handleFullScreenRequested);
+#endif
+
+    toolBar = new QToolBar(this);
+    toolBar->addAction(webEngineView->pageAction(QWebEnginePage::Back));
+    toolBar->addAction(webEngineView->pageAction(QWebEnginePage::Forward));
+    toolBar->addAction(webEngineView->pageAction(QWebEnginePage::Reload));
+    toolBar->addAction(webEngineView->pageAction(QWebEnginePage::Stop));
+    toolBar->addSeparator();
+    QAction *actionFullScreen = toolBar->addAction(QIcon(QStringLiteral(":/image/icon/fullscreen")),
+                                                   tr("Toggle Fullscreen"));
+    // Toggle the web view's fullscreen via JS, which round-trips through the
+    // same fullScreenRequested path as YouTube's own button.
+    connect(actionFullScreen, &QAction::triggered, this, [this]() {
+        webEngineView->page()->runJavaScript(QStringLiteral(
+            "if (document.fullscreenElement) { document.exitFullscreen(); }"
+            "else {"
+            "  var v = document.getElementsByTagName('video');"
+            "  if (v.length > 0) { v[0].requestFullscreen(); }"
+            "  else { document.documentElement.requestFullscreen(); }"
+            "}"));
+    });
+    toolBar->addWidget(locationEdit);
+
+    gLayout->addWidget(toolBar, 0, 0, 1, 1);
+    gLayout->addWidget(webEngineView, 1, 0, 1, 1);
+
+    // The toolbar hides itself after a few idle seconds and reappears on any
+    // mouse/keyboard activity, so it does not cover the video during playback.
+    timerHideToolbar = new QTimer(this);
+    connect(timerHideToolbar, &QTimer::timeout, this, &WebBrowserView::hideToolbar);
+    hideToolbar();
+
+    locationEdit->installEventFilter(this);
+    toolBar->installEventFilter(this);
+    webEngineView->installEventFilter(this);
+}
+
+WebBrowserView::~WebBrowserView() = default;
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::loadHomePageIfNeeded()
+{
+    if (homePageLoaded)
+        return;
+
+    QSettings settings;
+    settings.beginGroup(QStringLiteral("webBrowserWorkout"));
+    // One-time reset: clear any previously saved home page and force YouTube.
+    // The old Netflix default needs Widevine DRM, which this embedded view
+    // cannot bundle, so it never played. Guarded so the user can set their own
+    // URL afterwards.
+    if (!settings.value(QStringLiteral("youtubeResetDone"), false).toBool()) {
+        settings.setValue(QStringLiteral("defaultUrl"), QString::fromLatin1(kDefaultHomePage));
+        settings.setValue(QStringLiteral("youtubeResetDone"), true);
+    }
+    const QString urlSaved = settings.value(QStringLiteral("defaultUrl"),
+                                            QString::fromLatin1(kDefaultHomePage)).toString();
+    settings.endGroup();
+
+    webEngineView->load(QUrl::fromUserInput(urlSaved));
+    homePageLoaded = true;
+}
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::handleFullScreenRequested(QWebEngineFullScreenRequest request)
+{
+    // Accept the request but keep the web view docked in our layout: the page's
+    // fullscreen element then fills the existing web-view widget (the video area
+    // within the workout dialog) rather than covering the whole screen.
+    request.accept();
+
+    isFullScreen = request.toggleOn();
+    // Give the video the full widget by hiding our chrome while fullscreen.
+    if (isFullScreen) {
+        hideToolbar();
+    } else {
+        toolBar->setVisible(true);
+        timerHideToolbar->start(kToolbarHideMs);
+    }
+}
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::keyPressEvent(QKeyEvent *event)
+{
+    // Esc leaves page fullscreen (mirrors a normal browser).
+    if (event->key() == Qt::Key_Escape && isFullScreen) {
+        webEngineView->page()->runJavaScript(QStringLiteral(
+            "if (document.fullscreenElement) document.exitFullscreen();"));
+        event->accept();
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::hideToolbar()
+{
+    timerHideToolbar->stop();
+    toolBar->setVisible(false);
+}
+
+//------------------------------------------------------------------------------------------------
+bool WebBrowserView::eventFilter(QObject *watched, QEvent *event)
+{
+    Q_UNUSED(watched);
+
+    switch (event->type()) {
+    case QEvent::MouseMove:
+    case QEvent::Enter:
+    case QEvent::HoverEnter:
+    case QEvent::HoverMove:
+    case QEvent::KeyPress:
+        timerHideToolbar->start(kToolbarHideMs);
+        toolBar->setVisible(true);
+        break;
+    default:
+        break;
+    }
+
+    if (event->type() == QEvent::KeyPress) {
+        // Enter/Return in the address bar must navigate, not bubble up to the
+        // workout dialog (which would otherwise start/pause the workout).
+        auto *key = static_cast<QKeyEvent*>(event);
+        if (key->key() == Qt::Key_Enter || key->key() == Qt::Key_Return) {
+            changeLocation();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::changeLocation()
+{
+    webEngineView->load(QUrl::fromUserInput(locationEdit->text()));
+}
+
+//----------------------------------------------------------------------------------------
+void WebBrowserView::adjustLocation()
+{
+    locationEdit->setText(webEngineView->url().toString());
+}
+
+//------------------------------------------------------------------------------
+void WebBrowserView::updateUrlOfLineEdit(const QUrl &url)
+{
+    locationEdit->setText(url.toString());
+}
+
+//-----------------------------------------------------------------
+// Finds the first <video> element on the page (or inside a same-origin iframe)
+// and plays/pauses it, so the workout's start/pause controls also drive the
+// embedded video.
+namespace {
+QString videoControlJs(const char *method)
+{
+    return QStringLiteral(
+        "(function() {"
+        "  var v = document.getElementsByTagName('video');"
+        "  if (v.length > 0) { v[0].%1(); return; }"
+        "  var frames = document.getElementsByTagName('iframe');"
+        "  for (var i = 0; i < frames.length; ++i) {"
+        "    try {"
+        "      var fv = frames[i].contentDocument.getElementsByTagName('video');"
+        "      if (fv.length > 0) { fv[0].%1(); return; }"
+        "    } catch (e) { /* cross-origin frame, skip */ }"
+        "  }"
+        "})();").arg(QString::fromLatin1(method));
+}
+}
+
+void WebBrowserView::playVideo()
+{
+    webEngineView->page()->runJavaScript(videoControlJs("play"));
+}
+
+void WebBrowserView::pauseVideo()
+{
+    webEngineView->page()->runJavaScript(videoControlJs("pause"));
+}

--- a/src/ui/components/webbrowserview.h
+++ b/src/ui/components/webbrowserview.h
@@ -1,0 +1,64 @@
+#ifndef WEBBROWSERVIEW_H
+#define WEBBROWSERVIEW_H
+
+#include <QWidget>
+#include <QWebEngineFullScreenRequest>  // by-value slot param needs the complete type for moc
+
+class QWebEngineView;
+class QLineEdit;
+class QToolBar;
+class QTimer;
+class QGridLayout;
+
+/// In-frame web browser shown in the Workout dialog as an alternative to the
+/// VLC video player (Preferences -> Video Player -> "WebView").  Wraps a
+/// QWebEngineView with a minimal auto-hiding toolbar (navigation + address bar)
+/// so the user can watch YouTube and other DRM-free sites during a workout.
+///
+/// Note: DRM-protected services (Netflix, Disney+, etc.) require the proprietary
+/// Widevine module, which cannot be bundled in this open-source build, so they
+/// will not play.  YouTube and other HTML5 sources work.
+class WebBrowserView : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit WebBrowserView(QWidget *parent = nullptr);
+    ~WebBrowserView() override;
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+    /// Loads the user's configured home page (QSettings "webBrowserWorkout").
+    /// No-op after the first successful load so switching display modes during
+    /// a workout does not reset the page the user navigated to.
+    void loadHomePageIfNeeded();
+
+public slots:
+    void playVideo();
+    void pauseVideo();
+
+private slots:
+    void changeLocation();
+    void adjustLocation();
+    void updateUrlOfLineEdit(const QUrl &url);
+    void hideToolbar();
+
+    /// Honors fullscreen requests coming from the page itself (e.g. clicking
+    /// YouTube's fullscreen button). Keeps the view docked so the page's
+    /// fullscreen element fills the web-view widget rather than the whole screen.
+    void handleFullScreenRequested(QWebEngineFullScreenRequest request);
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+
+private:
+    QWebEngineView *webEngineView = nullptr;
+    QLineEdit      *locationEdit  = nullptr;
+    QToolBar       *toolBar       = nullptr;
+    QGridLayout    *gLayout       = nullptr;
+    QTimer         *timerHideToolbar = nullptr;
+
+    bool    homePageLoaded = false;
+    bool    isFullScreen   = false;
+};
+
+#endif // WEBBROWSERVIEW_H

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -482,7 +482,15 @@ void DialogConfig::initUi() {
 
     QSettings settings;
     settings.beginGroup("webBrowserWorkout");
-    QString urlSaved = settings.value("defaultUrl", "http://netflix.com" ).toString();
+    // One-time reset: clear any previously saved home page and force YouTube.
+    // DRM services (e.g. the old Netflix default) need Widevine, which the
+    // embedded QWebEngineView cannot bundle, so they never played. Guarded by a
+    // flag so the user can still set their own URL afterwards.
+    if (!settings.value("youtubeResetDone", false).toBool()) {
+        settings.setValue("defaultUrl", "https://www.youtube.com");
+        settings.setValue("youtubeResetDone", true);
+    }
+    QString urlSaved = settings.value("defaultUrl", "https://www.youtube.com" ).toString();
     settings.endGroup();
     ui->lineEdit_homePage->setText(urlSaved);
 

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -947,6 +947,11 @@ void DialogConfig::saveSettings() {
     settings.setValue("defaultUrl", ui->lineEdit_homePage->text());
     settings.endGroup();
 
+    // Persist display & sound prefs locally (the server putAccount endpoint is
+    // defunct), so the user's choices — including the video player — survive a
+    // restart.
+    account->saveDisplayPrefs();
+
     // Save the new preference tabs
     saveLoggingTab();
     saveLanguageTab();

--- a/src/ui/dialoglogin.cpp
+++ b/src/ui/dialoglogin.cpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QUuid>
 
 #include "logger.h"
@@ -200,6 +201,17 @@ DialogLogin::DialogLogin(QWidget *parent, bool testMode)
     ui->comboBox_language->setCurrentIndex(settings->language_index);
     ui->label_version->setText(Environnement::getVersion());
 
+    // Restore the last "work offline" choice so users who always run offline
+    // do not have to re-tick the box every launch.
+#ifndef Q_OS_WASM
+    {
+        QSettings s;
+        const bool rememberOffline = s.value(QStringLiteral("login/workOffline"), false).toBool();
+        ui->checkBox_workOffline->setChecked(rememberOffline);
+        ui->pushButton_startOffline->setVisible(rememberOffline);
+    }
+#endif
+
     // Create the embedded OAuth widget and insert it into the placeholder page.
     m_oauthWidget = new IntervalsIcuOAuthWidget(this);
     ui->widget_oauthPage->layout()->addWidget(m_oauthWidget);
@@ -266,8 +278,12 @@ DialogLogin::DialogLogin(QWidget *parent, bool testMode)
 
     // Check for app updates in the background; never block the login UI.
     // WASM users cannot download a desktop binary, so skip the version check.
+    // Source/dev builds report version "0.0.0" (APP_VERSION is only populated
+    // from git describe in CI release builds), which would always look outdated
+    // and pop the update dialog on every launch — skip the check for them.
 #ifndef Q_OS_WASM
-    replyVersion = VersionDAO::getVersion();
+    const bool isDevBuild = Environnement::getVersion().remove(QRegularExpression("^[vV]")) == "0.0.0";
+    replyVersion = isDevBuild ? nullptr : VersionDAO::getVersion();
     if (replyVersion) {
         connect(replyVersion, &QNetworkReply::finished,
                 this, &DialogLogin::slotFinishedGetVersion);
@@ -360,11 +376,11 @@ void DialogLogin::slotFinishedGetVersion() {
 
 void DialogLogin::on_checkBox_workOffline_clicked(bool checked)
 {
-    if (checked) {
-        ui->pushButton_startOffline->setVisible(true);
-    } else {
-        ui->pushButton_startOffline->setVisible(false);
-    }
+    ui->pushButton_startOffline->setVisible(checked);
+
+    // Remember the choice so it is pre-selected on the next launch.
+    QSettings s;
+    s.setValue(QStringLiteral("login/workOffline"), checked);
 }
 
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1467,40 +1467,6 @@ void MainWindow::on_actionExit_triggered()
 
 
 //----------------------------------------------------------------------------------------
-void MainWindow::on_actionLog_off_Exit_triggered()
-{
-
-    QMessageBox msgBox(this);
-    msgBox.setIcon(QMessageBox::Question);
-
-    msgBox.setText(tr("This will log you out of MaximumTrainer. You will need to re-enter your password to use MaximumTrainer again."));
-    msgBox.setInformativeText(tr("Do you wish to continue?"));
-
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
-    msgBox.setDefaultButton(QMessageBox::Yes);
-    msgBox.setButtonText(QMessageBox::Yes, tr("Logout"));
-    int reply = msgBox.exec();
-    if (reply == QMessageBox::Yes) {
-        qDebug() << "Yes was clicked";
-        Settings *settings = qApp->property("User_Settings").value<Settings*>();
-        settings->rememberMyPassword = false;
-        settings->lastLoggedKey = "";
-        settings->saveGeneralSettings();
-        this->close();
-
-    } else { //Cancel
-        qDebug() << "Cancel was clicked";
-        return;
-    }
-
-
-    /////////////////////
-
-
-}
-
-
-
 //----------------------------------------------------------------------------------------
 void MainWindow::on_actionAbout_MT_triggered()
 {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -20,7 +20,6 @@
 #include "userdao.h"
 #include "savingwindow.h"
 #include "soundplayer.h"
-#include "dialoginfowebview.h"
 #include "dialogmainwindowconfig.h"
 #include "savingwindow.h"
 #include "workoutdialog.h"
@@ -1536,10 +1535,9 @@ void MainWindow::on_actionAbout_Qt_triggered()
 //-----------------------------------------------
 void MainWindow::on_actionRequest_Help_triggered()
 {
-    DialogInfoWebView infoAntStick;
-    infoAntStick.setUrlWebView(Environnement::getUrlSupport());
-    qDebug() << "URL IS : " << Environnement::getUrlSupport();
-    infoAntStick.exec();
+    // Open the online user guide in the user's default browser.
+    QDesktopServices::openUrl(QUrl(QStringLiteral(
+        "https://maximumtrainer.github.io/MaximumTrainer_Redux/user-guide.html")));
 }
 //-----------------------------------------------
 void MainWindow::on_actionKeyboard_Shortcuts_triggered()

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1510,11 +1510,17 @@ void MainWindow::on_actionAbout_MT_triggered()
     QString copyright = tr("Copyright 2013-2019 maximus321")
                       + "<br/>"
                       + tr("Copyright 2019-present MaximumTrainer maintainers");
+    const QString repoUrl = QStringLiteral("https://github.com/MaximumTrainer/MaximumTrainer_Redux");
+    QString openSource = tr("%1 is free and open source. Contributions are welcome — "
+                            "fork it, open an issue, or send a pull request on "
+                            "<a href=\"%2\">GitHub</a>.")
+                            .arg(appName, repoUrl);
     this->setStyleSheet("QMessageBox { messagebox-text-interaction-flags: 5; }");
     QMessageBox::about(this,
                        tr("About ") + appName,
                        "<b>"+ nameWithVersion + "</b> - " + tr("Build on ")  + Environnement::getDateBuilded() + "<br/>" +
                        copyright + "<hr/>" +
+                       openSource + "<hr/>" +
                        tr("Normalized Power®(NP), Training Stress Score®(TSS) and Intensity Factor®(IF) are registered trademarks of Peaksware LLC."));
 
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -137,7 +137,6 @@ private slots:
 
     void on_actionOpen_Ride_triggered();
     void on_actionExit_triggered();
-    void on_actionLog_off_Exit_triggered();
 
 
     void on_actionSingle_Workout_triggered();

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -524,7 +524,6 @@
     </property>
     <addaction name="actionPreferences"/>
     <addaction name="separator"/>
-    <addaction name="actionLog_off_Exit"/>
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuTEst">
@@ -612,11 +611,6 @@
    </property>
    <property name="text">
     <string>Start Free Ride</string>
-   </property>
-  </action>
-  <action name="actionLog_off_Exit">
-   <property name="text">
-    <string>Change User</string>
    </property>
   </action>
   <action name="actionExit">

--- a/src/ui/wasm_stubs/QWebEngineFullScreenRequest
+++ b/src/ui/wasm_stubs/QWebEngineFullScreenRequest
@@ -1,0 +1,2 @@
+#pragma once
+#include "webengine_stubs_impl.h"

--- a/src/ui/wasm_stubs/webengine_stubs_impl.h
+++ b/src/ui/wasm_stubs/webengine_stubs_impl.h
@@ -16,6 +16,7 @@
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QAction>
 #include <QDesktopServices>
 #include <functional>
 
@@ -27,9 +28,17 @@ class QWebEngineScriptCollection;
 // ─────────────────────────────── QWebEngineSettings ──────────────────────────
 class QWebEngineSettings {
 public:
-    enum WebAttribute { PluginsEnabled = 0, JavascriptEnabled = 1 };
+    enum WebAttribute { PluginsEnabled = 0, JavascriptEnabled = 1, FullScreenSupportEnabled = 2 };
     void setAttribute(WebAttribute, bool) {}
     static QWebEngineSettings *defaultSettings() { static QWebEngineSettings s; return &s; }
+};
+
+// ─────────────────────── QWebEngineFullScreenRequest ─────────────────────────
+class QWebEngineFullScreenRequest {
+public:
+    void accept() {}
+    void reject() {}
+    bool toggleOn() const { return false; }
 };
 
 // ─────────────────────────────── QWebEngineScript ────────────────────────────
@@ -66,6 +75,7 @@ public:
 class QWebEnginePage : public QObject {
 public:
     enum NavigationType { NavigationTypeLinkClicked = 0 };
+    enum WebAction { Back = 0, Forward = 1, Reload = 2, Stop = 3 };
     explicit QWebEnginePage(QObject *parent = nullptr)
         : QObject(parent), m_profile(new QWebEngineProfile(this)) {}
     explicit QWebEnginePage(QWebEngineProfile *profile, QObject *parent = nullptr)
@@ -78,12 +88,14 @@ public:
     QUrl url() const { return {}; }
     QWebEngineProfile *profile() const { return m_profile; }
     QWebEngineScriptCollection &scripts() { return m_scripts; }
+    QAction *action(WebAction) { return &m_action; }
     void setWebChannel(QObject *) {}
     void toPlainText(std::function<void(const QString &)>) {}
 
 private:
     QWebEngineProfile *m_profile;
     QWebEngineScriptCollection m_scripts;
+    QAction m_action;
 };
 
 // ─────────────────────────────── QWebEngineView ──────────────────────────────
@@ -122,6 +134,7 @@ public:
     QUrl url() const { return m_currentUrl; }
     void setPage(QWebEnginePage *page) { if (page) m_page = page; }
     QWebEnginePage *page() const { return m_page; }
+    QAction *pageAction(QWebEnginePage::WebAction action) { return m_page->action(action); }
     void back() {}
     void forward() {}
     void reload() {}

--- a/src/ui/wasm_stubs/webengine_stubs_impl.h
+++ b/src/ui/wasm_stubs/webengine_stubs_impl.h
@@ -134,6 +134,7 @@ public:
     QUrl url() const { return m_currentUrl; }
     void setPage(QWebEnginePage *page) { if (page) m_page = page; }
     QWebEnginePage *page() const { return m_page; }
+    QWebEngineSettings *settings() { return QWebEngineSettings::defaultSettings(); }
     QAction *pageAction(QWebEnginePage::WebAction action) { return m_page->action(action); }
     void back() {}
     void forward() {}

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -4253,6 +4253,11 @@ void WorkoutDialog::showFullScreenWin() {
     qDebug() << "showFullScreenWin";
     this->setSizeGripEnabled(false);
     ui->widget_topMenu->setMinExpandExitVisible(true);
+    // Re-apply the expand-button icon: when the dialog opens directly in
+    // fullscreen the button's image stylesheet was set in the constructor while
+    // the button was hidden and is not rendered (shows as a white box) until it
+    // is reapplied. showNormalWin() already does this for the windowed path.
+    ui->widget_topMenu->updateExpandIcon();
 
 #ifdef Q_OS_MAC
     this->showMaximized();

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -34,6 +34,7 @@
 #include "clock.h"
 #include "workoututil.h"
 #include "dialogconfig.h"
+#include "webbrowserview.h"
 #include "dialogcalibrate.h"
 #include "dialogcalibratepm.h"
 #include "dialogkeyboardshortcuts.h"
@@ -1712,7 +1713,7 @@ void WorkoutDialog::start_or_pause_workout() {
         setWidgetsStopped(false);
         startWorkout();
         emit playPlayer();
-        // ui->widget_webPlayer->playVideo(); // WebBrowserV2 removed
+        if (webPlayer) webPlayer->playVideo();
 
     }
     // If workout paused, we resume it
@@ -1735,7 +1736,7 @@ void WorkoutDialog::start_or_pause_workout() {
         setWidgetsStopped(false);
         emit resumeClock();
         emit playPlayer();
-        // ui->widget_webPlayer->playVideo(); // WebBrowserV2 removed
+        if (webPlayer) webPlayer->playVideo();
 
     }
     // If not paused, we pause it
@@ -1750,7 +1751,7 @@ void WorkoutDialog::start_or_pause_workout() {
         setMessagePlot();
         emit pauseClock();
         emit pausePlayer();
-        // ui->widget_webPlayer->pauseVideo(); // WebBrowserV2 removed
+        if (webPlayer) webPlayer->pauseVideo();
     }
 }
 
@@ -2638,10 +2639,23 @@ void WorkoutDialog::setTimerFontSize(int value) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
+// Lazily create the QWebEngine-backed web player on first use, so the heavy
+// Chromium process is not started when the user stays on the default VLC player.
+WebBrowserView *WorkoutDialog::ensureWebPlayer() {
+    if (!webPlayer) {
+        webPlayer = new WebBrowserView(ui->widget_webPlayer);
+        ui->widget_webPlayer->layout()->addWidget(webPlayer);
+    }
+    return webPlayer;
+}
+
 void WorkoutDialog::showVideoPlayer(int choice) {
 
     /// Standard
     if (choice == 0) {
+        // Hiding the QWebEngineView only stops rendering, not playback, so
+        // explicitly pause it or its audio keeps playing behind the VLC player.
+        if (webPlayer) webPlayer->pauseVideo();
         ui->widget_webPlayer->setVisible(false);
         ui->widgetVideo->setVisible(true);
     }
@@ -2649,6 +2663,7 @@ void WorkoutDialog::showVideoPlayer(int choice) {
     else {
         ui->widgetVideo->setVisible(false);
         ui->widget_webPlayer->setVisible(true);
+        ensureWebPlayer()->loadHomePageIfNeeded();
     }
 }
 

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -34,6 +34,7 @@
 
 
 class DialogConfig;     // forward declaration
+class WebBrowserView;   // forward declaration (lazily created web video player)
 
 namespace Ui {
 class WorkoutDialog;
@@ -296,6 +297,14 @@ private:
 #ifdef GC_HAVE_VLCQT
     MyVlcPlayer *radioPlayer;
 #endif
+
+    // Embedded web video player (QWebEngine-based). Created lazily the first
+    // time the user selects the WebView option, so the heavy Chromium process
+    // is not spun up when the default VLC player is in use.
+    WebBrowserView *webPlayer = nullptr;
+    /// Returns the web player, creating it (inside widget_webPlayer) on first use.
+    WebBrowserView *ensureWebPlayer();
+
     DialogConfig *dconfig;
     QList<Radio> lstRadio;
 

--- a/src/ui/workoutdialog.ui
+++ b/src/ui/workoutdialog.ui
@@ -152,6 +152,20 @@ QwtScaleWidget {
            <height>1</height>
           </size>
          </property>
+         <layout class="QVBoxLayout" name="layout_webPlayer">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+         </layout>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
## Summary

A batch of Linux/desktop fixes and the restoration of the in-workout web video player. Each change is a self-contained commit.

## Changes

### 🐧 Wayland video embedding (`main.cpp`)
Under a native Wayland session, libvlc (X11/XCB-only video output in VLC 3.0.x) couldn't draw into the Qt widget's Wayland surface and spawned a separate popup window instead of embedding video in the workout frame. The app now detects Wayland at startup and forces the `xcb` platform (via XWayland) unless the user has pinned `QT_QPA_PLATFORM`.

### 🌐 Restored embedded web video player
Replaces the dead `WebBrowserV2` (removed in an earlier refactor) with a new `WebBrowserView` wrapping `QWebEngineView`:
- Auto-hiding toolbar (navigation + address bar)
- In-widget fullscreen (YouTube's button and Esc both work)
- Play/pause hooks tied to workout start/stop
- Created **lazily** on first selection, so the heavy Chromium process is not started for VLC users
- Home page forced to YouTube (one-time reset): DRM services like Netflix require Widevine, which an open-source build cannot bundle, so they never played
- WASM stubs extended so the browser build keeps compiling

### 💾 Local persistence of display & sound preferences (`account.*`)
Display/sound settings (incl. the VLC-vs-WebView choice) were only stored server-side via the now-defunct `putAccount` REST endpoint, so they reset on every restart — most visibly the video player reverting to VLC. They now round-trip through local `QSettings`.

### ✨ Login-screen quality of life (`dialoglogin.cpp`)
- Skip the update-available popup on dev/source builds (which report version `0.0.0` and always looked outdated)
- Remember the "work offline" checkbox state across launches

### 🔧 Expand-button icon fix (`workoutdialog.cpp`)
When the workout dialog opened directly in fullscreen, the expand button rendered as a white box (its icon stylesheet was applied while the button was hidden and never rendered). Now reapplied in `showFullScreenWin()`, matching the windowed path.

### 📖 Help menu → online user guide (`mainwindow.cpp`)
The Help action opened an in-app webview pointed at the defunct maximumtrainer.com support page. It now opens the GitHub Pages user guide (`/user-guide.html`) in the user's default browser.

### ℹ️ About dialog
Added a clickable GitHub / open-source contribution link.

### 🧹 Removed unused 'Change User' menu item (`mainwindow.*`)
The 'Change User' action cleared the saved password and closed the app to force a re-login. Removed the menu item, action, and slot handler.

## Notes
- Docs updated: README notes for the Wayland/xcb behavior and the YouTube-only WebView caveat.
- DRM (Netflix etc.) in the web player is intentionally unsupported — Widevine can't be bundled in an open-source build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
