### PR TITLE
ui(workout): window-on-top, grouped toolbar controls, native Start button + FTP-test profile update

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <QMessageBox>
+#include <QTimer>
 #ifdef Q_OS_WIN
 #include <QOperatingSystemVersion>
 #endif
@@ -184,6 +185,13 @@ int main(int argc, char *argv[]) {
         // activateWindow() forces it on top and focused.
         mainWin->raise();
         mainWin->activateWindow();
+        // On X11/Wayland the window is not yet mapped when show() returns, so the
+        // raise()/activateWindow() above can be a no-op and the window comes up
+        // behind others. Re-issue them once the event loop has processed the map.
+        QTimer::singleShot(0, mainWin, [mainWin]() {
+            mainWin->raise();
+            mainWin->activateWindow();
+        });
         return mainWin;
     };
 

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -131,6 +131,13 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     ui->pushButton_exit->setIcon(tintedStandardIcon(style(), QStyle::SP_TitleBarCloseButton, ctrlIconSize, iconColor));
     ui->pushButton_exit->setIconSize(ctrlIconSize);
 
+    // Start/Pause uses the same tinted standard media glyphs as the radio
+    // controls rather than the legacy coloured PNG, for a native, consistent
+    // look on the dark toolbar.
+    const QSize startIconSize(16, 16);
+    ui->pushButton_start->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaPlay, startIconSize, iconColor));
+    ui->pushButton_start->setIconSize(startIconSize);
+
 
     ui->pushButton_calibrateFEC->setFocusPolicy(Qt::NoFocus);
     ui->pushButton_calibratePM->setFocusPolicy(Qt::NoFocus);
@@ -324,14 +331,17 @@ void TopMenuWorkout::setButtonStartPaused(bool showPause) {
 
 
 
+    const QSize startIconSize(16, 16);
+    const QColor startIconColor(230, 230, 230);
     if (showPause) {
         ui->pushButton_start->setText(tr("Pause"));
-        ui->pushButton_start->setIcon(QIcon(":/image/icon/pause"));
+        ui->pushButton_start->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaPause, startIconSize, startIconColor));
     }
     else {
         ui->pushButton_start->setText(tr("Resume"));
-        ui->pushButton_start->setIcon(QIcon(":/image/icon/play"));
+        ui->pushButton_start->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaPlay, startIconSize, startIconColor));
     }
+    ui->pushButton_start->setIconSize(startIconSize);
 
 
 }

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -236,14 +236,6 @@ void TopMenuWorkout::setMinExpandExitVisible(bool visible) {
 
     ui->pushButton_expand->setVisible(visible);
     ui->pushButton_exit->setVisible(visible);
-
-    if (visible) {
-        ui->horizontalLayout_customButton->setContentsMargins(20,0,0,0);
-    }
-    else {
-        ui->horizontalLayout_customButton->setContentsMargins(0,0,0,0);
-    }
-
 }
 
 

--- a/src/ui/components/topmenuworkout.ui
+++ b/src/ui/components/topmenuworkout.ui
@@ -54,6 +54,14 @@ QGroupBox::title {
 	padding: 0px;
 }
 
+/* Radio controls: a light border visually groups the radio icon with its
+   prev/play-pause/next buttons. The button reset above keeps the buttons
+   themselves borderless so only this frame draws an outline. */
+QFrame#frame_radioGroup {
+	border: 1px solid rgb(120, 120, 120);
+	border-radius: 4px;
+}
+
 QLabel {
 color:white;
 }
@@ -603,90 +611,93 @@ border-radius: 1px;
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label_radioIcon">
-        <property name="text">
-         <string>RadioIcon</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="pushButton_prevRadio">
-        <property name="cursor">
-         <cursorShape>PointingHandCursor</cursorShape>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::NoFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Previous station (F6)</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="pushButton_playPauseRadio">
-        <property name="cursor">
-         <cursorShape>PointingHandCursor</cursorShape>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::NoFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Play / Pause (F7)</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="pushButton_nextRadio">
-        <property name="cursor">
-         <cursorShape>PointingHandCursor</cursorShape>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::NoFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Next station (F8)</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QFrame" name="frame_radio">
+       <widget class="QFrame" name="frame_radioGroup">
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="spacing">
+          <number>4</number>
+         </property>
          <property name="leftMargin">
-          <number>0</number>
+          <number>6</number>
          </property>
          <property name="topMargin">
