### PR TITLE
fix(linux): bundle OpenSSL pair + xdg-portal theme in AppImage

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -123,6 +123,23 @@ jobs:
             echo "WARN: NSS module $nss_lib not found on build host"
           fi
         done
+        # Qt's OpenSSL TLS backend (tls/libqopensslbackend.so) dlopen()s libssl
+        # and libcrypto at runtime, so linuxdeploy's static scan bundles neither
+        # reliably — in practice only libcrypto.so.3 gets pulled in. With the
+        # AppImage RUNPATH ($ORIGIN/../lib) the bundled libcrypto wins, but libssl
+        # is then resolved from the user's host. OpenSSL enforces a libssl<->
+        # libcrypto build-version match, so on any host whose OpenSSL 3.0.x point
+        # release differs from the build host's, the pair mismatches and every
+        # HTTPS connection logs "QSslSocket: TLS initialization failed". Bundle the
+        # matched pair so the backend always loads a self-consistent OpenSSL.
+        for ssl_lib in libssl.so.3 libcrypto.so.3; do
+          ssl_src=$(find /usr/lib/x86_64-linux-gnu -name "$ssl_lib" | head -1)
+          if [ -n "$ssl_src" ]; then
+            cp -vL "$ssl_src" AppDir/usr/lib/
+          else
+            echo "WARN: OpenSSL library $ssl_lib not found on build host"
+          fi
+        done
         # Desktop entry required by linuxdeploy
         cat > AppDir/usr/share/applications/maximumtrainer.desktop << 'EOF'
         [Desktop Entry]
@@ -173,6 +190,35 @@ jobs:
           echo "PASS: libsoftokn3 bundled in AppDir"
         else
           echo "FAIL: libsoftokn3 missing from AppDir — QtWebEngine will crash on HTTPS"
+          exit 1
+        fi
+
+    - name: Verify OpenSSL pair bundled
+      # Both libssl and libcrypto must be present so Qt's TLS backend loads a
+      # self-consistent OpenSSL — a lone libcrypto causes a libssl<->libcrypto
+      # version mismatch and "TLS initialization failed" on hosts with a
+      # different OpenSSL 3.0.x point release.
+      run: |
+        echo "=== OpenSSL check ==="
+        for ssl_lib in libssl.so.3 libcrypto.so.3; do
+          if find AppDir -name "$ssl_lib" -print -quit 2>/dev/null | grep -q .; then
+            echo "PASS: $ssl_lib bundled in AppDir"
+          else
+            echo "FAIL: $ssl_lib missing from AppDir — HTTPS/TLS will fail"
+            exit 1
+          fi
+        done
+
+    - name: Verify xdg-desktop-portal theme plugin bundled
+      # main.cpp sets QT_QPA_PLATFORMTHEME=xdgdesktopportal so the app tracks the
+      # desktop light/dark preference under xcb. The plugin must be bundled or
+      # the app silently falls back to Light.
+      run: |
+        echo "=== platform theme check ==="
+        if find AppDir -name "libqxdgdesktopportal.so" -print -quit 2>/dev/null | grep -q .; then
+          echo "PASS: libqxdgdesktopportal bundled in AppDir"
+        else
+          echo "FAIL: libqxdgdesktopportal missing — dark-mode detection will not work"
           exit 1
         fi
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -41,6 +41,20 @@ int main(int argc, char *argv[]) {
         if (isWayland)
             qputenv("QT_QPA_PLATFORM", "xcb");
     }
+
+    // Select the xdg-desktop-portal platform theme so the app tracks the
+    // desktop's light/dark preference. Under xcb (which we force above on
+    // Wayland) Qt does not auto-select a platform theme that exposes the
+    // GNOME/KDE colour scheme, so QStyleHints::colorScheme() — read by
+    // AppTheme::resolveMode() for "System" mode — reports Light regardless of
+    // the desktop being in dark mode. The xdgdesktopportal theme reads the
+    // standard org.freedesktop.appearance color-scheme over D-Bus and works
+    // across desktops. Only set it when the user has not pinned a theme; with
+    // no portal running it harmlessly falls back (System resolves to Light,
+    // same as before). The plugin (and libQt6DBus) must be bundled in the
+    // AppImage — see release-linux.yml.
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORMTHEME"))
+        qputenv("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
 #endif
 
     // QtWebEngine requires the GUI thread and Chromium's GPU process to share


### PR DESCRIPTION
## Summary

Fixes two Linux AppImage issues reported from a local v0.0.116 run — both **packaging/runtime gaps, not Qt-version bugs** (verified on the bundled Qt 6.7.3). The app stays on Qt 6.7.3 LTS.

### 1. `QSslSocket: TLS initialization failed` (repeated at startup)
The AppImage bundles `libcrypto.so.3` (from the ubuntu-22.04 build host) but **not its companion `libssl.so.3`**. With the AppImage RUNPATH (`$ORIGIN/../lib`) the bundled `libcrypto` wins, while `libssl` is resolved from the *user's host*. OpenSSL enforces a `libssl`↔`libcrypto` build-version match, so on any host with a different OpenSSL 3.0.x point release the pair mismatches and every HTTPS connection fails. Qt's OpenSSL TLS backend `dlopen()`s both libs, so linuxdeploy's static scan misses them — same root cause and fix pattern as the [NSS softokn fix](https://github.com/MaximumTrainer/MaximumTrainer_Redux/commit/5eb2ef3).

**Fix:** bundle the matched OpenSSL pair (`libssl.so.3` + `libcrypto.so.3`) into `AppDir/usr/lib`.

### 2. OS dark mode not picked up (workout list renders white under GNOME dark)
The app forces **xcb** under Wayland (for QtWebEngine stability). Under xcb, Qt does not auto-select a platform theme that exposes the desktop colour scheme, so `QStyleHints::colorScheme()` — read by `AppTheme::resolveMode()` for **System** mode — reports `Light` regardless of the desktop being dark.

**Fix:** set `QT_QPA_PLATFORMTHEME=xdgdesktopportal` in `main.cpp` (only when unset), so the app reads `org.freedesktop.appearance` over D-Bus. The plugin and `libQt6DBus` are bundled. Explicit Light/Dark preferences are unaffected — `AppTheme::apply()` force-sets the palette regardless of platform theme; the env var only influences the System auto-detect path.

## Changes
- `src/app/main.cpp` — select `xdgdesktopportal` platform theme on Linux (guarded; only when user hasn't pinned one).
- `.github/workflows/release-linux.yml` — bundle the OpenSSL pair; add verify steps for the OpenSSL pair and the portal theme plugin.

## Local verification (Linux, GNOME `prefer-dark`, Wayland→xcb)

Tested against the **bundled Qt 6.7.3** binary, not just my host Qt:

| Scenario | Workout list |
|----------|-------------|
| As-shipped (no env) | **Light** ❌ (reproduced) |
| `QT_QPA_PLATFORMTHEME=gtk3` | Light ❌ (ruled out) |
| `QT_QPA_PLATFORMTHEME=xdgdesktopportal` | **Dark** ✅ |
| **Locally-built binary with this fix, no env var set** | **Dark** ✅ |

TLS: confirmed the bundle ships `libcrypto` without `libssl`; bundling the matched pair clears the errors. (The mismatch is host-OpenSSL-dependent, so it reproduces on affected hosts rather than universally — the structural asymmetry is the bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)