### PR TITLE
ui(editor): bigger/clearer popups, native buttons, responsive columns

### DIFF
--- a/src/ui/workout_editor/cadenceeditor.cpp
+++ b/src/ui/workout_editor/cadenceeditor.cpp
@@ -35,6 +35,8 @@ CadenceEditor::CadenceEditor(QWidget *parent) :
 
     ui->gridLayout->setRowMinimumHeight(0,45);
     ui->gridLayout->setRowMinimumHeight(1,45);
+
+    MetricEditorVisibility::applyNativeOkCancelButtons(ui->pushButton_ok, ui->pushButton_default);
 }
 
 
@@ -95,10 +97,5 @@ void CadenceEditor::on_pushButton_ok_clicked()
 
 void CadenceEditor::on_pushButton_default_clicked()
 {
-    this->myInterval.setCadenceStepType(Interval::StepType::NONE);
-    this->myInterval.setTargetCadence_start(90);
-    this->myInterval.setTargetCadence_end(90);
-    this->myInterval.setTargetCadence_range(5);
-    emit endEdit();
-
+    emit cancelEdit();
 }

--- a/src/ui/workout_editor/cadenceeditor.h
+++ b/src/ui/workout_editor/cadenceeditor.h
@@ -23,6 +23,7 @@ public:
 
 signals:
     void endEdit();
+    void cancelEdit();
 
 private slots:
     void on_comboBox_cadence_currentIndexChanged(int index);

--- a/src/ui/workout_editor/hreditor.cpp
+++ b/src/ui/workout_editor/hreditor.cpp
@@ -36,6 +36,8 @@ HrEditor::HrEditor(QWidget *parent) :
 
     ui->gridLayout->setRowMinimumHeight(0,45);
     ui->gridLayout->setRowMinimumHeight(1,45);
+
+    MetricEditorVisibility::applyNativeOkCancelButtons(ui->pushButton_ok, ui->pushButton_default);
 }
 
 
@@ -133,11 +135,7 @@ void HrEditor::on_pushButton_ok_clicked()
 
 void HrEditor::on_pushButton_default_clicked()
 {
-    this->myInterval.setHrStepType(Interval::StepType::NONE);
-    this->myInterval.setTargetHR_start(0.5);
-    this->myInterval.setTargetHR_end(0.5);
-    this->myInterval.setTargetHR_range(15);
-    emit endEdit();
+    emit cancelEdit();
 }
 
 

--- a/src/ui/workout_editor/hreditor.h
+++ b/src/ui/workout_editor/hreditor.h
@@ -22,6 +22,7 @@ public:
 
 signals :
     void endEdit();
+    void cancelEdit();
 
 private slots:
     void on_comboBox_hr_currentIndexChanged(int index);

--- a/src/ui/workout_editor/intervaldelegate.cpp
+++ b/src/ui/workout_editor/intervaldelegate.cpp
@@ -54,19 +54,22 @@ QWidget *IntervalDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     /// Power
     else if (index.column() == 2 ) {
         PowerEditor *editor = new PowerEditor(parent);
-        connect (editor, SIGNAL(endEdit()), this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(endEdit()),    this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(cancelEdit()), this, SLOT(cancelWidgetEditor()) );
         return editor;
     }
     /// Cadence
     else if (index.column() == 3 ) {
         CadenceEditor *editor = new CadenceEditor(parent);
-        connect (editor, SIGNAL(endEdit()), this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(endEdit()),    this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(cancelEdit()), this, SLOT(cancelWidgetEditor()) );
         return editor;
     }
-    /// Cadence
+    /// Heart Rate
     else if (index.column() == 4 ) {
         HrEditor *editor = new HrEditor(parent);
-        connect (editor, SIGNAL(endEdit()), this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(endEdit()),    this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(cancelEdit()), this, SLOT(cancelWidgetEditor()) );
         return editor;
     }
     /// Display Msg
@@ -77,7 +80,8 @@ QWidget *IntervalDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     /// Repeat Perc
     else if (index.column() == 6 ) {
         RepeatIncreaseEditor *editor = new RepeatIncreaseEditor(parent);
-        connect (editor, SIGNAL(endEdit()), this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(endEdit()),    this, SLOT(closeWidgetEditor()) );
+        connect (editor, SIGNAL(cancelEdit()), this, SLOT(cancelWidgetEditor()) );
         return editor;
 
     }
