### PR TITLE
refactor(workout-editor): dedupe step-type show-hide into a shared helper

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -13,8 +13,8 @@ Status legend: ☐ todo · ◐ in progress · ☑ done
 |-------|--------|----|
 | 1 — Dead-code sweep | ☑ done | #230 |
 | 2 — Hot-path guards | ☑ done (2 of 4 items; 2 evaluated and intentionally skipped) | #227 |
-| 3 — De-duplication via templates | ☐ todo (deferred) | — |
-| 4 — Latent naming hazard | ☑ done | (this PR) |
+| 3 — De-duplication via templates | ◐ partial (singletons done; editors in progress) | #236 |
+| 4 — Latent naming hazard | ☑ done | #235 |
 | 5 — Quick correctness fixes | ☑ done (1 of 3; 2 dropped after inspection) | #234 |
 | 6 — Large mechanical modernization | ☐ todo | — |
 
@@ -41,16 +41,18 @@ skipped (risk to core data paths for no measurable gain).
 - ⏭ **Skipped — `updateCurve` ring buffer** (`workoutplotzoomer.cpp`): the sample buffer is capped at **90** at 1-4 Hz, and Qwt's `setSamples` copies internally regardless. The original #1 audit ranking conflated this with the 40 Hz replot, which #227 already fixed.
 
 ## Group 3 — De-duplication via templates  ◐  (partial)
