### PR TITLE
fix(ui): repair Qt6 combobox slots, drop dead action slots, rename .pro

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Build and install QWT
       # No QWT apt package exists for Qt6, so build 6.3.0 from source against the
-      # installed Qt6 and stage it under QWT_DIR. PowerVelo.pro is pointed at it
+      # installed Qt6 and stage it under QWT_DIR. MaximumTrainer.pro is pointed at it
       # via QWT_INSTALL=... .
       if: steps.qwt-cache.outputs.cache-hit != 'true'
       run: |
@@ -90,7 +90,7 @@ jobs:
 
     - name: Create Makefile
       run: |
-        qmake PowerVelo.pro "QWT_INSTALL=$QWT_DIR"
+        qmake MaximumTrainer.pro "QWT_INSTALL=$QWT_DIR"
       env:
         TP_CLIENT_SECRET:              ${{ secrets.TP_CLIENT_SECRET }}
         INTERVALS_OAUTH_CLIENT_ID:     ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Create Makefile
       run: |
-        qmake PowerVelo.pro \
+        qmake MaximumTrainer.pro \
           "QWT_INSTALL=/usr/local/qwt-6.3.0"
       env:
         TP_CLIENT_SECRET:              ${{ secrets.TP_CLIENT_SECRET }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Build QWT
       # No QWT apt/Qt6 binary package exists, so build 6.3.0 from source against
-      # the installed Qt6 and install it to QWT_INSTALL_DIR. PowerVelo.pro is
+      # the installed Qt6 and install it to QWT_INSTALL_DIR. MaximumTrainer.pro is
       # pointed at this location via QWT_INSTALL=... .
       if: steps.qwt-cache.outputs.cache-hit != 'true'
       run: |
@@ -141,7 +141,7 @@ jobs:
         $env:TP_CLIENT_SECRET = "${{ secrets.TP_CLIENT_SECRET }}"
         $env:INTERVALS_OAUTH_CLIENT_ID = "${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}"
         $env:INTERVALS_OAUTH_CLIENT_SECRET = "${{ secrets.INTERVALS_OAUTH_CLIENT_SECRET }}"
-        qmake PowerVelo.pro `
+        qmake MaximumTrainer.pro `
           "QWT_INSTALL=$qwtInstallDirFwd"
       shell: powershell
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         source "$EMSDK/emsdk_env.sh"
         export QMAKEFEATURES="$HOME/qwt-wasm/features"
         mkdir -p build-wasm && cd build-wasm
-        qmake ../PowerVelo.pro \
+        qmake ../MaximumTrainer.pro \
           "QWT_INSTALL=$HOME/qwt-wasm"
         emmake make -j$(nproc)
 

--- a/MaximumTrainer.pro
+++ b/MaximumTrainer.pro
@@ -14,7 +14,7 @@
 #
 # The CI fix: each workflow exports GIT_TAG to the environment before running
 # qmake (using a "Determine build version" step that calls git describe in
-# bash, where it works reliably).  PowerVelo.pro reads that env-var first and
+# bash, where it works reliably).  MaximumTrainer.pro reads that env-var first and
 # only falls back to $$system(git describe ...) for local development builds
 # where GIT_TAG is not set.
 GIT_VERSION = $$(GIT_TAG)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An open-source, high-performance indoor cycling training application built with 
 |------|---------|
 | **Language** | C++17 (≈ 95 % C++) |
 | **Framework** | Qt 6 (6.7+) on all platforms |
-| **Build file** | `PowerVelo.pro` (qmake) |
+| **Build file** | `MaximumTrainer.pro` (qmake) |
 | **Qt modules** | core · gui · widgets · network · bluetooth · webenginewidgets · printsupport · concurrent |
 | **Trainer protocol** | Bluetooth LE Fitness Machine Service (FTMS / 0x1826) for ERG resistance control |
 | **Sensor profiles** | Heart Rate (0x180D) · Cycling Speed & Cadence (0x1816) · Cycling Power (0x1818) · Moxy Muscle Oxygen (0xAAB0) |
@@ -184,7 +184,7 @@ On most modern distributions (Ubuntu 20.04+, Fedora 36+) these modules load auto
 
 ## Building
 
-All three platforms are built and tested automatically via GitHub Actions CI (see `.github/workflows/build.yml`). Use `PowerVelo.pro` with `qmake` and a standard C++ compiler.
+All three platforms are built and tested automatically via GitHub Actions CI (see `.github/workflows/build.yml`). Use `MaximumTrainer.pro` with `qmake` and a standard C++ compiler.
 
 ### Dependencies
 
@@ -219,7 +219,7 @@ All three platforms are built and tested automatically via GitHub Actions CI (se
 
 **qmake invocation:**
 ```powershell
-qmake PowerVelo.pro `
+qmake MaximumTrainer.pro `
   "QWT_INSTALL=C:/qwt"
 ```
 
@@ -250,7 +250,7 @@ mv /tmp/qwt6-stage/usr/local/qwt-6.3.0 /tmp/qwt6
 
 # Build MaximumTrainer
 cd /path/to/MaximumTrainer_Redux
-qmake6 PowerVelo.pro QWT_INSTALL=/tmp/qwt6
+qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6
 make -j$(nproc)
 # Run (QWT in a non-standard prefix needs LD_LIBRARY_PATH):
 LD_LIBRARY_PATH=/tmp/qwt6/lib ./build/release/MaximumTrainer
@@ -277,7 +277,7 @@ qmake qwt.pro && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
 # Build MaximumTrainer
 cd /path/to/MaximumTrainer_Redux
-qmake PowerVelo.pro \
+qmake MaximumTrainer.pro \
   "QWT_INSTALL=/usr/local/qwt-6.3.0"
 make
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -194,7 +194,7 @@
           <tbody>
             <tr><td>Language</td><td>C++17 (≈ 95 %)</td></tr>
             <tr><td>Framework</td><td>Qt 5.15.2 (Windows · Linux) &nbsp;·&nbsp; Qt 6.7.3 (macOS) &nbsp;·&nbsp; Qt 6.6.3 (WebAssembly / browser)</td></tr>
-            <tr><td>Build file</td><td><code>PowerVelo.pro</code> (qmake)</td></tr>
+            <tr><td>Build file</td><td><code>MaximumTrainer.pro</code> (qmake)</td></tr>
             <tr><td>Trainer protocol</td><td>Bluetooth LE FTMS (0x1826) — ERG automatic resistance control</td></tr>
             <tr><td>Sensor profiles</td><td>Heart Rate (0x180D) · CSC (0x1816) · Power (0x1818) · Moxy NIRS (0xAAB0)</td></tr>
             <tr><td>Workout formats</td><td><code>.erg</code> · <code>.mrc</code> · <code>.zwo</code> · <code>.fit</code> (native XML) · Intervals.icu calendar sync</td></tr>
@@ -298,7 +298,7 @@
           </a>
           <details class="build-details">
             <summary>Build from source</summary>
-            <pre><code>qmake PowerVelo.pro `
+            <pre><code>qmake MaximumTrainer.pro `
   "QWT_INSTALL=C:/qwt" `
   "SFML_INSTALL=C:/sfml/SFML-2.6.1"
 nmake</code></pre>
@@ -327,7 +327,7 @@ nmake</code></pre>
   libsfml-dev \
   cmake build-essential
 
-qmake6 PowerVelo.pro QWT_INSTALL=/tmp/qwt6
+qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6
 make -j$(nproc)</code></pre>
           </details>
         </div>
@@ -348,7 +348,7 @@ make -j$(nproc)</code></pre>
           <details class="build-details">
             <summary>Build from source</summary>
             <pre><code>brew install sfml
-qmake PowerVelo.pro \
+qmake MaximumTrainer.pro \
   "SFML_INSTALL=$(brew --prefix sfml)" \
   "QWT_INSTALL=/usr/local/qwt-6.3.0"
 make -j$(sysctl -n hw.logicalcpu)</code></pre>

--- a/src/persistence/db/environnement.h
+++ b/src/persistence/db/environnement.h
@@ -57,7 +57,7 @@ const static QString urlIntervalsIcuOAuthAuthorize(
 
 /// Intervals.icu OAuth2 client credentials.
 /// client_id and client_secret are injected at build time via environment variables
-/// INTERVALS_OAUTH_CLIENT_ID and INTERVALS_OAUTH_CLIENT_SECRET (see PowerVelo.pro).
+/// INTERVALS_OAUTH_CLIENT_ID and INTERVALS_OAUTH_CLIENT_SECRET (see MaximumTrainer.pro).
 /// The macros default to "259" (existing public client) and "" (no secret) when
 /// the environment variables are not set.
 #ifndef INTERVALS_OAUTH_CLIENT_ID
@@ -136,7 +136,7 @@ const static QString urlTrainingPeaksAuthorize("https://oauth.trainingpeaks.com/
 
 const static QString CLIENT_ID_TP = "maximumtrainer";
 // CLIENT_SECRET_TP is injected at build time via the TP_CLIENT_SECRET env var
-// (see PowerVelo.pro).  The macro expands to an empty string when the secret
+// (see MaximumTrainer.pro).  The macro expands to an empty string when the secret
 // has not been configured, which disables the token-refresh flow.
 #ifndef TP_CLIENT_SECRET
 #define TP_CLIENT_SECRET ""

--- a/src/persistence/db/trainingpeaks_service.h
+++ b/src/persistence/db/trainingpeaks_service.h
@@ -14,7 +14,7 @@
 /// access token when the current one expires.
 ///
 /// The client_id and client_secret for the token exchange are taken from
-/// the TP_CLIENT_SECRET compile-time define (see PowerVelo.pro).
+/// the TP_CLIENT_SECRET compile-time define (see MaximumTrainer.pro).
 ///
 /// All methods are non-blocking and return a pending QNetworkReply*.
 /// The caller must connect QNetworkReply::finished to a slot.

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -372,6 +372,9 @@ void DialogConfig::initUi() {
     ui->checkBox_showWorkoutRemainingTime->setChecked(account->show_workout_remaining);
     ui->checkBox_showElapsedTime->setChecked(account->show_elapsed);
     ui->comboBox_fontSizeTimer->setCurrentText(QString::number(account->font_size_timer) );
+    // Connect after setCurrentText() so seeding the initial value does not emit.
+    connect(ui->comboBox_fontSizeTimer, &QComboBox::currentTextChanged,
+            this, &DialogConfig::onTimerFontSizeChanged);
 
     int startTrigger = account->start_trigger;
     /// 0 - Cadence
@@ -580,7 +583,7 @@ void DialogConfig::on_checkBox_showElapsedTime_clicked(bool checked)
     parentDialog->showTimerWorkoutElapsed(checked);
 }
 
-void DialogConfig::on_comboBox_fontSizeTimer_currentIndexChanged(const QString &arg1)
+void DialogConfig::onTimerFontSizeChanged(const QString &arg1)
 {
     parentDialog->setTimerFontSize(arg1.toInt());
 }

--- a/src/ui/dialogconfig.h
+++ b/src/ui/dialogconfig.h
@@ -115,7 +115,10 @@ private slots:
     void on_checkBox_showIntervalRemainingTime_clicked(bool checked);
     void on_checkBox_showWorkoutRemainingTime_clicked(bool checked);
     void on_checkBox_showElapsedTime_clicked(bool checked);
-    void on_comboBox_fontSizeTimer_currentIndexChanged(const QString &arg1);
+    // Connected explicitly (see initUi): Qt6 removed
+    // QComboBox::currentIndexChanged(const QString&), so the old
+    // connectSlotsByName auto-connection silently no longer fired.
+    void onTimerFontSizeChanged(const QString &arg1);
 
 
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1602,24 +1602,9 @@ void MainWindow::on_actionWorkout_triggered()
     Util::openWorkoutFolder("null");
 }
 //-----------------------------------------------
-void MainWindow::on_actionOpen_Course_Folder_triggered()
-{
-    Util::openCourseFolder("null");
-}
-//-----------------------------------------------
 void MainWindow::on_actionHistory_triggered()
 {
     ftb->setCurrentIndex(4); // History (was index 6 before Profile/Settings removal)
-}
-
-
-//------------------------------------------------------
-void MainWindow::on_actionToggleQueue_triggered()
-{
-    if (m_queueDock->isVisible())
-        m_queueDock->hide();
-    else
-        m_queueDock->show();
 }
 
 
@@ -1939,20 +1924,6 @@ void MainWindow::startWorkoutWithHubs(const Workout &workout,
     w->show();
 }
 #endif // GC_WASM_BUILD
-
-
-////////////////////////////////////////////////////////////////////////
-void MainWindow::on_actionImportCourse_triggered()
-{
-    //    bool result = ui->tab_edit_course->loadCourseTrigger();
-
-    //    if (result) {
-    //        ui->tabWidget_course->setCurrentIndex(1);
-    //        ftb->setCurrentIndex(1);
-    //    }
-
-}
-
 
 
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -136,9 +136,7 @@ private slots:
     void slotVersionCheckFinished();
     void on_actionPreferences_triggered();
     void on_actionWorkout_triggered();
-    void on_actionOpen_Course_Folder_triggered();
     void on_actionHistory_triggered();
-    void on_actionToggleQueue_triggered();
     void addWorkoutToQueue(const Workout &workout);
 
 
@@ -164,8 +162,6 @@ private slots:
     void slotIntervalsIcuUploadFinished();
 
     void onNetworkOnlineChanged(bool isOnline);
-
-    void on_actionImportCourse_triggered();
 
     void createWebChannelPlan();
     void createWebChannelZone();

--- a/src/ui/workout_editor/repeatwidget.cpp
+++ b/src/ui/workout_editor/repeatwidget.cpp
@@ -42,6 +42,10 @@ RepeatWidget::RepeatWidget(RepeatData *data, QWidget *parent) :
 
     ui->comboBox_repeat->setCurrentText(QString::number(data->getNumberRepeat()));
 
+    // Connect after setCurrentText() so seeding the initial value does not emit.
+    connect(ui->comboBox_repeat, &QComboBox::currentTextChanged,
+            this, &RepeatWidget::onRepeatCountChanged);
+
     ui->comboBox_repeat->installEventFilter(this);
     ui->widget_right->installEventFilter(this);
 }
@@ -90,7 +94,7 @@ void RepeatWidget::on_pushButton_delete_clicked()
     emit deleteSignal(data->getId());
 }
 
-void RepeatWidget::on_comboBox_repeat_currentIndexChanged(const QString &arg1)
+void RepeatWidget::onRepeatCountChanged(const QString &arg1)
 {
     this->data->setNumberRepeat(arg1.toInt());
     emit updateSignal(this->data->getId());

--- a/src/ui/workout_editor/repeatwidget.h
+++ b/src/ui/workout_editor/repeatwidget.h
@@ -39,7 +39,10 @@ signals:
 
 private slots:
     void on_pushButton_delete_clicked();
-    void on_comboBox_repeat_currentIndexChanged(const QString &arg1);
+    // Connected explicitly (see constructor): Qt6 removed
+    // QComboBox::currentIndexChanged(const QString&), so the old
+    // connectSlotsByName auto-connection silently no longer fired.
+    void onRepeatCountChanged(const QString &arg1);
 
 
 private:


### PR DESCRIPTION
## Summary

Three related cleanups surfaced from startup-log triage of the Linux build:

### 1. Qt6 combobox regression (real bug — silently broken UI)
Qt6 **removed** `QComboBox::currentIndexChanged(const QString&)` (only the `int` overload survives). Two `connectSlotsByName` auto-connections relied on the removed overload and silently stopped firing after the Qt6 migration:

- **`RepeatWidget`** repeat-count dropdown (workout editor) → `setNumberRepeat()` never ran. **Changing a repeat block's count did nothing.**
- **`DialogConfig`** timer font-size dropdown (preferences) → `setTimerFontSize()` never ran.

Both now use an explicit `connect()` to `currentTextChanged` (Qt6's direct replacement, same `QString` arg, body unchanged), wired **after** `setCurrentText()` so seeding the initial value doesn't emit. Slots are renamed off the `on_<obj>_<signal>` pattern so `connectSlotsByName` no longer tries/warns. Neither combobox is editable, so `currentTextChanged` ≡ a selection change.

### 2. Dead action slots removed
Three `MainWindow` slots had no matching `.ui` action and no manual `connect()` — each logged a `connectSlotsByName: No matching signal` warning at startup:
- `on_actionOpen_Course_Folder_triggered`, `on_actionImportCourse_triggered` — dead since the Course feature was removed.
- `on_actionToggleQueue_triggered` — unreachable (the queue dock auto-shows when a workout is added).

(`Util::openCourseFolder` is retained — still used by `main_coursepage.cpp`.)

### 3. Renamed `PowerVelo.pro` → `MaximumTrainer.pro`
Updated all references: the four CI build workflows, README, docs, and source comments. The `.pro` sets `TARGET = MaximumTrainer` explicitly, so the **binary name is unchanged** — this is a rename of the project file only. Release workflows package a pre-built artifact and don't qmake the app, so they needed no change.

## Local verification (Linux, Qt 6.7.3 / 6.10)
- **Clean build** via the renamed `MaximumTrainer.pro` (qmake + make) ✓
- App starts with **zero `connectSlotsByName` warnings** (was 5) ✓
- **Behavioral test** of the repeat dropdown: selecting "4" updates `RepeatData` `2 → 4`. Confirmed the *pre-fix* code leaves it stale at `2` (reproducing the reported bug) and the fix corrects it ✓

