### PR TITLE
cleanup: remove dead ANT remnants (ANT+ no longer supported)

### DIFF
--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -94,7 +94,6 @@ Account::Account(QObject *parent) : QObject(parent)  {
 
 
     // -----------------------------------  Settings ----------------------------------------------------------------------
-    nb_ant_stick = 1;
     nb_user_studio = 3;
     enable_studio_mode = false;
     use_pm_for_cadence = false;

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -87,7 +87,6 @@ public:
 
 
     // -----------------------------------  Settings ----------------------------------------------------------------------
-    int nb_ant_stick;
     int nb_user_studio;
     bool enable_studio_mode;
     bool use_pm_for_cadence;

--- a/src/ui/dialogmainwindowconfig.cpp
+++ b/src/ui/dialogmainwindowconfig.cpp
@@ -282,15 +282,15 @@ void DialogMainWindowConfig::stravaLabelClicked() {
 void DialogMainWindowConfig::trainingPeaksLabelClicked() {
 
 
-    DialogInfoWebView infoAntStick;
+    DialogInfoWebView trainingPeaksInfoView;
 
-    infoAntStick.setTitle(tr("Connect MaximumTrainer with your TrainingPeaks account"));
-    infoAntStick.setUsedForTrainingPeaks(true);
-    connect(&infoAntStick, SIGNAL(trainingPeaksLinked(bool)), this, SLOT(trainingPeaksLinked(bool)) );
-    infoAntStick.setUrlWebView(Environnement::getURLTrainingPeaksAuthorize());
+    trainingPeaksInfoView.setTitle(tr("Connect MaximumTrainer with your TrainingPeaks account"));
+    trainingPeaksInfoView.setUsedForTrainingPeaks(true);
+    connect(&trainingPeaksInfoView, SIGNAL(trainingPeaksLinked(bool)), this, SLOT(trainingPeaksLinked(bool)) );
+    trainingPeaksInfoView.setUrlWebView(Environnement::getURLTrainingPeaksAuthorize());
 
     qDebug() << "TP URL IS : " << Environnement::getURLTrainingPeaksAuthorize();
-    infoAntStick.exec();
+    trainingPeaksInfoView.exec();
 
 }
 


### PR DESCRIPTION
## What

ANT+ protocol support was dropped when the app moved to BLE; a few vestigial
references lingered. This removes the **genuinely-dead** ones:

- `Account::nb_ant_stick` — initialised to `1` in the constructor and never
  read again, never serialized to the DB/account file. Pure dead config.
- `DialogMainWindowConfig` — the **TrainingPeaks** info dialog's local variable
  was misleadingly named `infoAntStick` (copy-paste leftover). Renamed to
  `trainingPeaksInfoView` to match what it actually is.

## What this deliberately does NOT touch

These *look* like ANT but are load-bearing — removing them would break the
build / live sensor handling:

- `Sensor::getAntId()` and the `int antID` parameters in `workoutdialog` /
  `dialogcalibrate` / `dialogcalibratepm` — this is the **generic per-device
  id** used throughout live BLE pairing, calibration and ERG control (9 call
  sites). A rename to `deviceId` is a mechanical Group-6 job, not a removal.
- `m_ergSmoothAntID` — the ERG smoothing target's device id (same story).
- `src/fitness/fit/*` (`ant_channel_id_mesg`, `antplus_device_type`,
  `ant_enabled`, `source_type == ant`) — **vendored Garmin FIT SDK**; these are
  part of the `.fit` file format, not our ANT support.

Net: ANT+ support is already gone — only cosmetic remnants remained, and those
are what this cleans up.

## Verification

- Clean `qmake6` + `make` build is green (removing the `account.h` field
  recompiles all its dependents).
- Headless `--screenshots` run renders all 8 screens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