-- ☑ `DataPower/DataHeartRate/DataCadence/DataSpeed` — the four byte-identical singleton `.cpp` files (~590 lines) replaced by one CRTP base `DataMetricSingleton<Derived>` in `datametric.h`; each metric is now an ~11-line `final` subclass. Net −598 lines. Public API (`DataPower::instance().append()` etc.) unchanged; verified app builds + workout plots render live data. (The `CurveData*` wrappers were left as-is — they differ more than the audit implied and aren't pure boilerplate.)
-- ☐ `PowerEditor/HrEditor/CadenceEditor` — identical NONE/FLAT/PROGRESSIVE show-hide structure → a parameterised `MetricEditor`. (Still todo — separate change.)
+- ☑ `DataPower/DataHeartRate/DataCadence/DataSpeed` — the four byte-identical singleton `.cpp` files (~590 lines) replaced by one CRTP base `DataMetricSingleton<Derived>` in `datametric.h`; each metric is now an ~11-line `final` subclass. Net −598 lines. Public API (`DataPower::instance().append()` etc.) unchanged; verified app builds + workout plots render live data. (The `CurveData*` wrappers were left as-is — they differ more than the audit implied and aren't pure boilerplate.) **(PR #236)**
+- ◐ `PowerEditor/HrEditor/CadenceEditor` — the audit proposed one parameterised `MetricEditor`, but a full merge is **not** small/low-risk: the three diverge (Power adds L/R balance + test-interval; Power/HR have a unit toggle, Cadence doesn't) and each has its own `.ui` with a distinct `Ui::` namespace.
+  - ☑ **First step shipped:** extracted the one byte-identical part — the NONE/FLAT/PROGRESSIVE show-hide block in each `on_comboBox_*_currentIndexChanged` — into `MetricEditorVisibility::applyStepTypeVisibility(...)` (`metriceditorvisibility.h`). ~75 lines of triplicated visibility logic → 1 inline helper + 3 call sites. Verified: builds + workout-editor screenshot renders.
+  - ☐ Remaining (optional, larger): dedup the unit-toggle handlers (`on_comboBox_FTPorWatts` / `on_comboBox_LTHRorBpm`) and/or a fuller shared base. Lower value, more divergence — defer unless it pays off.
 
 ## Group 4 — Latent naming hazard  ☑
 - ☑ Two classes were both named `IntervalsIcuService` (static `intervals_icu_service.*` + QObject `intervalsicuservice.*`), both compiled in `db.pri` — an ODR/confusion trap. Renamed the static one to **`IntervalsIcuApi`** and its files to `intervals_icu_api.{h,cpp}`; updated `db.pri` and the 3 test projects that use it. The QObject `IntervalsIcuService` (used by the UI) is unchanged. Verified: app builds + the `intervals_icu_tests` unit suite passes (19/19).
 
-## Group 5 — Quick correctness fixes  ☐
-- ☐ `simplecrypt.cpp:~130` — unguarded `qrand()` (removed in Qt6) → `QRandomGenerator`. (Confirm it even compiles on Qt6 CI.)
-- ☐ `util.cpp:~859,~881` — `Util::zipFileToDisk`/`unzipFile` discard `QFile::open()` return → check + log + bail.
-- ☐ `selfloops_service.cpp:~31` — local `gzipCompress` duplicates `Util::zipFileHelperConvertToGzip` → call the util.
+## Group 5 — Quick correctness fixes  ☑  (1 of 3 shipped; 2 dropped after inspection — PR #234)
+- ☑ `util.cpp` — `Util::zipFileToDisk`/`unzipFile` discarded the `QFile::open()` return → now checked + logged + bailed. **(PR #234)**
+- ⏭ **Dropped** — `simplecrypt.cpp` `qrand()`: not actually present/broken on the current Qt6 tree; no change needed.
+- ⏭ **Dropped** — `selfloops_service.cpp` local `gzipCompress`: on inspection it diverges enough from `Util::zipFileHelperConvertToGzip` that folding it in added risk for no real gain.
 
 ## Group 6 — Large mechanical modernization (one PR per sweep; low-risk, big diff)  ☐
 - ☐ 243 string-based `connect(SIGNAL/SLOT)` → function-pointer syntax (compile-time checked). Worst: `workoutdialog.cpp` (96), `mainwindow.cpp` (66).

--- a/src/ui/workout_editor/cadenceeditor.cpp
+++ b/src/ui/workout_editor/cadenceeditor.cpp
@@ -1,5 +1,6 @@
 #include "cadenceeditor.h"
 #include "ui_cadenceeditor.h"
+#include "metriceditorvisibility.h"
 #include <QDebug>
 
 CadenceEditor::~CadenceEditor()
@@ -59,36 +60,15 @@ void CadenceEditor::on_comboBox_cadence_currentIndexChanged(int index)
     Interval::StepType typeStep = static_cast<Interval::StepType>(index);
     myInterval.setCadenceStepType(typeStep);
 
-
-    /// change interface (hide/show widgets)
-    if (index == 0) { ///None
-        ui->spinBox_cadenceStart->setVisible(false);
-        ui->label_toCadenceTxt->setVisible(false);
-        ui->spinBox_cadenceEnd->setVisible(false);
-        ui->label_cadenceRpmTxt->setVisible(false);
-        ui->label_acceptedCadence->setVisible(false);
-        ui->spinBox_rangeCadence->setVisible(false);
-        ui->label_accptedRpmTxt->setVisible(false);
-    }
-    else if (index == 1) { ///FLAT
-        ui->spinBox_cadenceEnd->setVisible(false);
-        ui->label_toCadenceTxt->setVisible(false);
-
-        ui->spinBox_cadenceStart->setVisible(true);
-        ui->label_cadenceRpmTxt->setVisible(true);
-        ui->label_acceptedCadence->setVisible(true);
-        ui->spinBox_rangeCadence->setVisible(true);
-        ui->label_accptedRpmTxt->setVisible(true);
-    }
-    else { ///2- Progressive
-        ui->spinBox_cadenceStart->setVisible(true);
-        ui->label_toCadenceTxt->setVisible(true);
-        ui->spinBox_cadenceEnd->setVisible(true);
-        ui->label_cadenceRpmTxt->setVisible(true);
-        ui->label_acceptedCadence->setVisible(true);
-        ui->spinBox_rangeCadence->setVisible(true);
-        ui->label_accptedRpmTxt->setVisible(true);
-    }
+    MetricEditorVisibility::applyStepTypeVisibility(
+        index,
+        ui->spinBox_cadenceStart,
+        ui->label_toCadenceTxt,
+        ui->spinBox_cadenceEnd,
+        ui->label_cadenceRpmTxt,
+        ui->label_acceptedCadence,
+        ui->spinBox_rangeCadence,
+        ui->label_accptedRpmTxt);
 }
 
 

--- a/src/ui/workout_editor/hreditor.cpp
+++ b/src/ui/workout_editor/hreditor.cpp
@@ -1,5 +1,6 @@
 #include "hreditor.h"
 #include "ui_hreditor.h"
+#include "metriceditorvisibility.h"
 #include <QDebug>
 
 HrEditor::~HrEditor()
@@ -76,36 +77,15 @@ void HrEditor::on_comboBox_hr_currentIndexChanged(int index)
     Interval::StepType typeStep = static_cast<Interval::StepType>(hrStepType);
     myInterval.setHrStepType(typeStep);
 
-
-    /// change interface (hide/show widgets)
-    if (index == 0) { ///None
-        ui->spinBox_lthrStart->setVisible(false);
-        ui->label_toLthrTxt->setVisible(false);
-        ui->spinBox_lthrEnd->setVisible(false);
-        ui->comboBox_LTHRorBpm->setVisible(false);
-        ui->label_acceptedLthr->setVisible(false);
-        ui->spinBox_rangeLthr->setVisible(false);
-        ui->label_accptedBpmTxt->setVisible(false);
-    }
-    else if (index == 1) { ///FLAT
-        ui->spinBox_lthrEnd->setVisible(false);
-        ui->label_toLthrTxt->setVisible(false);
-
-        ui->spinBox_lthrStart->setVisible(true);
-        ui->comboBox_LTHRorBpm->setVisible(true);
-        ui->label_acceptedLthr->setVisible(true);
-        ui->spinBox_rangeLthr->setVisible(true);
-        ui->label_accptedBpmTxt->setVisible(true);
-    }
-    else { ///2- Progressive
-        ui->spinBox_lthrStart->setVisible(true);
-        ui->label_toLthrTxt->setVisible(true);
-        ui->spinBox_lthrEnd->setVisible(true);
-        ui->comboBox_LTHRorBpm->setVisible(true);
-        ui->label_acceptedLthr->setVisible(true);
-        ui->spinBox_rangeLthr->setVisible(true);
-        ui->label_accptedBpmTxt->setVisible(true);
-    }
+    MetricEditorVisibility::applyStepTypeVisibility(
+        index,
+        ui->spinBox_lthrStart,
+        ui->label_toLthrTxt,
+        ui->spinBox_lthrEnd,
+        ui->comboBox_LTHRorBpm,
+        ui->label_acceptedLthr,
+        ui->spinBox_rangeLthr,
+        ui->label_accptedBpmTxt);
 }
 
 

--- a/src/ui/workout_editor/metriceditorvisibility.h
+++ b/src/ui/workout_editor/metriceditorvisibility.h
@@ -1,0 +1,42 @@
+#ifndef METRICEDITORVISIBILITY_H
+#define METRICEDITORVISIBILITY_H
+
+#include <QWidget>
+
+// PowerEditor / HrEditor / CadenceEditor share an identical
+// None / Flat / Progressive show-hide layout driven by their step-type
+// combobox. The widget set is the same shape in every editor — only the
+// concrete ui-> pointers differ — so the visibility rule lives here once.
+//
+// stepTypeIndex: 0 = None (hide everything), 1 = Flat (single target, no
+// "to" range), anything else = Progressive (start..end range).
+namespace MetricEditorVisibility {
+
+inline void applyStepTypeVisibility(int stepTypeIndex,
+                                    QWidget *startSpinBox,
+                                    QWidget *toLabel,
+                                    QWidget *endSpinBox,
+                                    QWidget *unitWidget,
+                                    QWidget *acceptedRangeLabel,
+                                    QWidget *rangeSpinBox,
+                                    QWidget *acceptedUnitLabel)
+{
+    const bool isNone = (stepTypeIndex == 0);
+    const bool isFlat = (stepTypeIndex == 1);
+
+    const bool showCommonControls = !isNone;            // Flat or Progressive
+    const bool showEndTarget = !isNone && !isFlat;      // Progressive only
+
+    startSpinBox->setVisible(showCommonControls);
+    unitWidget->setVisible(showCommonControls);
+    acceptedRangeLabel->setVisible(showCommonControls);
+    rangeSpinBox->setVisible(showCommonControls);
+    acceptedUnitLabel->setVisible(showCommonControls);
+
+    toLabel->setVisible(showEndTarget);
+    endSpinBox->setVisible(showEndTarget);
+}
+
+} // namespace MetricEditorVisibility
+
+#endif // METRICEDITORVISIBILITY_H

--- a/src/ui/workout_editor/powereditor.cpp
+++ b/src/ui/workout_editor/powereditor.cpp
@@ -1,5 +1,6 @@
 #include "powereditor.h"
 #include "ui_powereditor.h"
+#include "metriceditorvisibility.h"
 
 #include <QDebug>
 #include <QPainter>
@@ -82,39 +83,15 @@ void PowerEditor::on_comboBox_power_currentIndexChanged(int index)
     Interval::StepType typeStep = static_cast<Interval::StepType>(index);
     myInterval.setPowerStepType(typeStep);
 
-
-    /// change interface (hide/show widgets)
-    //////////////////////////////////////////////////////////////////////////////////////////
-
-    if (index == 0) { ///None
-        ui->spinBox_ftpStart->setVisible(false);
-        ui->label_toFtpTxt->setVisible(false);
-        ui->spinBox_ftpEnd->setVisible(false);
-        ui->comboBox_FTPorWatts->setVisible(false);
-        ui->label_acceptedPower->setVisible(false);
-        ui->spinBox_rangePower->setVisible(false);
-        ui->label_accptedWattsTxt->setVisible(false);
-
-    }
-    else if (index == 1) { ///FLAT
-        ui->spinBox_ftpEnd->setVisible(false);
-        ui->label_toFtpTxt->setVisible(false);
-
-        ui->spinBox_ftpStart->setVisible(true);
-        ui->comboBox_FTPorWatts->setVisible(true);
-        ui->label_acceptedPower->setVisible(true);
-        ui->spinBox_rangePower->setVisible(true);
-        ui->label_accptedWattsTxt->setVisible(true);
-    }
-    else { ///2- Progressive
-        ui->spinBox_ftpStart->setVisible(true);
-        ui->label_toFtpTxt->setVisible(true);
-        ui->spinBox_ftpEnd->setVisible(true);
-        ui->comboBox_FTPorWatts->setVisible(true);
-        ui->label_acceptedPower->setVisible(true);
-        ui->spinBox_rangePower->setVisible(true);
-        ui->label_accptedWattsTxt->setVisible(true);
-    }
+    MetricEditorVisibility::applyStepTypeVisibility(
+        index,
+        ui->spinBox_ftpStart,
+        ui->label_toFtpTxt,
+        ui->spinBox_ftpEnd,
+        ui->comboBox_FTPorWatts,
+        ui->label_acceptedPower,
+        ui->spinBox_rangePower,
+        ui->label_accptedWattsTxt);
 }
 
 

--- a/src/ui/workout_editor/workout_editor.pri
+++ b/src/ui/workout_editor/workout_editor.pri
@@ -27,7 +27,8 @@ HEADERS +=\
     $$PWD/intervalviewstyle.h \
     $$PWD/myqwtpickermachine.h \
     $$PWD/myqwtplotpicker.h \
-    $$PWD/repeatincreaseeditor.h
+    $$PWD/repeatincreaseeditor.h \
+    $$PWD/metriceditorvisibility.h
 
 FORMS += \
     $$PWD/repeatwidget.ui \


### PR DESCRIPTION
## What

Group 3 (de-duplication) follow-up. `PowerEditor`, `HrEditor`, and
`CadenceEditor` each carried a **byte-identical** NONE/FLAT/PROGRESSIVE
show-hide block inside their step-type combobox slot. This hoists that one
genuinely-shared piece into:

```cpp
MetricEditorVisibility::applyStepTypeVisibility(index, startSpin, toLabel,
    endSpin, unitWidget, acceptedRangeLabel, rangeSpin, acceptedUnitLabel);
```

(`src/ui/workout_editor/metriceditorvisibility.h`). ~75 lines of triplicated
visibility logic collapse to one inline helper + 3 call sites.

## Why this and not a full `MetricEditor`

The original audit proposed merging all three into one parameterised
`MetricEditor`. That is **not** a small/low-risk change: the editors genuinely
diverge — Power adds L/R balance + a test-interval checkbox, Power/HR have a
%/absolute unit toggle that Cadence lacks, and each owns a separate `.ui` with
its own `Ui::` namespace. This PR ships the one part that *is* identical and
defers the rest (noted in `REFACTOR_PLAN.md`).

## Also

Reconciles `REFACTOR_PLAN.md` bookkeeping: Group 3 → partial (singletons done
via #236, editors in progress), Group 4 PR # corrected to #235, and the Group 5
detail section squared with its progress snapshot (1 item shipped via #234, 2
dropped after inspection).

## Verification

- Clean `qmake6` + `make` build is green.
- Headless `--screenshots` run renders the workout editor correctly (FLAT and
  PROGRESSIVE rows display as before).
- Logic verified equivalent line-by-line against all three original slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
