### PR TITLE
feat(sensors): FTMS-collapse UI — trainer-first, gray out covered slots, cap riders at 8

### DIFF
--- a/src/btle/btle_sensor_store.cpp
+++ b/src/btle/btle_sensor_store.cpp
@@ -7,13 +7,20 @@
 
 QList<BtleSensorRole> BtleSensorStore::allRoles()
 {
+    // Trainer first: it is the primary device and, when paired, covers the
+    // Power and Cadence/Speed slots listed directly beneath it.
     return {
-        BtleSensorRole::HeartRate,
+        BtleSensorRole::Trainer,
         BtleSensorRole::Power,
         BtleSensorRole::CadenceSpeed,
-        BtleSensorRole::Trainer,
+        BtleSensorRole::HeartRate,
         BtleSensorRole::Oxygen
     };
+}
+
+bool BtleSensorStore::roleCoveredByTrainer(BtleSensorRole role)
+{
+    return role == BtleSensorRole::Power || role == BtleSensorRole::CadenceSpeed;
 }
 
 QString BtleSensorStore::roleKey(BtleSensorRole role)

--- a/src/btle/btle_sensor_store.h
+++ b/src/btle/btle_sensor_store.h
@@ -56,6 +56,11 @@ public:
     /// All roles in display order. Single source of truth for iteration.
     static QList<BtleSensorRole> allRoles();
 
+    /// True if a paired FTMS Trainer makes this role's dedicated slot redundant.
+    /// FTMS Indoor Bike Data carries power, cadence and speed over one
+    /// connection, so the Power and Cadence/Speed slots are covered by it.
+    static bool roleCoveredByTrainer(BtleSensorRole role);
+
 private:
     static constexpr const char *kGroup = "btleSensors";
 

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -268,12 +268,34 @@ void SensorsWidget::onBatteryThresholdChanged(int percent)
     m_account->saveBatteryWarningThreshold();
 }
 
