### PR TITLE
fix: raise and focus MainWindow after login dialog closes

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -164,6 +164,12 @@ int main(int argc, char *argv[]) {
         splash.finish(mainWin);
 #endif
         mainWin->show();
+        // Bring the window to the front and give it focus. After the non-modal
+        // login dialog is dismissed some window managers (notably on Linux) leave
+        // the freshly-shown MainWindow stacked behind other windows; raise() +
+        // activateWindow() forces it on top and focused.
+        mainWin->raise();
+        mainWin->activateWindow();
         return mainWin;
     };
 


### PR DESCRIPTION
After the non-modal login dialog accepts (including the **Start Offline** path), the main window was only shown via `show()`. On some window managers — notably Linux — that left it stacked *behind* other windows and unfocused.

This adds `raise()` + `activateWindow()` right after `show()` in `launchMainWindow()` so the window comes to the front and takes focus. Applies to both the online and offline login paths since both funnel through the same `accepted` handler.

