### PR TITLE
fix(util): handle QFile::open failures in zip/unzip helpers

### DIFF
--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -799,12 +799,18 @@ QByteArray Util::zipFileHelperConvertToGzip(const QByteArray& data) {
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void Util::zipFileToDisk(QString filename, QString zipFilename, bool useGzip) {
+bool Util::zipFileToDisk(QString filename, QString zipFilename, bool useGzip) {
 
     QFile infile(filename);
     QFile outfile(zipFilename);
-    infile.open(QIODevice::ReadOnly);
-    outfile.open(QIODevice::WriteOnly);
+    if (!infile.open(QIODevice::ReadOnly)) {
+        qWarning() << "zipFileToDisk: cannot read" << filename << infile.errorString();
+        return false;
+    }
+    if (!outfile.open(QIODevice::WriteOnly)) {
+        qWarning() << "zipFileToDisk: cannot write" << zipFilename << outfile.errorString();
+        return false;
+    }
     QByteArray uncompressedData = infile.readAll();
     QByteArray compressedData;
 
@@ -818,20 +824,28 @@ void Util::zipFileToDisk(QString filename, QString zipFilename, bool useGzip) {
     outfile.write(compressedData);
     infile.close();
     outfile.close();
+    return true;
 }
 
 
-void Util::unzipFile(QString zipFilename , QString filename) {
+bool Util::unzipFile(QString zipFilename , QString filename) {
 
     QFile infile(zipFilename);
     QFile outfile(filename);
-    infile.open(QIODevice::ReadOnly);
-    outfile.open(QIODevice::WriteOnly);
+    if (!infile.open(QIODevice::ReadOnly)) {
+        qWarning() << "unzipFile: cannot read" << zipFilename << infile.errorString();
+        return false;
+    }
+    if (!outfile.open(QIODevice::WriteOnly)) {
+        qWarning() << "unzipFile: cannot write" << filename << outfile.errorString();
+        return false;
+    }
     QByteArray uncompressedData = infile.readAll();
     QByteArray compressedData = qUncompress(uncompressedData);
     outfile.write(compressedData);
     infile.close();
     outfile.close();
+    return true;
 }
 
 

--- a/src/app/util.h
+++ b/src/app/util.h
@@ -85,8 +85,8 @@ public:
 
 
     // Zip, Unzip
-    static void zipFileToDisk(QString filename, QString zipFilename, bool useGzip);
-    static void unzipFile(QString zipFilename , QString filename);
+    static bool zipFileToDisk(QString filename, QString zipFilename, bool useGzip);
+    static bool unzipFile(QString zipFilename , QString filename);
     // used for Gzip convert
     static QByteArray zipFileHelperConvertToGzip(const QByteArray& data);
     static quint32 crc32buf(const QByteArray& data);


### PR DESCRIPTION
## Summary

Group 5 (quick correctness fixes) from the refactor plan. After verifying each audit item against the current code, only one was a genuine, safe fix — shipped here; the other two were correctly rejected (details below).

## Fix: `QFile::open()` failures in zip/unzip helpers

`Util::zipFileToDisk` and `Util::unzipFile` discarded the `bool` return of `QFile::open()` and continued regardless — a failed open silently wrote an empty/corrupt output file with no diagnostic. Both now check `open()` for input **and** output, log via `qWarning()`, and return `false` on failure (return type `void` → `bool`). The lone caller (`ExtRequest`, before a TrainingPeaks upload) used it as a statement and is unaffected.

## Audit items dropped after inspection (documented for the record)

- **`qrand()`/`qsrand()` "removed in Qt6":** false positive. All call sites in `simplecrypt.cpp` are already `#if QT_VERSION`-guarded — Qt6 uses the `QRandomGenerator` path. Nothing to fix.
- **Dedup selfloops' `gzipCompress` into `Util::zipFileHelperConvertToGzip`:** rejected. `util.h` is a heavy header (pulls in `QApplication` + `qwt_plot.h`), so making the headless `selfloops_service` depend on it forces widgets+QWT onto a network-only module and breaks its `QT -= gui` test. Coupling a clean service to the GUI/QWT layer to remove ~30 self-contained lines is a worse trade than the duplication.

## Verification (Linux, Qt 6.10)
- Clean build ✓
- Demo workout (screenshot mode) runs, no crashes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
