### PR TITLE
fix(ci): re-bundle NSS softokn modules in Linux AppImage

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -107,6 +107,22 @@ jobs:
         cp build/release/MaximumTrainer AppDir/usr/bin/
         # Bundle the QWT shared library so the qt plugin / patchelf can resolve it
         cp -P "$QWT_DIR"/lib/libqwt.so* AppDir/usr/lib/
+        # QtWebEngine dlopen()s these NSS modules at runtime, so linuxdeploy's
+        # static dependency scan never sees them and leaves them out. Without
+        # them, NSS loads the host's (newer) libsoftokn3 against the bundled
+        # (older) libnssutil3, causing a fatal "NSSUTIL_3.x not found" crash on
+        # the first HTTPS request (e.g. the Intervals.icu login). Pre-copy the
+        # NSS module family into AppDir so linuxdeploy bundles a self-consistent
+        # set alongside the libnss3/libnssutil3 it already pulls in.
+        for nss_lib in libsoftokn3.so libfreebl3.so libfreeblpriv3.so \
+                       libnssckbi.so libnssdbm3.so; do
+          nss_src=$(find /usr/lib/x86_64-linux-gnu -name "$nss_lib" | head -1)
+          if [ -n "$nss_src" ]; then
+            cp -vL "$nss_src" AppDir/usr/lib/
+          else
+            echo "WARN: NSS module $nss_lib not found on build host"
+          fi
+        done
         # Desktop entry required by linuxdeploy
         cat > AppDir/usr/share/applications/maximumtrainer.desktop << 'EOF'
         [Desktop Entry]
@@ -146,6 +162,18 @@ jobs:
           echo "PASS: libqwt found in AppDir"
         else
           echo "WARN: libqwt not found in AppDir"
+        fi
+
+    - name: Verify NSS runtime modules bundled
+      # libsoftokn3 is the critical one — its absence (or a version skew against
+      # the bundled libnssutil3) crashes QtWebEngine on the first HTTPS request.
+      run: |
+        echo "=== NSS module check ==="
+        if find AppDir -name "libsoftokn3.so" -print -quit 2>/dev/null | grep -q .; then
+          echo "PASS: libsoftokn3 bundled in AppDir"
+        else
+          echo "FAIL: libsoftokn3 missing from AppDir — QtWebEngine will crash on HTTPS"
+          exit 1
         fi
 
     - name: Upload artifact


### PR DESCRIPTION
## Problem

The v0.0.114 Linux AppImage crashes on launch on Ubuntu hosts with a newer NSS, the moment it makes its first HTTPS request (the Intervals.icu login):

```
libnssutil3.so: version `NSSUTIL_3.108' not found (required by /usr/lib/x86_64-linux-gnu/libsoftokn3.so)
[FATAL:nss_util.cc(126)] nss_error=-5925
Trace/breakpoint trap (core dumped)
```

## Root cause

Extracting the released AppImage shows it bundles `libnss3`, `libnssutil3`, `libnspr4`, `libplc4`, `libplds4`, `libsmime3` — but **not** `libsoftokn3` (nor `libfreebl3`, `libnssckbi`, `libnssdbm3`).

QtWebEngine `dlopen()`s `libsoftokn3` at runtime, so linuxdeploy's static dependency scan never sees it. With it missing from the bundle, NSS falls back to the **host's** newer `libsoftokn3`, which is loaded against the **bundle's older** `libnssutil3` → `NSSUTIL_3.x not found` → fatal crash.

This step existed (added in #212) but was dropped when #216 rewrote `release-linux.yml`. #217/#219 didn't restore it, so v0.0.114 shipped broken.

## Fix

- Pre-copy the NSS module family (`libsoftokn3`, `libfreebl3`, `libfreeblpriv3`, `libnssckbi`, `libnssdbm3`) into `AppDir/usr/lib/` before `linuxdeploy` runs, so the bundle is self-consistent.
- Restore the verification step that fails the build if `libsoftokn3` is absent.

Diff is additive only — no other behaviour changes.

## Note

This fixes the next release; the already-published v0.0.114 AppImage needs a re-release (e.g. v0.0.115) to pick it up.