@@ -94,6 +98,16 @@ void IntervalDelegate::closeWidgetEditor() {
     QWidget *editor = qobject_cast<QWidget*>(sender());
 
     emit commitData(editor);
+    emit closeEditor(editor);
+
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+void IntervalDelegate::cancelWidgetEditor() {
+
+    // Close without committing — discards the edit (Cancel button).
+    QWidget *editor = qobject_cast<QWidget*>(sender());
     emit closeEditor(editor);
 
 }
@@ -222,10 +236,10 @@ void IntervalDelegate::updateEditorGeometry(QWidget *editor,  const QStyleOption
         editor->setGeometry(option.rect.x(), option.rect.y(), 350, 90);
         editor->move(editor->parentWidget()->mapToGlobal(option.rect.topLeft()));
     }
-    /// HR
+    /// Repeat Change
     else if  (index.column() == 6) {
         editor->setWindowFlags(Qt::Popup);
-        editor->setGeometry(option.rect.x(), option.rect.y(), 300, 90);
+        editor->setGeometry(option.rect.x(), option.rect.y(), 490, 150);
         editor->move(editor->parentWidget()->mapToGlobal(option.rect.topLeft()));
     }
 

--- a/src/ui/workout_editor/intervaldelegate.h
+++ b/src/ui/workout_editor/intervaldelegate.h
@@ -29,6 +29,7 @@ signals:
 
 public slots:
     void closeWidgetEditor();
+    void cancelWidgetEditor();
 
 private :
 

--- a/src/ui/workout_editor/metriceditorvisibility.h
+++ b/src/ui/workout_editor/metriceditorvisibility.h
@@ -2,6 +2,8 @@
 #define METRICEDITORVISIBILITY_H
 
 #include <QWidget>
+#include <QPushButton>
+#include <QStyle>
 
 // PowerEditor / HrEditor / CadenceEditor share an identical
 // None / Flat / Progressive show-hide layout driven by their step-type
@@ -35,6 +37,20 @@ inline void applyStepTypeVisibility(int stepTypeIndex,
 
     toLabel->setVisible(showEndTarget);
     endSpinBox->setVisible(showEndTarget);
+}
+
+// The editors share two icon-only action buttons. Give them the native OS
+// Ok/Cancel icons (matching the Repeat-change editor) and drop any text so they
+// stay compact.
+inline void applyNativeOkCancelButtons(QPushButton *okButton, QPushButton *cancelButton)
+{
+    okButton->setText(QString());
+    okButton->setIcon(okButton->style()->standardIcon(QStyle::SP_DialogOkButton));
+    okButton->setToolTip(QObject::tr("Confirm"));
+
+    cancelButton->setText(QString());
+    cancelButton->setIcon(cancelButton->style()->standardIcon(QStyle::SP_DialogCancelButton));
+    cancelButton->setToolTip(QObject::tr("Cancel"));
 }
 
 } // namespace MetricEditorVisibility

