### PR TITLE
chore: bump QWT 6.2.0 → 6.3.0 across all platforms and docs

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -58,23 +58,23 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.QWT_DIR }}
-        key: qwt-6.2.0-qt-${{ env.QT_VERSION }}-linux
+        key: qwt-6.3.0-qt-${{ env.QT_VERSION }}-linux
 
     - name: Build and install QWT
-      # No QWT apt package exists for Qt6, so build 6.2.0 from source against the
+      # No QWT apt package exists for Qt6, so build 6.3.0 from source against the
       # installed Qt6 and stage it under QWT_DIR. PowerVelo.pro is pointed at it
       # via QWT_INSTALL=... .
       if: steps.qwt-cache.outputs.cache-hit != 'true'
       run: |
         cd /tmp
-        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
+        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
         tar xf qwt.tar.bz2
-        cd qwt-6.2.0
+        cd qwt-6.3.0
         qmake qwt.pro
         make -j$(nproc)
         make install INSTALL_ROOT=/tmp/qwt6-stage
         mkdir -p "$QWT_DIR"
-        mv /tmp/qwt6-stage/usr/local/qwt-6.2.0/* "$QWT_DIR"/
+        mv /tmp/qwt6-stage/usr/local/qwt-6.3.0/* "$QWT_DIR"/
 
     - name: Determine build version
       run: |

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -47,14 +47,14 @@ jobs:
       uses: actions/cache@v4
       with:
         # Cache only the directories needed to compile and link against QWT.
-        # Excluding qwt-6.2.0/doc avoids a gtar extraction failure on macOS
+        # Excluding qwt-6.3.0/doc avoids a gtar extraction failure on macOS
         # runners where that subtree contains paths that confuse GNU tar.
         path: |
-          /usr/local/qwt-6.2.0/lib
-          /usr/local/qwt-6.2.0/include
-          /usr/local/qwt-6.2.0/features
-          /usr/local/qwt-6.2.0/mkspecs
-        key: qwt-6.2.0-qt-6.7.3-macos-nodoc
+          /usr/local/qwt-6.3.0/lib
+          /usr/local/qwt-6.3.0/include
+          /usr/local/qwt-6.3.0/features
+          /usr/local/qwt-6.3.0/mkspecs
+        key: qwt-6.3.0-qt-6.7.3-macos-nodoc
 
     - name: Build and install QWT
       if: steps.qwt-cache.outputs.cache-hit != 'true'
@@ -62,22 +62,22 @@ jobs:
         # Remove any pre-installed Homebrew qwt that could shadow our headers
         brew uninstall qwt --force --ignore-dependencies 2>/dev/null || true
         cd /tmp
-        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
+        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
         tar -xjf qwt.tar.bz2
-        cd qwt-6.2.0
+        cd qwt-6.3.0
         sed -i.bak 's/QwtFramework//' qwtconfig.pri
         qmake qwt.pro
         make -j$(sysctl -n hw.logicalcpu)
         sudo make install
 
     - name: Fix QWT install_name for macdeployqt compatibility
-      # QWT 6.2.0 default LC_ID_DYLIB is /usr/lib/libqwt.6.dylib but the actual
-      # file is at /usr/local/qwt-6.2.0/lib/.  macdeployqt resolves dependencies
+      # QWT 6.3.0 default LC_ID_DYLIB is /usr/lib/libqwt.6.dylib but the actual
+      # file is at /usr/local/qwt-6.3.0/lib/.  macdeployqt resolves dependencies
       # by following LC_ID_DYLIB, so it errors "no file at /usr/lib/..." if the
       # install_name is wrong.  Fix it before the app is linked so the app binary's
       # LC_LOAD_DYLIB also records the correct path.
       run: |
-        QWT_LIB=/usr/local/qwt-6.2.0/lib/libqwt.6.dylib
+        QWT_LIB=/usr/local/qwt-6.3.0/lib/libqwt.6.dylib
         sudo install_name_tool -id "$QWT_LIB" "$QWT_LIB"
         echo "QWT install_name: $(otool -D $QWT_LIB | tail -1)"
 
@@ -97,7 +97,7 @@ jobs:
     - name: Create Makefile
       run: |
         qmake PowerVelo.pro \
-          "QWT_INSTALL=/usr/local/qwt-6.2.0"
+          "QWT_INSTALL=/usr/local/qwt-6.3.0"
       env:
         TP_CLIENT_SECRET:              ${{ secrets.TP_CLIENT_SECRET }}
         INTERVALS_OAUTH_CLIENT_ID:     ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}
@@ -108,7 +108,7 @@ jobs:
         echo "=== All qwt_plot.h on system ==="
         find /opt/homebrew /usr/local -name "qwt_plot.h" 2>/dev/null || true
         echo "=== Installed qwtconfig.pri ==="
-        cat /usr/local/qwt-6.2.0/features/qwtconfig.pri 2>/dev/null || true
+        cat /usr/local/qwt-6.3.0/features/qwtconfig.pri 2>/dev/null || true
 
     - name: Run MakeFile
       run: make -j$(sysctl -n hw.logicalcpu)
@@ -147,14 +147,14 @@ jobs:
       run: |
         mkdir -p build/tests
         cd tests/integration
-        qmake login_screen_tests.pro "QWT_INSTALL=/usr/local/qwt-6.2.0"
+        qmake login_screen_tests.pro "QWT_INSTALL=/usr/local/qwt-6.3.0"
         make -j$(sysctl -n hw.logicalcpu)
 
     - name: Build workout UI test
       run: |
         mkdir -p build/tests
         cd tests/integration
-        qmake workout_ui_tests.pro "QWT_INSTALL=/usr/local/qwt-6.2.0" \
+        qmake workout_ui_tests.pro "QWT_INSTALL=/usr/local/qwt-6.3.0" \
           QMAKE_LFLAGS+="-L$(brew --prefix openssl@3)/lib" \
           QMAKE_CXXFLAGS+="-I$(brew --prefix openssl@3)/include"
         make -j$(sysctl -n hw.logicalcpu)
@@ -172,7 +172,7 @@ jobs:
       run: |
         mkdir -p build/tests
         cd tests/integration
-        qmake ui_navigation_tests.pro "QWT_INSTALL=/usr/local/qwt-6.2.0" \
+        qmake ui_navigation_tests.pro "QWT_INSTALL=/usr/local/qwt-6.3.0" \
           QMAKE_LFLAGS+="-L$(brew --prefix openssl@3)/lib" \
           QMAKE_CXXFLAGS+="-I$(brew --prefix openssl@3)/include"
         make -j$(sysctl -n hw.logicalcpu)
@@ -181,14 +181,14 @@ jobs:
       run: |
         mkdir -p build/tests
         cd tests/integration
-        qmake ui_screens_tests.pro "QWT_INSTALL=/usr/local/qwt-6.2.0"
+        qmake ui_screens_tests.pro "QWT_INSTALL=/usr/local/qwt-6.3.0"
         make -j$(sysctl -n hw.logicalcpu)
 
     - name: Build workout I/O test
       run: |
         mkdir -p build/tests
         cd tests/integration
-        qmake workout_io_tests.pro "QWT_INSTALL=/usr/local/qwt-6.2.0"
+        qmake workout_io_tests.pro "QWT_INSTALL=/usr/local/qwt-6.3.0"
         make -j$(sysctl -n hw.logicalcpu)
 
     - name: Build workout creator test
@@ -205,23 +205,23 @@ jobs:
       # MaximumTrainer.app is also bundled so that testFullApplicationJourney()
       # can launch the real application without needing QWT installed on the runner.
       run: |
-        cp /usr/local/qwt-6.2.0/lib/libqwt.6.dylib build/tests/
+        cp /usr/local/qwt-6.3.0/lib/libqwt.6.dylib build/tests/
         install_name_tool \
-          -change /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+          -change /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
           @loader_path/libqwt.6.dylib \
           build/tests/login_screen_tests
         install_name_tool \
-          -change /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+          -change /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
           @loader_path/libqwt.6.dylib \
           build/tests/workout_ui_tests
         install_name_tool \
-          -change /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+          -change /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
           @loader_path/libqwt.6.dylib \
           build/tests/ui_navigation_tests
         for bin in ui_screens_tests workout_io_tests; do
           if [ -f "build/tests/$bin" ]; then
             install_name_tool \
-              -change /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+              -change /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
               @loader_path/libqwt.6.dylib \
               "build/tests/$bin"
           fi
@@ -231,10 +231,10 @@ jobs:
         # Guard: verify the app binary exists before attempting to patch it.
         test -f build/release/MaximumTrainer.app/Contents/MacOS/MaximumTrainer
         mkdir -p build/release/MaximumTrainer.app/Contents/MacOS
-        cp /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+        cp /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
            build/release/MaximumTrainer.app/Contents/MacOS/
         install_name_tool \
-          -change /usr/local/qwt-6.2.0/lib/libqwt.6.dylib \
+          -change /usr/local/qwt-6.3.0/lib/libqwt.6.dylib \
           @loader_path/libqwt.6.dylib \
           build/release/MaximumTrainer.app/Contents/MacOS/MaximumTrainer
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -93,10 +93,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.QWT_INSTALL_DIR }}
-        key: qwt-6.2.0-qt-${{ env.QT_VERSION }}-msvc2019-win64
+        key: qwt-6.3.0-qt-${{ env.QT_VERSION }}-msvc2019-win64
 
     - name: Build QWT
-      # No QWT apt/Qt6 binary package exists, so build 6.2.0 from source against
+      # No QWT apt/Qt6 binary package exists, so build 6.3.0 from source against
       # the installed Qt6 and install it to QWT_INSTALL_DIR. PowerVelo.pro is
       # pointed at this location via QWT_INSTALL=... .
       if: steps.qwt-cache.outputs.cache-hit != 'true'
@@ -104,10 +104,10 @@ jobs:
         $qwtInstallDirFwd = $env:QWT_INSTALL_DIR -replace '\\', '/'
         Set-Location ..
         # Use curl.exe -L to follow SourceForge redirects reliably
-        curl.exe -L -o "$env:TEMP\qwt.tar.bz2" "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
+        curl.exe -L -o "$env:TEMP\qwt.tar.bz2" "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
         7z x "$env:TEMP\qwt.tar.bz2" -o"$env:TEMP" -y
         7z x "$env:TEMP\qwt.tar" -o"." -y
-        Rename-Item "qwt-6.2.0" "qwt-src"
+        Rename-Item "qwt-6.3.0" "qwt-src"
         Set-Location "qwt-src"
         # Patch every QWT_INSTALL_PREFIX assignment to use the new path
         (Get-Content "qwtconfig.pri") | ForEach-Object {

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -107,6 +107,22 @@ jobs:
         cp build/release/MaximumTrainer AppDir/usr/bin/
         # Bundle the QWT shared library so the qt plugin / patchelf can resolve it
         cp -P "$QWT_DIR"/lib/libqwt.so* AppDir/usr/lib/
+        # QtWebEngine dlopen()s these NSS modules at runtime, so linuxdeploy's
+        # static dependency scan never sees them and leaves them out. Without
+        # them, NSS loads the host's (newer) libsoftokn3 against the bundled
+        # (older) libnssutil3, causing a fatal "NSSUTIL_3.x not found" crash on
+        # the first HTTPS request (e.g. the Intervals.icu login). Pre-copy the
+        # NSS module family into AppDir so linuxdeploy bundles a self-consistent
+        # set alongside the libnss3/libnssutil3 it already pulls in.
+        for nss_lib in libsoftokn3.so libfreebl3.so libfreeblpriv3.so \
+                       libnssckbi.so libnssdbm3.so; do
+          nss_src=$(find /usr/lib/x86_64-linux-gnu -name "$nss_lib" | head -1)
+          if [ -n "$nss_src" ]; then
+            cp -vL "$nss_src" AppDir/usr/lib/
+          else
+            echo "WARN: NSS module $nss_lib not found on build host"
+          fi
+        done
         # Desktop entry required by linuxdeploy
         cat > AppDir/usr/share/applications/maximumtrainer.desktop << 'EOF'
         [Desktop Entry]
@@ -146,6 +162,18 @@ jobs:
           echo "PASS: libqwt found in AppDir"
         else
           echo "WARN: libqwt not found in AppDir"
+        fi
+
+    - name: Verify NSS runtime modules bundled
+      # libsoftokn3 is the critical one — its absence (or a version skew against
+      # the bundled libnssutil3) crashes QtWebEngine on the first HTTPS request.
+      run: |
+        echo "=== NSS module check ==="
+        if find AppDir -name "libsoftokn3.so" -print -quit 2>/dev/null | grep -q .; then
+          echo "PASS: libsoftokn3 bundled in AppDir"
+        else
+          echo "FAIL: libsoftokn3 missing from AppDir — QtWebEngine will crash on HTTPS"
+          exit 1
         fi
 
     - name: Upload artifact

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -69,20 +69,20 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.QWT_DIR }}
-        key: qwt-6.2.0-qt-${{ env.QT_VERSION }}-linux
+        key: qwt-6.3.0-qt-${{ env.QT_VERSION }}-linux
 
     - name: Build and install QWT
       if: steps.qwt-cache.outputs.cache-hit != 'true'
       run: |
         cd /tmp
-        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
+        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
         tar xf qwt.tar.bz2
-        cd qwt-6.2.0
+        cd qwt-6.3.0
         qmake qwt.pro
         make -j$(nproc)
         make install INSTALL_ROOT=/tmp/qwt6-stage
         mkdir -p "$QWT_DIR"
-        mv /tmp/qwt6-stage/usr/local/qwt-6.2.0/* "$QWT_DIR"/
+        mv /tmp/qwt6-stage/usr/local/qwt-6.3.0/* "$QWT_DIR"/
 
     - name: Download linuxdeploy and the Qt plugin
       # linuxdeploy + linuxdeploy-plugin-qt support Qt6; the classic

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -54,9 +54,9 @@ jobs:
       run: |
         brew uninstall qwt --force --ignore-dependencies 2>/dev/null || true
         cd /tmp
-        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
+        curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
         tar -xjf qwt.tar.bz2
-        cd qwt-6.2.0
+        cd qwt-6.3.0
         sed -i.bak 's/QwtFramework//' qwtconfig.pri
         qmake qwt.pro
         make -j$(sysctl -n hw.logicalcpu)
@@ -65,9 +65,9 @@ jobs:
     - name: Package with macdeployqt
       run: |
         APP=build/release/MaximumTrainer.app/Contents/MacOS/MaximumTrainer
-        QWT_LIB=/usr/local/qwt-6.2.0/lib/libqwt.6.dylib
+        QWT_LIB=/usr/local/qwt-6.3.0/lib/libqwt.6.dylib
 
-        # QWT 6.2.0 default LC_ID_DYLIB is /usr/lib/libqwt.6.dylib but the actual
+        # QWT 6.3.0 default LC_ID_DYLIB is /usr/lib/libqwt.6.dylib but the actual
         # file is at $QWT_LIB. macdeployqt follows LC_ID_DYLIB to locate a library,
         # so it cannot find QWT unless we fix the install_name first.
         sudo install_name_tool -id "$QWT_LIB" "$QWT_LIB"
@@ -79,7 +79,7 @@ jobs:
         # Add QWT rpath so the .app stays self-contained when moved between
         # machines. '|| true' tolerates a duplicate rpath already baked in at
         # build time. (QtMultimedia frameworks are handled by macdeployqt.)
-        install_name_tool -add_rpath /usr/local/qwt-6.2.0/lib "$APP" || true
+        install_name_tool -add_rpath /usr/local/qwt-6.3.0/lib "$APP" || true
 
         macdeployqt build/release/MaximumTrainer.app -dmg
         mv build/release/MaximumTrainer.dmg MaximumTrainer-macos.dmg

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ All three platforms are built and tested automatically via GitHub Actions CI (se
 | Dependency | Version | Platform | Notes |
 |------------|---------|----------|-------|
 | Qt | 6.x (6.7+) | all | Core framework (incl. QtMultimedia, QtWebEngine, QtBluetooth) |
-| QWT | 6.2.0 | all | Plotting widgets (built from source against Qt 6) |
+| QWT | 6.3.0 | all | Plotting widgets (built from source against Qt 6) |
 
 > **Audio & media playback:** both sound-effect feedback (interval beeps, etc.,
 > via `QSoundEffect`) and the embedded video + internet-radio player
@@ -227,7 +227,7 @@ qmake PowerVelo.pro `
 
 **Download links:**
 - Qt 6.x: https://www.qt.io/download
-- QWT 6.2.0: https://sourceforge.net/projects/qwt/files/qwt/6.2.0/
+- QWT 6.3.0: https://sourceforge.net/projects/qwt/files/qwt/6.3.0/
 
 ### Linux
 
@@ -240,13 +240,13 @@ sudo apt-get install -y \
   qt6-multimedia-dev qt6-webchannel-dev qt6-positioning-dev \
   cmake build-essential
 
-# Build QWT 6.2.0 from source against Qt 6 (installs to /tmp/qwt6 here)
+# Build QWT 6.3.0 from source against Qt 6 (installs to /tmp/qwt6 here)
 cd /tmp && curl -L -o qwt.tar.bz2 \
-  "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
-tar xf qwt.tar.bz2 && cd qwt-6.2.0
+  "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
+tar xf qwt.tar.bz2 && cd qwt-6.3.0
 qmake6 qwt.pro && make -j$(nproc)
 make install INSTALL_ROOT=/tmp/qwt6-stage
-mv /tmp/qwt6-stage/usr/local/qwt-6.2.0 /tmp/qwt6
+mv /tmp/qwt6-stage/usr/local/qwt-6.3.0 /tmp/qwt6
 
 # Build MaximumTrainer
 cd /path/to/MaximumTrainer_Redux
@@ -269,16 +269,16 @@ Uses Qt 6.7.3 with Clang. QWT is built from source (non-framework) against Qt 6.
 ```bash
 # Install Qt 6.7.3 via install-qt-action or the Qt Installer, then:
 
-# Build QWT 6.2.0 from source (non-framework, required for Qt 6)
-curl -L -o /tmp/qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.2.0/qwt-6.2.0.tar.bz2/download"
-tar -xjf /tmp/qwt.tar.bz2 -C /tmp && cd /tmp/qwt-6.2.0
+# Build QWT 6.3.0 from source (non-framework, required for Qt 6)
+curl -L -o /tmp/qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
+tar -xjf /tmp/qwt.tar.bz2 -C /tmp && cd /tmp/qwt-6.3.0
 sed -i.bak 's/QwtFramework//' qwtconfig.pri
 qmake qwt.pro && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
 # Build MaximumTrainer
 cd /path/to/MaximumTrainer_Redux
 qmake PowerVelo.pro \
-  "QWT_INSTALL=/usr/local/qwt-6.2.0"
+  "QWT_INSTALL=/usr/local/qwt-6.3.0"
 make
 ```
 

--- a/agents.md
+++ b/agents.md
@@ -32,7 +32,7 @@ completed activities to the Garmin FIT format.
 |-----------|-------|
 | Language | C++17 |
 | UI Toolkit | Qt 6 (Widgets + WebEngineWidgets) |
-| Plotting | QWT 6.2 |
+| Plotting | QWT 6.3 |
 | Serialisation | Garmin FIT SDK, TCX, GPX, XML |
 | Hardware protocols | BLE (Qt Bluetooth) |
 | Audio/Video | QtMultimedia (`QMediaPlayer` video + radio, `QSoundEffect` sound effects), platform stubs for WASM |

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,7 +290,7 @@
           <p class="download-desc">Windows 10/11 — 64-bit (MSVC build)</p>
           <ul class="download-deps">
             <li>Qt 6.x (win64_msvc2019_64)</li>
-            <li>QWT 6.2.0</li>
+            <li>QWT 6.3.0</li>
             <li>SFML 2.6.1</li>
           </ul>
           <a id="win-download-btn" class="btn btn-primary btn-disabled" href="#" aria-disabled="true" title="Not yet available — coming soon">
@@ -312,7 +312,7 @@ nmake</code></pre>
           <p class="download-desc">Ubuntu 24.04+ / Debian-based distros</p>
           <ul class="download-deps">
             <li>Qt 6.x (from apt)</li>
-            <li>QWT 6.2.0 (from source)</li>
+            <li>QWT 6.3.0 (from source)</li>
             <li>libsfml-dev</li>
           </ul>
           <a id="linux-download-btn" class="btn btn-primary btn-disabled" href="#" aria-disabled="true" title="Not yet available — coming soon">
@@ -339,7 +339,7 @@ make -j$(nproc)</code></pre>
           <p class="download-desc">macOS 12+ (Apple Silicon &amp; Intel)</p>
           <ul class="download-deps">
             <li>Qt 6.7.3 (via Qt Installer)</li>
-            <li>QWT 6.2.0 (from source)</li>
+            <li>QWT 6.3.0 (from source)</li>
             <li>SFML (brew install sfml)</li>
           </ul>
           <a id="mac-download-btn" class="btn btn-primary btn-disabled" href="#" aria-disabled="true" title="Not yet available — coming soon">
@@ -350,7 +350,7 @@ make -j$(nproc)</code></pre>
             <pre><code>brew install sfml
 qmake PowerVelo.pro \
   "SFML_INSTALL=$(brew --prefix sfml)" \
-  "QWT_INSTALL=/usr/local/qwt-6.2.0"
+  "QWT_INSTALL=/usr/local/qwt-6.3.0"
 make -j$(sysctl -n hw.logicalcpu)</code></pre>
           </details>
         </div>


### PR DESCRIPTION
## Summary

Bumps **QWT 6.2.0 → 6.3.0** ([released 2024-05-08](https://sourceforge.net/projects/qwt/files/qwt/6.3.0/), superseding 6.2.0 from 2021-07-18). The Wasm build (`build.yml`) was already on 6.3.0; this aligns the Linux, Windows, and macOS CI workflows and all docs so every platform builds against the same QWT release.

QWT 6.3.0 carries ~3 years of "bugfixes/adjustments needed because of new Qt developments," which is relevant to the ongoing Qt6 work.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release-linux.yml`, `build-linux.yml` | download URL, tarball, `cd`, install path, cache key |
| `.github/workflows/build-windows.yml` | download URL, `Rename-Item` source dir, cache key |
| `.github/workflows/release-mac.yml`, `build-mac.yml` | download, `cd`, `/usr/local/qwt-6.3.0` paths, cache keys, dylib patch paths |
| `README.md`, `agents.md`, `docs/index.html` | dependency tables + build instructions |

## Compatibility notes

- Backward-compatible minor release — no documented breaking API changes.
- The dylib soname stays `libqwt.6.dylib` (major version unchanged), so the macOS `install_name_tool` logic is untouched — only install-prefix paths shift.
- **Cache keys bumped** on every platform so CI rebuilds QWT from source rather than restoring a stale 6.2.0 cache.
- Only QWT touched — no Qt version strings changed.

## Local verification

Built QWT 6.3.0 from source against Qt 6 and compiled the app against it locally on Linux (see PR thread for results).
