### PR TITLE
fix: eliminate QLayout double-assign, null pixmap typo, and AppImage startup warnings

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -105,6 +105,18 @@ jobs:
         # Create AppDir structure
         mkdir -p AppDir/usr/bin AppDir/usr/lib AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
         cp build/release/MaximumTrainer AppDir/usr/bin/
+        # QtWebEngine spell-checker tries to set a dictionaries path relative to
+        # the binary at startup and emits a WARNING if the directory is absent.
+        # Create the empty directories so the path-override succeeds (no dictionaries
+        # = spell-check disabled, unchanged from before).
+        mkdir -p AppDir/usr/bin/qtwebengine_dictionaries
+        mkdir -p AppDir/usr/libexec/qtwebengine_dictionaries
+        # linuxdeploy-plugin-qt sets FONTCONFIG_FILE="${APPDIR}/etc/fonts/fonts.conf"
+        # in the generated AppRun; bundle the build host's config so the packaged
+        # app can locate fonts on the user's machine instead of logging
+        # "Cannot load default config file: No such file: (null)".
+        mkdir -p AppDir/etc/fonts
+        cp /etc/fonts/fonts.conf AppDir/etc/fonts/ 2>/dev/null || true
         # Bundle the QWT shared library so the qt plugin / patchelf can resolve it
         cp -P "$QWT_DIR"/lib/libqwt.so* AppDir/usr/lib/
         # QtWebEngine dlopen()s these NSS modules at runtime, so linuxdeploy's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ make install INSTALL_ROOT=/tmp/qwt6-stage
 mkdir -p /tmp/qwt6 && mv /tmp/qwt6-stage/usr/local/qwt-6.3.0/* /tmp/qwt6/
 
 # 2. Build the app (from repo root):
-qmake6 PowerVelo.pro QWT_INSTALL=/tmp/qwt6
+qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6
 make -j$(nproc)
 
 # 3. Run (QWT in a non-standard prefix needs LD_LIBRARY_PATH):
@@ -39,7 +39,7 @@ LD_LIBRARY_PATH=/tmp/qwt6/lib ./build/release/MaximumTrainer
 ```
 
 - **qmake binary is `qmake6`** here (Qt 6.10 system install on Linux). CI pins Qt **6.7.3 LTS** — local Qt may be newer.
-- **The `.pro` file:** currently **`PowerVelo.pro`**. A rename to `MaximumTrainer.pro` is in flight (see In-flight work). If `PowerVelo.pro` is gone, use `MaximumTrainer.pro` — same file. The binary `TARGET` is always `MaximumTrainer`.
+- **The `.pro` file:** **`MaximumTrainer.pro`** (renamed from `PowerVelo.pro` in PR #227). The binary `TARGET` is always `MaximumTrainer`.
 - **Incremental builds:** after `qmake6`, just `make -j$(nproc)`. **A clean build needs `make clean` first** — stale `.obj` files can make `make` a silent no-op (`Nothing to be done for 'first'`) when only config changed.
 
 ### Verifying a change without a GUI session
@@ -143,14 +143,12 @@ Per `agents.md §7`:
 
 ---
 
-## In-flight work (as of 2026-06-06 — verify with `gh pr list` before relying on this)
+## In-flight work (as of 2026-06-07 — verify with `gh pr list` before relying on this)
 
-Open PRs (author maximus321, against upstream master):
-- **#227** — Qt6 combobox-slot fixes + dead-slot cleanup + `PowerVelo.pro` →
-  `MaximumTrainer.pro` rename + workout mini-graph perf throttle.
-- **#228** — swap `QwtSystemClock` → Qt's `QElapsedTimer` in the workout clock.
-
-Recently merged: dark-mode + OpenSSL AppImage fixes; QWT 6.2 → 6.3 bump.
+Recently merged: #227 (Qt6 combobox fixes + `MaximumTrainer.pro` rename + mini-graph throttle),
+#228 (`QwtSystemClock` → `QElapsedTimer`), #230 (dead-code sweep), #234 (zip error handling),
+#235 (`IntervalsIcuService` → `IntervalsIcuApi` rename), #236 (DataMetric CRTP template),
+#237 (Intervals OAuth URL fix), dark-mode + OpenSSL AppImage fixes, QWT 6.2 → 6.3 bump.
 
 The **workout dialog timer** is driven by a `Clock` QObject on a worker
 `QThread` ticking every 25ms; it derives elapsed seconds from a monotonic

--- a/src/ui/components/balancewidget.ui
+++ b/src/ui/components/balancewidget.ui
@@ -43,7 +43,6 @@ QGroupBox
 QGroupBox::title
 {
     subcontrol-origin: margin;	
-    background:url(:/assets/subWindowBackground);
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
     border: 1px solid #0b477b;

--- a/src/ui/components/infowidget.cpp
+++ b/src/ui/components/infowidget.cpp
@@ -262,7 +262,7 @@ void InfoWidget::setTypeInfoBox(TypeInfoBox type) {
     int size = 35;
     QPixmap pixmapPower = QPixmap(":/image/icon/power2");
     QPixmap pixmapCadence = QPixmap(":/image/icon/crank2");
-    QPixmap pixmapSpeed = QPixmap(":/image/icon/speed)");
+    QPixmap pixmapSpeed = QPixmap(":/image/icon/speed");
     QPixmap pixmapHr = QPixmap(":/image/icon/heart2");
     QPixmap pixmapTarget = QPixmap(":/image/icon/target");
 

--- a/src/ui/components/timewidget.ui
+++ b/src/ui/components/timewidget.ui
@@ -56,7 +56,6 @@ QGroupBox
 QGroupBox::title
 {
     subcontrol-origin: margin;	
-    background:url(:/assets/subWindowBackground);
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
     border: 1px solid #0b477b;

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -224,6 +224,7 @@ void DialogConfig::RadioDoubleClicked(QModelIndex index) {
     qDebug() << "Radio url is" << radio.getUrl();
 
 
+    isConnecting = true;
     QString status = tr("Connecting to ") + currentRadioName + "...";
     ui->label_statusRadio->setText(status);
     ui->label_statusRadio->fadeIn(400);
@@ -245,6 +246,7 @@ void DialogConfig::RadioDoubleClicked(QModelIndex index) {
 //---------------------------------------------------------------------------------------------
 void DialogConfig::radioStartedPlaying() {
 
+    isConnecting = false;
     QString status =  "<b>" + currentRadioName + "</b>";
     ui->label_statusRadio->setText(status);
     ui->label_statusRadio->fadeIn(400);
@@ -256,6 +258,14 @@ void DialogConfig::radioStartedPlaying() {
 }
 
 void DialogConfig::radioStoppedPlaying() {
+    // When switching stations the player briefly stops to change source.
+    // Re-emit the "Connecting to..." status so the top bar doesn't lose it.
+    if (isConnecting) {
+        QString status = tr("Connecting to ") + currentRadioName + "...";
+        emit radioStatus(status);
+        isPlayingRadio = false;
+        return;
+    }
     ui->label_statusRadio->setText("");
     emit radioStatus("");
 

--- a/src/ui/dialogconfig.h
+++ b/src/ui/dialogconfig.h
@@ -201,6 +201,7 @@ private:
     bool playOnNextSliderRelease;
 
     bool isPlayingRadio;
+    bool isConnecting = false;
 
     // Studio tab controls
     QCheckBox    *checkStudioMode   = nullptr;

--- a/src/ui/plots/workoutplot.cpp
+++ b/src/ui/plots/workoutplot.cpp
@@ -368,7 +368,7 @@ void WorkoutPlot::init(bool firstInit) {
 
         //------------------------------
         widgetCanvas = this->canvas();
-        QGridLayout *gridLayout = new QGridLayout(this);
+        QGridLayout *gridLayout = new QGridLayout();
         gridLayout->setContentsMargins(0, 0, 0, 0);
         gridLayout->setSpacing(0);
         gridLayout->setContentsMargins(0,0,0,0);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -392,7 +392,7 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
     widgetBattery->setAttribute(Qt::WA_TransparentForMouseEvents,true);
     widgetBattery->setFocusPolicy(Qt::NoFocus);
     QHBoxLayout *hLayout = new QHBoxLayout(widgetBattery);
-    QVBoxLayout *vLayoutSub = new QVBoxLayout(widgetBattery);
+    QVBoxLayout *vLayoutSub = new QVBoxLayout();
     hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     vLayoutSub->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

- **`workoutdialog.cpp`**: `QVBoxLayout` was constructed with `widgetBattery` as parent — a widget that already had `hLayout` set — causing `QLayout: Attempting to add QLayout "" to QWidget ""` on every workout dialog open. Fixed by constructing without a parent (it's added via `hLayout->addLayout()`).
- **`infowidget.cpp`**: Typo `":/image/icon/speed)"` (trailing `)` inside the string literal) produced an invalid resource path, making `QPixmap::scaled` warn `Pixmap is a null pixmap` four times at startup (once per InfoWidget). Fixed the string.
- **`workoutplot.cpp`**: Construct `QGridLayout` without parent before assigning to the canvas widget.
- **`balancewidget.ui` / `timewidget.ui`**: Removed dead CSS `background:url(:/assets/subWindowBackground)` referencing a resource that never existed in `MyResources.qrc`, causing `Could not create pixmap from :/assets/subWindowBackground` in the AppImage.
- **`release-linux.yml`**: Pre-create `qtwebengine_dictionaries` dirs and bundle `fonts.conf` to suppress `DIR_APP_DICTIONARIES` and fontconfig startup noise in the AppImage.
- **`dialogconfig.cpp/.h`** (radio): Add `isConnecting` flag so "Connecting to \<station\>…" appears in **both** the options panel and the top workout bar. Root cause: `QMediaPlayer::setSource()` synchronously fires `playbackStateChanged(Stopped)` inside `openUrlRadio()`, which triggered `radioStoppedPlaying()` → `radioStatus("")` and overwrote the "Connecting to…" in the top bar before the first repaint. The flag guards `radioStoppedPlaying()` during a station switch and re-emits the connecting status instead of clearing it.

## Test plan

- [ ] Build locally: `make clean && make -j$(nproc)`
- [ ] Confirm `QLayout: Attempting to add QLayout` and `QPixmap::scaled: Pixmap is a null pixmap` are absent from startup log
- [ ] Open the workout dialog — no layout warnings in console
- [ ] Open Options → Radio, double-click a station — "Connecting to \<station\>…" appears in **both** the options label and the top bar label; transitions to station name once streaming starts
- [ ] CI AppImage build passes and startup log is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