--- a/src/ui/workout_editor/powereditor.cpp
+++ b/src/ui/workout_editor/powereditor.cpp
@@ -43,6 +43,7 @@ PowerEditor::PowerEditor(QWidget *parent) : QWidget(parent),ui(new Ui::PowerEdit
     ui->gridLayout->setRowMinimumHeight(0,45);
     ui->gridLayout->setRowMinimumHeight(1,45);
 
+    MetricEditorVisibility::applyNativeOkCancelButtons(ui->pushButton_ok, ui->pushButton_default);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -212,15 +213,7 @@ void PowerEditor::on_pushButton_ok_clicked()
 
 void PowerEditor::on_pushButton_default_clicked()
 {
-
-    this->myInterval.setPowerStepType(Interval::StepType::NONE);
-    this->myInterval.setTargetFTP_start(0.60);
-    this->myInterval.setTargetFTP_end(0.60);
-    this->myInterval.setTargetFTP_range(20);
-    this->myInterval.setTestInterval(false);
-    this->myInterval.setRightPowerTarget(-1);
-
-    emit endEdit();
+    emit cancelEdit();
 }
 
 

--- a/src/ui/workout_editor/powereditor.h
+++ b/src/ui/workout_editor/powereditor.h
@@ -24,6 +24,7 @@ public:
 
 signals :
     void endEdit();
+    void cancelEdit();
 
 
 private slots:

--- a/src/ui/workout_editor/repeatincreaseeditor.cpp
+++ b/src/ui/workout_editor/repeatincreaseeditor.cpp
@@ -2,6 +2,8 @@
 #include "ui_repeatincreaseeditor.h"
 
 #include <QDebug>
+#include <QPushButton>
+#include <QStyle>
 
 
 RepeatIncreaseEditor::~RepeatIncreaseEditor()
@@ -30,9 +32,23 @@ RepeatIncreaseEditor::RepeatIncreaseEditor(QWidget *parent) :
 
 
 
-    ui->gridLayout->setRowMinimumHeight(0,80);
-    ui->gridLayout->setRowMinimumHeight(1,10);
+    ui->gridLayout->setRowMinimumHeight(0,26);
+    ui->gridLayout->setRowMinimumHeight(1,56);
+    ui->gridLayout->setRowMinimumHeight(2,34);
 
+    // Native Ok/Cancel button box: Ok confirms, Cancel discards the edit.
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &RepeatIncreaseEditor::endEdit);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &RepeatIncreaseEditor::cancelEdit);
+
+    // Icon-only buttons (drop the text) so they take less room.
+    if (QPushButton *ok = ui->buttonBox->button(QDialogButtonBox::Ok)) {
+        ok->setText(QString());
+        ok->setIcon(style()->standardIcon(QStyle::SP_DialogOkButton));
+    }
+    if (QPushButton *cancel = ui->buttonBox->button(QDialogButtonBox::Cancel)) {
+        cancel->setText(QString());
+        cancel->setIcon(style()->standardIcon(QStyle::SP_DialogCancelButton));
+    }
 }
 
 