-          <number>0</number>
+          <number>1</number>
          </property>
          <property name="rightMargin">
-          <number>0</number>
+          <number>6</number>
          </property>
          <property name="bottomMargin">
-          <number>0</number>
+          <number>1</number>
          </property>
+         <item>
+          <widget class="QLabel" name="label_radioIcon">
+           <property name="text">
+            <string>RadioIcon</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="pushButton_prevRadio">
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>Previous station (F6)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="pushButton_playPauseRadio">
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>Play / Pause (F7)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="pushButton_nextRadio">
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>Next station (F8)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -767,44 +778,47 @@ border-radius: 1px;
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton_config">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>28</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>30</width>
-          <height>28</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Settings</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>30</width>
-          <height>28</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_customButton">
-        <property name="leftMargin">
-         <number>20</number>
+        <property name="spacing">
+         <number>2</number>
         </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="pushButton_config">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>28</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>30</width>
+            <height>28</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Settings</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>30</width>
+            <height>28</height>
+           </size>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QPushButton" name="pushButton_expand">
           <property name="sizePolicy">

--- a/src/ui/components/topmenuworkout.ui
+++ b/src/ui/components/topmenuworkout.ui
@@ -57,6 +57,24 @@ QPushButton#pushButton_exit:hover {
         border-radius: 4px;
 }
 
+/* Start / Interval are real text buttons, not icon-only controls, so give them
+   a standard, native-looking button chrome (the flat reset above is meant for
+   the icon-only window/radio controls). */
+QPushButton#pushButton_start, QPushButton#pushButton_lap {
+        background-color: #2d2d2d;
+        border: 1px solid #5a5a5a;
+        border-radius: 4px;
+        padding: 3px 8px;
+        color: white;
+}
+QPushButton#pushButton_start:hover, QPushButton#pushButton_lap:hover {
+        background-color: #3c3c3c;
+        border-color: #6e6e6e;
+}
+QPushButton#pushButton_start:pressed, QPushButton#pushButton_lap:pressed {
+        background-color: #555555;
+}
+
 QGroupBox#groupBox_commandWorkout {
      border: 2px solid gray;
 	 background-color: rgb(0, 0, 0);
@@ -256,13 +274,13 @@ border-radius: 1px;
         </property>
         <property name="minimumSize">
          <size>
-          <width>100</width>
+          <width>120</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>125</width>
+          <width>150</width>
           <height>16777215</height>
          </size>
         </property>

--- a/src/ui/components/topmenuworkout.ui
+++ b/src/ui/components/topmenuworkout.ui
@@ -41,6 +41,22 @@ QPushButton, QToolButton {
         color: white;
 }
 
+/* Give the icon-only radio buttons a slightly larger, evenly padded hit area
+   so they are easier to click. */
+QToolButton {
+        padding: 3px;
+}
+
+/* Hover highlight: make it obvious which icon-only control is under the cursor
+   and where the clickable area is. */
+QToolButton:hover,
+QPushButton#pushButton_config:hover,
+QPushButton#pushButton_expand:hover,
+QPushButton#pushButton_exit:hover {
+        background-color: #3c3c3c;
+        border-radius: 4px;
+}
+
 QGroupBox#groupBox_commandWorkout {
      border: 2px solid gray;
 	 background-color: rgb(0, 0, 0);
@@ -620,7 +636,7 @@ border-radius: 1px;
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <property name="spacing">
-          <number>4</number>
+          <number>8</number>
          </property>
          <property name="leftMargin">
           <number>6</number>
@@ -771,7 +787,7 @@ border-radius: 1px;
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>10</width>
+          <width>40</width>
           <height>24</height>
          </size>
         </property>
@@ -780,7 +796,7 @@ border-radius: 1px;
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_customButton">
         <property name="spacing">
-         <number>2</number>
+         <number>8</number>
         </property>
         <property name="leftMargin">
          <number>0</number>

--- a/src/ui/dialogmainwindowconfig.cpp
+++ b/src/ui/dialogmainwindowconfig.cpp
@@ -12,6 +12,7 @@
 #include <QGroupBox>
 #include <QDesktopServices>
 #include <QStandardPaths>
+#include <QShowEvent>
 
 #include "util.h"
 #include "environnement.h"
@@ -313,6 +314,21 @@ void DialogMainWindowConfig::on_pushButton_browseHistoryDir_clicked()
         msgBox.setStandardButtons(QMessageBox::Close);
         msgBox.exec();
     }