+bool SensorsWidget::trainerPaired() const
+{
+    for (const SlotRow &row : m_rows)
+        if (row.role == BtleSensorRole::Trainer && row.current.isValid())
+            return true;
+    return false;
+}
+
 void SensorsWidget::refreshRow(int rowIndex)
 {
     SlotRow &slot = m_rows[rowIndex];
     if (!slot.deviceLabel)
         return;
 
+    // A paired FTMS trainer reports power, cadence and speed over one
+    // connection, so its dedicated slots are redundant — disable scanning and
+    // show why. A previously-saved device stays clearable so it can be removed.
+    if (BtleSensorStore::roleCoveredByTrainer(slot.role) && trainerPaired()) {
+        slot.scanButton->setEnabled(false);
+        slot.clearButton->setEnabled(slot.current.isValid());
+        slot.deviceLabel->setText(slot.current.isValid()
+                                  ? tr("%1 (provided by trainer)").arg(slot.current.name)
+                                  : tr("Provided by trainer"));
+        slot.deviceLabel->setStyleSheet(QStringLiteral("color: #777;"));
+        return;
+    }
+
+    slot.scanButton->setEnabled(true);
     if (slot.current.isValid()) {
         slot.deviceLabel->setText(slot.current.name);
         slot.deviceLabel->setStyleSheet(QString());
@@ -295,7 +317,9 @@ void SensorsWidget::onScanClicked(int rowIndex)
     m_rows[rowIndex].current =
         BtleSensorStore::fromDeviceInfo(m_rows[rowIndex].role, scanner.selectedDevice());
     BtleSensorStore::saveSensor(m_rows[rowIndex].current);   // persist immediately
-    refreshRow(rowIndex);
+    // Refresh every row: pairing the Trainer collapses the Power/Cadence slots.
+    for (int i = 0; i < m_rows.size(); ++i)
+        refreshRow(i);
 #else
     Q_UNUSED(rowIndex);
 #endif
@@ -307,7 +331,8 @@ void SensorsWidget::onClearClicked(int rowIndex)
     BtleSensorStore::clearSensor(m_rows[rowIndex].role);
     m_rows[rowIndex].current = BtleSavedSensor{};
     m_rows[rowIndex].current.role = m_rows[rowIndex].role;
-    refreshRow(rowIndex);
+    for (int i = 0; i < m_rows.size(); ++i)
+        refreshRow(i);
 #else
     Q_UNUSED(rowIndex);
 #endif

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -285,6 +285,8 @@ void SensorsWidget::refreshRow(int rowIndex)
     // A paired FTMS trainer reports power, cadence and speed over one
     // connection, so its dedicated slots are redundant — disable scanning and
     // show why. A previously-saved device stays clearable so it can be removed.
+    // (BtleSensorStore is desktop-only; the WASM build never reaches here.)
+#ifndef GC_WASM_BUILD
     if (BtleSensorStore::roleCoveredByTrainer(slot.role) && trainerPaired()) {
         slot.scanButton->setEnabled(false);
         slot.clearButton->setEnabled(slot.current.isValid());
@@ -294,6 +296,7 @@ void SensorsWidget::refreshRow(int rowIndex)
         slot.deviceLabel->setStyleSheet(QStringLiteral("color: #777;"));
         return;
     }
+#endif
 
     slot.scanButton->setEnabled(true);
     if (slot.current.isValid()) {

--- a/src/ui/sensorswidget.h
+++ b/src/ui/sensorswidget.h
@@ -51,6 +51,8 @@ private:
 
     void buildUi();
     void refreshRow(int rowIndex);
+    /// True if the Trainer slot currently holds a valid saved device.
+    bool trainerPaired() const;
 
     QVector<SlotRow> m_rows;
     QCheckBox *m_controlResistanceCheck = nullptr;

--- a/src/ui/studiowidget.cpp
+++ b/src/ui/studiowidget.cpp
@@ -31,11 +31,12 @@
 
 namespace {
 // The sensor roles offered per rider in Studio mode (Oxygen is omitted).
+// Trainer first: when paired it covers the Power and Cadence/Speed slots below.
 const QVector<BtleSensorRole> kStudioSensorRoles = {
-    BtleSensorRole::HeartRate,
+    BtleSensorRole::Trainer,
     BtleSensorRole::Power,
     BtleSensorRole::CadenceSpeed,
-    BtleSensorRole::Trainer
+    BtleSensorRole::HeartRate
 };
 }
 
@@ -198,20 +199,20 @@ QGroupBox *StudioWidget::buildRiderCard(int riderIndex)
         slot.deviceLabel = new QLabel(box);
         slot.deviceLabel->setStyleSheet(QStringLiteral("color: #777;"));
 
-        QPushButton *scanButton = new QPushButton(tr("Scan…"), box);
-        scanButton->setFixedWidth(70);
+        slot.scanButton = new QPushButton(tr("Scan…"), box);
+        slot.scanButton->setFixedWidth(70);
         slot.clearButton = new QPushButton(tr("Clear"), box);
         slot.clearButton->setFixedWidth(55);
 
         const int slotIdx = card.sensorSlots.size();
-        connect(scanButton, &QPushButton::clicked,
+        connect(slot.scanButton, &QPushButton::clicked,
                 this, [this, riderIndex, slotIdx]() { onScanClicked(riderIndex, slotIdx); });
         connect(slot.clearButton, &QPushButton::clicked,
                 this, [this, riderIndex, slotIdx]() { onClearClicked(riderIndex, slotIdx); });
 
         grid->addWidget(roleLabel,        row, 0);
         grid->addWidget(slot.deviceLabel, row, 1);
-        grid->addWidget(scanButton,       row, 2);
+        grid->addWidget(slot.scanButton,  row, 2);
         grid->addWidget(slot.clearButton, row, 3);
 
         card.sensorSlots.append(slot);
@@ -316,6 +317,20 @@ void StudioWidget::refreshSensorSlot(int riderIndex, int slotIdx)
     const QMap<BtleSensorRole, BtleSavedSensor> saved = BtleSensorStore::loadAll(riderIndex);
     const BtleSavedSensor s = saved.value(slot.role, BtleSavedSensor{});
 
+    // A paired FTMS trainer covers this rider's Power and Cadence/Speed slots
+    // (one connection carries all three), so disable scanning them and show why.
+    const bool trainerPaired = saved.value(BtleSensorRole::Trainer, BtleSavedSensor{}).isValid();
+    if (BtleSensorStore::roleCoveredByTrainer(slot.role) && trainerPaired) {
+        slot.scanButton->setEnabled(false);
+        slot.clearButton->setEnabled(s.isValid());
+        slot.deviceLabel->setText(s.isValid()
+                                  ? tr("%1 (provided by trainer)").arg(s.name)
+                                  : tr("Provided by trainer"));
+        slot.deviceLabel->setStyleSheet(QStringLiteral("color: #777;"));
+        return;
+    }
+
+    slot.scanButton->setEnabled(true);
     if (s.isValid()) {
         slot.deviceLabel->setText(s.name);
         slot.deviceLabel->setStyleSheet(QString());
@@ -401,7 +416,9 @@ void StudioWidget::onScanClicked(int riderIndex, int slotIdx)
 
     BtleSavedSensor saved = BtleSensorStore::fromDeviceInfo(slot.role, scanner.selectedDevice());
     BtleSensorStore::saveSensor(saved, riderIndex);     // persist to the rider's package
-    refreshSensorSlot(riderIndex, slotIdx);
+    // Refresh the whole card: pairing the Trainer collapses Power/Cadence slots.
+    for (int s = 0; s < m_cards[riderIndex - 1].sensorSlots.size(); ++s)
+        refreshSensorSlot(riderIndex, s);
 #else
     Q_UNUSED(riderIndex);
     Q_UNUSED(slotIdx);
@@ -413,7 +430,8 @@ void StudioWidget::onClearClicked(int riderIndex, int slotIdx)
 #ifndef GC_WASM_BUILD
     SensorSlot &slot = m_cards[riderIndex - 1].sensorSlots[slotIdx];
     BtleSensorStore::clearSensor(slot.role, riderIndex);
-    refreshSensorSlot(riderIndex, slotIdx);
+    for (int s = 0; s < m_cards[riderIndex - 1].sensorSlots.size(); ++s)
+        refreshSensorSlot(riderIndex, s);
 #else
     Q_UNUSED(riderIndex);
     Q_UNUSED(slotIdx);

--- a/src/ui/studiowidget.h
+++ b/src/ui/studiowidget.h
@@ -65,11 +65,12 @@ private slots:
     void onImportClicked();
 
 private:
-    static constexpr int kMaxRiders = 15;
+    static constexpr int kMaxRiders = 8;
 
     struct SensorSlot {
         BtleSensorRole role = BtleSensorRole::HeartRate;
         QLabel      *deviceLabel = nullptr;
+        QPushButton *scanButton  = nullptr;
         QPushButton *clearButton = nullptr;
     };
     struct RiderCard {


### PR DESCRIPTION
## What

A paired FTMS smart trainer reports **power, cadence and speed over a single BLE connection**, so the dedicated Power and Cadence/Speed sensor slots are redundant when a Trainer is paired. This PR makes both sensor UIs reflect that, and lowers the Studio rider cap to a realistic number.

### Changes
- **Trainer-first ordering** in both the Sensors page (`allRoles()`) and the Studio per-rider cards (`kStudioSensorRoles`): **Trainer → Power → Cadence/Speed → Heart Rate**. The FTMS-covered roles sit directly beneath Trainer so the relationship is obvious.
- **Gray-out covered slots**: when a Trainer is paired, Power and Cadence/Speed disable their *Scan* button and show **"Provided by trainer"**. A previously-saved device on those slots stays clearable so it can be removed. Heart Rate is untouched (FTMS doesn't carry it).
- **Single source of truth**: new `BtleSensorStore::roleCoveredByTrainer()`.
- **Rider cap 15 → 8**: a single BLE adapter — the only one Qt can address on Windows/macOS — reliably holds ~8 simultaneous connections. 8 trainer-only riders is an honest ceiling; 15 was never achievable on one adapter.

### Note on scaling
The cap of 8 assumes **trainers only** (1 connection each). Heart-rate straps add a second connection per rider, so 8 riders + HR = ~16 connections, past what a single adapter sustains. Making HR best-effort + surfacing a live connection-count warning is a sensible follow-up; this PR does not include it.

## Testing
- Clean build (`qmake6` + `make -j`); app launches.
- Studio reorder confirmed via screenshot — every rider card lists Trainer first.
- Gray-out confirmed by seeding a Trainer for one rider: its Power + Cadence/Speed greyed to "Provided by trainer" with Scan disabled, while a trainer-less rider stayed fully active.
- No tests assert on role ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