@@ -52,13 +68,6 @@ void RepeatIncreaseEditor::setInterval(const Interval &interval) {
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
-void RepeatIncreaseEditor::on_pushButton_ok_clicked()
-{
-    emit endEdit();
-}
-
-
-//////////////////////////////////////////////////////////////////////////////////////////
 void RepeatIncreaseEditor::on_doubleSpinBox_increaseFTP_valueChanged(double arg1)
 {
     myInterval.setRepeatIncreaseFTP(arg1);
@@ -73,12 +82,4 @@ void RepeatIncreaseEditor::on_spinBox_increaseCadence_valueChanged(int arg1)
 void RepeatIncreaseEditor::on_doubleSpinBox_increaseLTHR_valueChanged(double arg1)
 {
     myInterval.setRepeatIncreaseLTHR(arg1);
-}
-
-void RepeatIncreaseEditor::on_pushButton_default_clicked()
-{
-    this->myInterval.setRepeatIncreaseFTP(0);
-    this->myInterval.setRepeatIncreaseCadence(0);
-    this->myInterval.setRepeatIncreaseLTHR(0);
-    emit endEdit();
 }

--- a/src/ui/workout_editor/repeatincreaseeditor.h
+++ b/src/ui/workout_editor/repeatincreaseeditor.h
@@ -21,18 +21,15 @@ public:
 
 signals:
     void endEdit();
+    void cancelEdit();
 
 
 private slots:
-    void on_pushButton_ok_clicked();
-
     void on_doubleSpinBox_increaseFTP_valueChanged(double arg1);
 
     void on_spinBox_increaseCadence_valueChanged(int arg1);
 
     void on_doubleSpinBox_increaseLTHR_valueChanged(double arg1);
-
-    void on_pushButton_default_clicked();
 
 private:
     Ui::RepeatIncreaseEditor *ui;

--- a/src/ui/workout_editor/repeatincreaseeditor.ui
+++ b/src/ui/workout_editor/repeatincreaseeditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>426</width>
-    <height>100</height>
+    <width>490</width>
+    <height>150</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,13 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>100</height>
+    <height>150</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>16777215</width>
-    <height>100</height>
+    <height>150</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -59,17 +59,17 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QGroupBox" name="groupBox_2">
         <property name="minimumSize">
          <size>
-          <width>110</width>
+          <width>150</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>110</width>
+          <width>150</width>
           <height>16777215</height>
          </size>
         </property>
@@ -92,7 +92,7 @@
          <item>
           <widget class="QSpinBox" name="spinBox_increaseCadence">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -117,17 +117,17 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QGroupBox" name="groupBox">
         <property name="minimumSize">
          <size>
-          <width>110</width>
+          <width>150</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>110</width>
+          <width>150</width>
           <height>16777215</height>
          </size>
         </property>
@@ -153,7 +153,7 @@
          <item>
           <widget class="QDoubleSpinBox" name="doubleSpinBox_increaseFTP">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -175,17 +175,17 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="2">
+      <item row="1" column="2">
        <widget class="QGroupBox" name="groupBox_3">
         <property name="minimumSize">
          <size>
-          <width>115</width>
+          <width>150</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>110</width>
+          <width>150</width>
           <height>16777215</height>
          </size>
         </property>
@@ -211,7 +211,7 @@
          <item>
           <widget class="QDoubleSpinBox" name="doubleSpinBox_increaseLTHR">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -236,81 +236,19 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Each Repeat, Increase/Decrease Target by</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_default">
-          <property name="minimumSize">
-           <size>
-            <width>60</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Reset to default</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../MyResources.qrc">
-            <normaloff>:/image/icon/delete</normaloff>:/image/icon/delete</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_ok">
-          <property name="minimumSize">
-           <size>
-            <width>60</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Confirm</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../MyResources.qrc">
-            <normaloff>:/image/icon/check</normaloff>:/image/icon/check</iconset>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="0" colspan="3">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Each Repeat, Increase/Decrease Target by:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/workout_editor/repeatwidget.cpp
+++ b/src/ui/workout_editor/repeatwidget.cpp
@@ -1,7 +1,9 @@
 #include "repeatwidget.h"
 #include "ui_repeatwidget.h"
+#include "themedicon.h"
 #include <QLabel>
 #include <QDebug>
+#include <QStyle>
 
 RepeatWidget::~RepeatWidget() {
     delete ui;
@@ -23,10 +25,16 @@ RepeatWidget::RepeatWidget(RepeatData *data, QWidget *parent) :
     ui->setupUi(this);
 
 
-    QIcon iconRepeat(":/image/icon/repeat");
+    // Tint the repeat glyph to the palette text colour so it stays visible in
+    // both light and dark themes (the bundled icon is dark).
+    const QColor glyphColor = palette().color(QPalette::WindowText);
+    QIcon iconRepeat = tintedIcon(":/image/icon/repeat", glyphColor);
     for (int i=0; i<ui->comboBox_repeat->count(); i++)
         ui->comboBox_repeat->setItemIcon(i, iconRepeat);
     setMouseTracking(true);
+
+    // Native close (X) icon for removing the repeat block.
+    ui->pushButton_delete->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
 
 
     setWindowFlags(Qt::WindowStaysOnTopHint);

--- a/src/ui/workout_editor/themedicon.h
+++ b/src/ui/workout_editor/themedicon.h
@@ -1,0 +1,35 @@
+#ifndef THEMEDICON_H
+#define THEMEDICON_H
+
+#include <QIcon>
+#include <QPixmap>
+#include <QPainter>
+#include <QColor>
+
+// Recolour a monochrome glyph (e.g. resources/images/repeat.png) to `color`,
+// using the source alpha as a mask. The bundled icons are dark and vanish on a
+// dark background; tinting them to the palette text colour keeps them visible
+// under both light and dark themes.
+inline QPixmap tintedPixmap(const QString &resourcePath, const QColor &color)
+{
+    QPixmap src(resourcePath);
+    if (src.isNull())
+        return src;
+
+    QPixmap out(src.size());
+    out.fill(Qt::transparent);
+    QPainter p(&out);
+    p.drawPixmap(0, 0, src);
+    p.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    p.fillRect(out.rect(), color);
+    p.end();
+    return out;
+}
+
+inline QIcon tintedIcon(const QString &resourcePath, const QColor &color)
+{
+    const QPixmap pm = tintedPixmap(resourcePath, color);
+    return pm.isNull() ? QIcon(resourcePath) : QIcon(pm);
+}
+
+#endif // THEMEDICON_H

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -12,6 +12,7 @@
 
 
 #include "intervaldelegate.h"
+#include "themedicon.h"
 #include "util.h"
 #include "account.h"
 #include "xmlutil.h"
@@ -31,6 +32,11 @@ WorkoutCreator::~WorkoutCreator()
 WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::WorkoutCreator)
 {
     ui->setupUi(this);
+
+    // The repeat glyph is a dark icon; tint it to the palette text colour so it
+    // is visible in both light and dark themes.
+    ui->pushButton_repeat->setIcon(
+        tintedIcon(":/image/icon/repeat", palette().color(QPalette::ButtonText)));
 
     this->account = qApp->property("Account").value<Account*>();
 
@@ -85,32 +91,17 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
 
 
 
-    ui->tableView->setColumnWidth(0, 35);  //drag selector
-    ui->tableView->setColumnWidth(1, 90);  //time
-    ui->tableView->setColumnWidth(2, 160); //power
-    ui->tableView->setColumnWidth(3, 160); //cadence
-    ui->tableView->setColumnWidth(4, 160); //hr
-    ui->tableView->setColumnWidth(5, 130); // display message
-    ui->tableView->setColumnWidth(6, 130); // dummy column
-    ui->tableView->setColumnWidth(7, 130); // dummy column
-
-
     //Connect Edit trigger (fix bug that sometimes select Cell instead of edit, TOFIX: edit: editing failed on columns not editable..)
     connect(ui->tableView, SIGNAL(clicked(QModelIndex)), ui->tableView, SLOT(edit(QModelIndex)));
 
-
-    widthLast2Column = ui->tableView->columnWidth(ui->tableView->model()->columnCount()-1);
-    //    widthLast2Column += ui->tableView->columnWidth(ui->tableView->model()->columnCount()-2);
-    totalWidthColumms = 0;
-    for (int i=0; i<ui->tableView->model()->columnCount(); i++) {
-        totalWidthColumms += ui->tableView->columnWidth(i);
-    }
-    //    qDebug() << "totalWidgthColumn :" << totalWidthColumms;
+    // Column widths are distributed responsively to fill the table — see
+    // distributeColumnWidths(), driven by the viewport resize below.
+    ui->tableView->viewport()->installEventFilter(this);
 
 
 
 
-    ui->tableView->verticalHeader()->setDefaultSectionSize(50); //55
+    ui->tableView->verticalHeader()->setDefaultSectionSize(70); //55
 
     ui->tableView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->tableView->verticalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -118,6 +109,8 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
     /// Disable resize vertical header
     ui->tableView->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
     ui->tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+
+    distributeColumnWidths();
 
 
     ui->tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -136,7 +129,8 @@ WorkoutCreator::WorkoutCreator(QWidget *parent) : QWidget(parent), ui(new Ui::Wo
 
 
     contextMenu = new QMenu(this);
-    actionRepeat = contextMenu->addAction(QIcon(":/image/icon/repeat"), tr("Repeat"));
+    actionRepeat = contextMenu->addAction(
+        tintedIcon(":/image/icon/repeat", palette().color(QPalette::WindowText)), tr("Repeat"));
     actionCopy = contextMenu->addAction(QIcon(":/image/icon/copy"), tr("Copy"));
     actionDelete = contextMenu->addAction(QIcon(":/image/icon/delete"), tr("Delete"));
 
@@ -631,6 +625,69 @@ void WorkoutCreator::on_pushButton_delete_clicked()
 
     ajustRepeatWidgetPosition();
 
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// Spread the table's width across the columns so it always fills the viewport:
+// it stays usable on small screens and takes advantage of large ones. Column 0
+// (the drag handle) keeps a fixed narrow width; the rest share the remaining
+// width by weight, preserving the previous proportions.
+void WorkoutCreator::distributeColumnWidths() {
+
+    if (!ui->tableView->model())
+        return;
+
+    const int columnCount = ui->tableView->model()->columnCount();
+    if (columnCount < 8)
+        return;
+
+    const int handleWidth = 35;
+    ui->tableView->setColumnWidth(0, handleWidth);
+
+    // Weights for columns 1..7: Duration, Power, Cadence, Heart Rate,
+    // Display Message, Repeat Change, # Repeat.
+    static const double weight[8] = { 0.0, 1.1, 2.1, 2.1, 2.1, 2.1, 1.75, 1.6 };
+    double totalWeight = 0.0;
+    for (int c = 1; c < columnCount && c < 8; ++c)
+        totalWeight += weight[c];
+    if (totalWeight <= 0.0)
+        return;
+
+    const int available = ui->tableView->viewport()->width() - handleWidth;
+    if (available <= 0)
+        return;
+
+    int used = 0;
+    for (int c = 1; c < columnCount; ++c) {
+        int columnWidth;
+        if (c == columnCount - 1) {
+            columnWidth = available - used;            // last column absorbs rounding
+        } else {
+            const double w = (c < 8) ? weight[c] : 1.0;
+            columnWidth = int(available * w / totalWeight);
+            used += columnWidth;
+        }
+        ui->tableView->setColumnWidth(c, columnWidth);
+    }
+
+    // Refresh the cached widths the repeat overlays are sized/positioned with.
+    totalWidthColumms = 0;
+    for (int c = 0; c < columnCount; ++c)
+        totalWidthColumms += ui->tableView->columnWidth(c);
+    widthLast2Column = ui->tableView->columnWidth(columnCount - 1);
+
+    ajustRepeatWidgetPosition();
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+bool WorkoutCreator::eventFilter(QObject *watched, QEvent *event) {
+
+    if (watched == ui->tableView->viewport() && event->type() == QEvent::Resize)
+        distributeColumnWidths();
+
+    return QWidget::eventFilter(watched, event);
 }
 
 

--- a/src/ui/workout_editor/workoutcreator.h
+++ b/src/ui/workout_editor/workoutcreator.h
@@ -25,6 +25,9 @@ public:
 
     void paintEvent(QPaintEvent *);
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 
 
 public slots:
@@ -74,6 +77,7 @@ private slots:
 private :
     void restoreRepeatWidgetInterface();
     void ajustRepeatWidgetPosition();
+    void distributeColumnWidths();
 
 
 


### PR DESCRIPTION
## Summary

A polish pass over the **workout editor** interval table and its cell-editor
popups — driven by hands-on testing in the running app (light + dark themes,
several window sizes).

## Repeat Change popup (`RepeatIncreaseEditor`)
- Sized properly (was clipped at `300×90`, truncating "Heart Rate (%LTHR)" and
  cutting off the bottom row) and reflowed **top → bottom**: instruction text on
  top, the Power/Cadence/Heart Rate controls in the middle, a native
  `QDialogButtonBox` at the bottom-right.
- Spin boxes pinned to a fixed height (no more vertical ballooning) and metric
  boxes widened so the titles read fully.
- **Icon-only native Ok/Cancel**; Cancel now **discards** the edit.

## Power / Cadence / Heart Rate editors
- Same **native Ok/Cancel** icons; the ✗ now cancels/discards instead of the old
  reset-to-default. Shared setup in
  `MetricEditorVisibility::applyNativeOkCancelButtons()`.
- `IntervalDelegate` gains a `cancelWidgetEditor()` slot (closes without
  committing), wired to each editor's new `cancelEdit()` signal.

## Repeat overlay & icons
- Native close (**X**) icon on the overlay's delete button.
- The dark "repeat" glyph is **tinted to the palette text colour** so it's
  visible in both light and dark themes (new `themedicon.h` helper) — applied to
  the Repeat button, the right-click action, and the `# Repeat` combo.

## Table layout
- Taller rows (50 → 70).
- **Responsive column widths**: columns fill the viewport and scale with the
  window (weighted; the drag-handle column stays fixed), so the table is usable
  on small screens and uses the space on big ones. The repeat overlay's cached
  widths refresh and it repositions on every viewport resize.

## Testing
- `make -j` clean build against current `master`; verified live in the app
  (editors open/confirm/cancel correctly, repeat overlay tracks column resizes,
  icons visible in dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
