### PR TITLE
audio: use the PulseAudio backend on Linux (fixes Bluetooth / active-output)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -55,6 +55,17 @@ int main(int argc, char *argv[]) {
     // AppImage — see release-linux.yml.
     if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORMTHEME"))
         qputenv("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
+
+    // Use the PulseAudio audio backend rather than Qt's default PipeWire-native
+    // one. On PipeWire systems the native backend enumerates only the ALSA
+    // sinks, misses Bluetooth outputs entirely, and reports the wrong default —
+    // so playback gets stuck on e.g. HDMI and never follows the user's
+    // headphones. The PulseAudio backend (served by pipewire-pulse on modern
+    // desktops, or PulseAudio proper) sees every sink incl. Bluetooth and tracks
+    // the system default correctly. If PulseAudio isn't available Qt logs a
+    // notice and falls back to its default backend, so this is safe to force.
+    if (qEnvironmentVariableIsEmpty("QT_AUDIO_BACKEND"))
+        qputenv("QT_AUDIO_BACKEND", "pulseaudio");
 #endif
 
     // QtWebEngine requires the GUI thread and Chromium's GPU process to share


### PR DESCRIPTION
## Summary

Fixes the app not using the active audio output on Linux — e.g. playback staying
on HDMI instead of moving to connected Bluetooth headphones.

## Cause

Qt's default **PipeWire-native** audio backend enumerates only the ALSA sinks,
**misses Bluetooth outputs entirely**, and reports the **wrong default**, so
audio gets stuck on the wrong device.

## Fix

Force `QT_AUDIO_BACKEND=pulseaudio` at startup (served by pipewire-pulse on
modern desktops, or PulseAudio proper). Qt then lists every sink including the
Bluetooth headset and tracks the system default correctly (the PipeWire `spa`
enumeration errors also go away). If PulseAudio isn't available Qt logs a notice
and falls back to its default backend, so it's safe to force; only set when the
user hasn't pinned `QT_AUDIO_BACKEND`.

**Linux-only** (alongside the existing `QT_QPA_PLATFORM*` setup) — Windows
(WASAPI) and macOS (CoreAudio) already follow the system default.

## Testing

- `make -j` clean build on top of current `master`.
- Verified on Ubuntu/PipeWire: before, Qt saw only HDMI + Yeti X and defaulted to
  HDMI; with the fix it sees the Bose Bluetooth headset marked as default, and
  audio plays through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
