### PR TITLE
fix(ci): install libxcb-cursor0 for AppImage Qt deployment

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -60,6 +60,7 @@ jobs:
           libusb-1.0-0-dev \
           libssl-dev \
           libgl1-mesa-dev \
+          libxcb-cursor0 \
           libfuse2 \
           file
 


### PR DESCRIPTION
## Problem

The Linux AppImage release pipeline fails on master ([run 26973719355](https://github.com/MaximumTrainer/MaximumTrainer_Redux/actions/runs/26973719355/job/79600225900)):

```
Deploying shared library .../plugins/platforms/libqxcb.so
Deploying dependencies for ELF file .../libqxcb.so
ERROR: Could not find dependency: libxcb-cursor.so.0
ERROR: Failed to run plugin: qt (exit code: 1)
```

## Root cause

Qt 6.5+ ships `libqxcb.so` (the XCB platform plugin) with a hard dependency on `libxcb-cursor.so.0`. When `linuxdeploy-plugin-qt` scans `libqxcb.so` to bundle its dependencies, the library isn't present on the runner, so it aborts.

The `libxcb-cursor0` package is **already installed** in every test job in `build-linux.yml`, but the **"Install system dependencies"** step of the AppImage release job (`release-linux.yml`) was missing it.

## Fix

Add `libxcb-cursor0` to the release job's apt install list — a one-line, packaging-only change. No application code touched.

