### PR TITLE
audio: follow the system default output when devices change

### DIFF
--- a/src/app/qtmediaplayer.cpp
+++ b/src/app/qtmediaplayer.cpp
@@ -4,6 +4,8 @@
 
 #include <QMediaPlayer>
 #include <QAudioOutput>
+#include <QMediaDevices>
+#include <QAudioDevice>
 #include <QVideoWidget>
 #include <QGridLayout>
 #include <QMenu>
@@ -27,6 +29,15 @@ QtMediaPlayer::QtMediaPlayer(QWidget *parent) : QWidget(parent)
     m_player = new QMediaPlayer(this);
     m_audio  = new QAudioOutput(this);
     m_player->setAudioOutput(m_audio);
+
+    // QAudioOutput binds to whatever device is default at creation and does not
+    // follow the system default afterwards. Watch for device changes (e.g.
+    // plugging in headphones) and re-point the output at the new default so
+    // playback moves with it.
+    m_mediaDevices = new QMediaDevices(this);
+    connect(m_mediaDevices, &QMediaDevices::audioOutputsChanged,
+            this, &QtMediaPlayer::updateAudioDevice);
+    updateAudioDevice();
 
     auto *layout = new QGridLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -207,6 +218,16 @@ void QtMediaPlayer::applyVolume()
     // QAudioOutput volume is 0.0–1.0; honour the mute flag.
     m_audio->setMuted(isMuted);
     m_audio->setVolume(audioVol / 100.0);
+}
+
+void QtMediaPlayer::updateAudioDevice()
+{
+    const QAudioDevice defaultDevice = QMediaDevices::defaultAudioOutput();
+    if (defaultDevice.isNull() || m_audio->device() == defaultDevice)
+        return;
+
+    qDebug() << "QtMediaPlayer: switching audio output to" << defaultDevice.description();
+    m_audio->setDevice(defaultDevice);
 }
 
 // ── QSettings persistence (same keys as the VLC implementation) ──────────────

--- a/src/app/qtmediaplayer.h
+++ b/src/app/qtmediaplayer.h
@@ -17,6 +17,7 @@
 
 QT_FORWARD_DECLARE_CLASS(QMediaPlayer)
 QT_FORWARD_DECLARE_CLASS(QAudioOutput)
+QT_FORWARD_DECLARE_CLASS(QMediaDevices)
 QT_FORWARD_DECLARE_CLASS(QVideoWidget)
 QT_FORWARD_DECLARE_CLASS(QLabel)
 QT_FORWARD_DECLARE_CLASS(QTimer)
@@ -76,8 +77,13 @@ private:
 
     void applyVolume();
 
-    QMediaPlayer *m_player = nullptr;
-    QAudioOutput *m_audio  = nullptr;
+    // Follow the system's default audio output so the player switches to a newly
+    // connected device (e.g. headphones) instead of staying on the old one.
+    void updateAudioDevice();
+
+    QMediaPlayer  *m_player = nullptr;
+    QAudioOutput  *m_audio  = nullptr;
+    QMediaDevices *m_mediaDevices = nullptr;
     QVideoWidget *m_video  = nullptr;
     QMenu        *m_menu   = nullptr;
     QLabel       *m_hint   = nullptr;   // "right-click to open media" overlay

--- a/src/app/soundplayer.cpp
+++ b/src/app/soundplayer.cpp
@@ -1,5 +1,8 @@
 #include "soundplayer.h"
 #include <QDebug>
+#ifdef SOUNDPLAYER_USE_QSOUNDEFFECT
+#include <QAudioDevice>
+#endif
 
 
 SoundPlayer::~SoundPlayer() {
@@ -21,8 +24,33 @@ SoundPlayer::SoundPlayer(QObject *parent) : QObject(parent)
     soundPowerTooLow.setSource(QUrl("qrc:/sound/powerTooLow"));
     soundPowerTooHigh.setSource(QUrl("qrc:/sound/powerTooHigh"));
 
+    // QSoundEffect binds to the default device at creation; follow later changes
+    // (e.g. plugging in headphones) so beeps move to the new output.
+    m_mediaDevices = new QMediaDevices(this);
+    connect(m_mediaDevices, &QMediaDevices::audioOutputsChanged,
+            this, &SoundPlayer::applyAudioDevice);
+    applyAudioDevice();
+
     m_initialized = true;
     setVolume(100);
+}
+
+
+//------------------------------------------------------------------------------------------------------------------------
+void SoundPlayer::applyAudioDevice() {
+
+    const QAudioDevice defaultDevice = QMediaDevices::defaultAudioOutput();
+    if (defaultDevice.isNull())
+        return;
+
+    for (QSoundEffect *effect : { &soundAchievement, &soundLastBeepInterval,
+                                  &soundFirstBeepInterval, &soundEndWorkout,
+                                  &soundStartWorkout, &soundCadenceTooLow,
+                                  &soundCadenceTooHigh, &soundPowerTooLow,
+                                  &soundPowerTooHigh }) {
+        if (effect->audioDevice() != defaultDevice)
+            effect->setAudioDevice(defaultDevice);
+    }
 }
 
 

--- a/src/app/soundplayer.h
+++ b/src/app/soundplayer.h
@@ -10,6 +10,7 @@
 #if !defined(Q_OS_WASM) && defined(GC_HAVE_QTMULTIMEDIA)
 #define SOUNDPLAYER_USE_QSOUNDEFFECT
 #include <QSoundEffect>
+#include <QMediaDevices>
 #endif
 
 
@@ -45,6 +46,11 @@ public:
 
 private :
 #ifdef SOUNDPLAYER_USE_QSOUNDEFFECT
+    // Point every effect at the current default output so beeps follow a newly
+    // connected device (e.g. headphones).
+    void applyAudioDevice();
+    QMediaDevices *m_mediaDevices = nullptr;
+
     QSoundEffect soundAchievement;
     QSoundEffect soundLastBeepInterval;
     QSoundEffect soundFirstBeepInterval;


### PR DESCRIPTION
## Summary

Fixes the app not switching to a newly connected audio output (e.g. plugging in
headphones on Ubuntu) — playback stayed on the previous device.

## Cause

`QAudioOutput` (the media/radio player) and `QSoundEffect` (the workout beeps)
bind to whatever device is **default at creation time** and do **not** follow the
system default afterwards. On PulseAudio/PipeWire the default sink moves when you
connect headphones, but Qt keeps the originally-selected concrete device.

## Fix

Watch `QMediaDevices::audioOutputsChanged` and re-point the output at the current
`QMediaDevices::defaultAudioOutput()` whenever it changes:

- `QtMediaPlayer::updateAudioDevice()` → `m_audio->setDevice(...)`
- `SoundPlayer::applyAudioDevice()` → updates every `QSoundEffect`

Both run at construction and on every device change, so a newly connected output
is picked up automatically. No-ops on WASM / headless builds (guarded by the
existing `GC_HAVE_QTMULTIMEDIA` / `SOUNDPLAYER_USE_QSOUNDEFFECT` paths).

## Testing

- `make -j` clean build against `master`; app launches fine.
- **Needs a real-hardware check**: start audio/radio in the app, then connect
  headphones — playback should move to them (and back to speakers on unplug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