+}
+
+
+///////////////////////////////////////////////////////////////////////
+void DialogMainWindowConfig::showEvent(QShowEvent *event) {
+
+    QDialog::showEvent(event);
+
+    // The athlete profile can change outside this dialog — an FTP test writes a
+    // new FTP/LTHR straight into the account. Re-read those fields on every open
+    // so the spin boxes reflect the current values and OK does not clobber a
+    // freshly-tested result with the stale value loaded at construction time.
+    ui->spinBox_ftp->setValue(account->FTP);
+    ui->spinBox_lthr->setValue(account->LTHR);
+    ui->doubleSpinBox_weight->setValue(account->weight_kg);
 }
 
 

--- a/src/ui/dialogmainwindowconfig.h
+++ b/src/ui/dialogmainwindowconfig.h
@@ -29,6 +29,9 @@ public:
     void accept();
     void reject();
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 
 
 signals:

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -4012,8 +4012,12 @@ void WorkoutDialog::showTestResult() {
                                       + "<div style='color:white;height:7px;'>------------------------------------</div><br/> "
                                       + tr("FTP: ") + QString::number(newFTP) + tr(" watts") + tr(" (Previous: ") +  QString::number(account->FTP) + tr(" watts)") + "<br/>"
                                       + tr("LTHR: ")  + QString::number(newLTHR) + tr(" bpm") + tr(" (Previous: ") +  QString::number(account->LTHR) + tr(" bpm)"), 500);
-            if (newFTP > 0) { account->FTP = newFTP; }
-            if (newLTHR > 0) { account->LTHR = newLTHR; }
+            // Persist the new FTP/LTHR into the athlete profile so they survive
+            // a restart and show up in Preferences. Keep the previous value for
+            // any metric the test could not compute (<= 0).
+            const int ftpToSave  = (newFTP  > 0) ? newFTP  : account->FTP;
+            const int lthrToSave = (newLTHR > 0) ? newLTHR : account->LTHR;
+            account->saveProfileFields(ftpToSave, lthrToSave, account->weight_kg);
             emit ftp_lthr_changed();
         }
     }


### PR DESCRIPTION
## Summary

Four workout-toolbar / startup fixes, plus an FTP-test profile fix.

### 1. Main window starts on top (AppImage on Ubuntu)
`show()` was followed by `raise()`/`activateWindow()`, but on X11/Wayland the window isn't mapped yet when `show()` returns, so those calls were a no-op and the window came up behind others. Re-issue them via a queued `singleShot` after the event loop has processed the map.

### 2. Group the radio controls
Wrap the radio icon + prev/play-pause/next buttons in a bordered `QFrame` so they read as one logical group (replaces the unused empty `frame_radio`).

### 3. Group the window controls
Move the settings (cog) button next to expand/exit so the three window controls sit together. A later commit widens the gap to the radio group (~+30px), spaces the three controls 8px apart for easier clicking, uses the same 8px spacing inside the radio group, and adds a hover highlight so each icon-only control's clickable area is obvious.

### 4. Native-looking Start / Interval buttons
The Start/Resume/Pause button rendered as flat borderless text with a legacy coloured circular PNG. Give `pushButton_start` / `pushButton_lap` a standard button chrome (dark fill, 1px border, rounded corners, hover/pressed states) and use the tinted Qt `SP_MediaPlay` / `SP_MediaPause` glyphs for the start/pause/resume states, matching the radio media buttons.

### 5. FTP test updates the athlete profile
The FTP / 8-min test computed a new FTP and LTHR but only set the in-memory `Account` — the values were never persisted and the Preferences dialog (built once at startup) kept showing the old numbers (pressing OK there would even write the stale values back over the result).
- The solo test path now calls `Account::saveProfileFields()` so the new FTP/LTHR are written to `QSettings` (durable across restarts), keeping the previous value for any metric the test could not compute.
- `DialogMainWindowConfig::showEvent()` refreshes the FTP/LTHR/weight spin boxes on every open so Preferences always reflects the latest profile.

## Testing
- Clean local build (qmake6 + make), 0 errors.
- Verified the toolbar grouping, spacing, and native Start button via `--screenshots` headless render.
- Not exercised headlessly: the hover/pressed states, the live Resume/Pause icon swap during a workout, and the FTP-test → Preferences round trip (these need an interactive session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
