### PR TITLE
refactor(clock): use Qt's QElapsedTimer instead of QwtSystemClock

### DIFF
--- a/src/ui/components/clock.h
+++ b/src/ui/components/clock.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QVector>
-#include "qwt_system_clock.h"
+#include <QElapsedTimer>
 
 class Clock : public QObject
 {
@@ -59,8 +59,8 @@ private :
 
     QTimer *timerClock;
     const int timerClockMs = 25;
-    QwtSystemClock d_clock;
-    QwtSystemClock d_clock_speed;
+    QElapsedTimer d_clock;
+    QElapsedTimer d_clock_speed;
 
     double totalTimeElapsed_msec;
     int lastSecond;


### PR DESCRIPTION
## Summary

Replaces QWT's `QwtSystemClock` with Qt's native `QElapsedTimer` in the workout `Clock`. Qt has shipped `QElapsedTimer` since 4.7 — the same monotonic high-resolution clock, immune to system-clock changes — so there's no reason to depend on QWT for timekeeping. `QwtSystemClock` simply predates `QElapsedTimer`, which is why it was used originally.

## Change

A drop-in swap in `src/ui/components/clock.h`:
- `#include "qwt_system_clock.h"` → `#include <QElapsedTimer>`
- `QwtSystemClock d_clock / d_clock_speed` → `QElapsedTimer`

Both expose `start()` / `elapsed()`. `QElapsedTimer::elapsed()` returns `qint64` (implicitly converted to the existing `double` members). **No behavioural change** — identical monotonic semantics. QWT is still used for the plots; this only removes the QWT-for-timing coupling.

## Context

The per-second timekeeping was already correct and drift-free (it derives the elapsed second from `elapsed()` rather than counting ticks). This is purely a dependency cleanup, not a behaviour fix.

## Local verification (Linux, Qt 6.10)
- Clean build ✓
- Confirmed in a real interactive run: elapsed timer counts correctly, pause/resume excludes paused time, interval countdowns and mini-graphs behave exactly as before ✓

## Notes
- Independent of #227 (disjoint files — #227 never touches `clock.*`), so the two merge in any order with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
