### PR TITLE
Fix audio output switch

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -55,6 +55,17 @@ int main(int argc, char *argv[]) {
     // AppImage — see release-linux.yml.
     if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORMTHEME"))
         qputenv("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
+
+    // Use the PulseAudio audio backend rather than Qt's default PipeWire-native
+    // one. On PipeWire systems the native backend enumerates only the ALSA
+    // sinks, misses Bluetooth outputs entirely, and reports the wrong default —
+    // so playback gets stuck on e.g. HDMI and never follows the user's
+    // headphones. The PulseAudio backend (served by pipewire-pulse on modern
+    // desktops, or PulseAudio proper) sees every sink incl. Bluetooth and tracks
+    // the system default correctly. If PulseAudio isn't available Qt logs a
+    // notice and falls back to its default backend, so this is safe to force.
+    if (qEnvironmentVariableIsEmpty("QT_AUDIO_BACKEND"))
+        qputenv("QT_AUDIO_BACKEND", "pulseaudio");
 #endif
 
     // QtWebEngine requires the GUI thread and Chromium's GPU process to share

--- a/src/app/qtmediaplayer.cpp
+++ b/src/app/qtmediaplayer.cpp
@@ -4,6 +4,8 @@
 
 #include <QMediaPlayer>
 #include <QAudioOutput>
+#include <QMediaDevices>
+#include <QAudioDevice>
 #include <QVideoWidget>
 #include <QGridLayout>
 #include <QMenu>
@@ -27,6 +29,15 @@ QtMediaPlayer::QtMediaPlayer(QWidget *parent) : QWidget(parent)
     m_player = new QMediaPlayer(this);
     m_audio  = new QAudioOutput(this);
     m_player->setAudioOutput(m_audio);
+
+    // Unlike the short QSoundEffect beeps (which the audio server re-routes to
+    // the new default on their own), the radio/media output is a persistent
+    // stream pinned to its creation-time device. Follow device changes so it
+    // moves to a newly connected output (e.g. headphones) mid-playback.
+    m_mediaDevices = new QMediaDevices(this);
+    connect(m_mediaDevices, &QMediaDevices::audioOutputsChanged,
+            this, &QtMediaPlayer::updateAudioDevice);
+    updateAudioDevice();
 
     auto *layout = new QGridLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -207,6 +218,16 @@ void QtMediaPlayer::applyVolume()
     // QAudioOutput volume is 0.0–1.0; honour the mute flag.
     m_audio->setMuted(isMuted);
     m_audio->setVolume(audioVol / 100.0);
+}
+
+void QtMediaPlayer::updateAudioDevice()
+{
+    const QAudioDevice defaultDevice = QMediaDevices::defaultAudioOutput();
+    if (defaultDevice.isNull() || m_audio->device() == defaultDevice)
+        return;
+
+    qDebug() << "QtMediaPlayer: switching audio output to" << defaultDevice.description();
+    m_audio->setDevice(defaultDevice);
 }
 
 // ── QSettings persistence (same keys as the VLC implementation) ──────────────

--- a/src/app/qtmediaplayer.h
+++ b/src/app/qtmediaplayer.h
@@ -17,6 +17,7 @@
 
 QT_FORWARD_DECLARE_CLASS(QMediaPlayer)
 QT_FORWARD_DECLARE_CLASS(QAudioOutput)
+QT_FORWARD_DECLARE_CLASS(QMediaDevices)
 QT_FORWARD_DECLARE_CLASS(QVideoWidget)
 QT_FORWARD_DECLARE_CLASS(QLabel)
 QT_FORWARD_DECLARE_CLASS(QTimer)
@@ -76,9 +77,15 @@ private:
 
     void applyVolume();
 
-    QMediaPlayer *m_player = nullptr;
-    QAudioOutput *m_audio  = nullptr;
-    QVideoWidget *m_video  = nullptr;
+    // The radio/media output is a long-lived stream pinned to the device it was
+    // created on, so it does not move when the system default changes. Watch for
+    // device changes and re-point it at the new default.
+    void updateAudioDevice();
+
+    QMediaPlayer  *m_player = nullptr;
+    QAudioOutput  *m_audio  = nullptr;
+    QMediaDevices *m_mediaDevices = nullptr;
+    QVideoWidget  *m_video  = nullptr;
     QMenu        *m_menu   = nullptr;
     QLabel       *m_hint   = nullptr;   // "right-click to open media" overlay
 };


### PR DESCRIPTION
Fix audio output on Ubuntu and on all platform so it follows the new device that is connected. Previously it was sticking to the original output device, even if your system default output changed (speaker vs headphone, etc.)