### PR TITLE
Post-workout panel: Strava-parity auto-upload + activity link for Intervals.icu

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -31,7 +31,6 @@
 #include "importerworkout.h"
 #include "importerworkoutzwo.h"
 #include "intervalsicudao.h"
-#include "intervalsicuservice.h"
 #include "xmlutil.h"
 #include "managerachievement.h"
 #include "simulator_hub.h"
@@ -107,7 +106,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     planObject = new PlanObject(this);         ///Used with QWebView Plan page
 
     replyIntervalsIcuZwo    = nullptr;
-    replyIntervalsIcuUpload = nullptr;
 
 
     createWebChannelPlan();
@@ -1740,6 +1738,7 @@ void MainWindow::on_actionMultiple_Workouts_triggered()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::checkToUploadFile(const QString& filename, const QString& nameOnly, const QString& description) {
 
+    Q_UNUSED(description);
     qDebug() << "check to upload Fit file";
 
     // ── Plan adherence: auto-mark this workout as completed ──────────────────
@@ -1748,61 +1747,11 @@ void MainWindow::checkToUploadFile(const QString& filename, const QString& nameO
         m_adherenceStore->addCompleted(today, nameOnly, filename);
     }
 
-    // Strava auto-upload is handled in WorkoutDialog's post-workout panel
-    // (so the status shows there and the manual button is replaced), which
-    // avoids uploading the same activity twice. Only Intervals.icu auto-uploads
-    // here.
-
-    // Intervals.icu
-    if (account->intervals_icu_auto_upload &&
-        !account->intervals_icu_athlete_id.isEmpty() &&
-        (!account->intervals_icu_api_key.isEmpty() ||
-         !account->intervals_icu_access_token.isEmpty()) &&
-        NetworkMonitor::instance()->isOnline()) {
-
-        ui->widget_bottomMenu->setGeneralMessage(tr("Uploading your activity to Intervals.icu..."));
-        IntervalsIcuService *svc = new IntervalsIcuService(this);
-        svc->setCredentials(account->intervals_icu_api_key, account->intervals_icu_athlete_id);
-        svc->setAccessToken(account->intervals_icu_access_token);
-        const QString externalId = QFileInfo(filename).baseName();
-        replyIntervalsIcuUpload = svc->uploadActivity(filename, nameOnly, externalId);
-        if (replyIntervalsIcuUpload) {
-            connect(replyIntervalsIcuUpload, SIGNAL(finished()), this, SLOT(slotIntervalsIcuUploadFinished()));
-        }
-        svc->deleteLater();
-    }
-
+    // Strava and Intervals.icu auto-uploads are both handled in WorkoutDialog's
+    // post-workout panel (so the status — and the "View on …" link — shows
+    // there, and the manual button is replaced), which also avoids uploading
+    // the same activity twice.
 }
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-void MainWindow::slotIntervalsIcuUploadFinished()
-{
-    qDebug() << "slotIntervalsIcuUploadFinished";
-
-    if (replyIntervalsIcuUpload->error() == QNetworkReply::NoError) {
-        ui->widget_bottomMenu->setGeneralMessage(
-            tr("Your activity was successfully uploaded to Intervals.icu"), 5000);
-    } else {
-        const int httpStatus = replyIntervalsIcuUpload
-            ->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        if (httpStatus == 401) {
-            ui->widget_bottomMenu->setGeneralMessage(
-                tr("Intervals.icu upload failed: invalid API key (401)"), 5000);
-        } else if (httpStatus == 409) {
-            ui->widget_bottomMenu->setGeneralMessage(
-                tr("Activity already present on Intervals.icu"), 5000);
-        } else {
-            ui->widget_bottomMenu->setGeneralMessage(
-                "Intervals.icu: " + replyIntervalsIcuUpload->errorString(), 5000);
-        }
-        LOG_WARN("MainWindow",
-                 QStringLiteral("Intervals.icu upload failed: ")
-                 + replyIntervalsIcuUpload->errorString()
-                 + QStringLiteral(" HTTP ") + QString::number(httpStatus));
-    }
-    replyIntervalsIcuUpload->deleteLater();
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::onNetworkOnlineChanged(bool isOnline)

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -149,9 +149,6 @@ private slots:
     void on_actionSingle_Workout_triggered();
     void on_actionMultiple_Workouts_triggered();
 
-    //-Intervals.icu
-    void slotIntervalsIcuUploadFinished();
-
     void onNetworkOnlineChanged(bool isOnline);
 
     void createWebChannelPlan();
@@ -211,8 +208,6 @@ private:
     int saveAccountTry;
     SavingWindow savingWindow;
 
-    //Intervals.icu
-    QNetworkReply *replyIntervalsIcuUpload;
     QNetworkReply *replyVersionCheck = nullptr;
 
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -19,6 +19,8 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QDateTime>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include "interval.h"
 #include "workout.h"
@@ -3820,10 +3822,24 @@ void WorkoutDialog::showPostWorkoutPanel()
                 QTimer::singleShot(0, this, &WorkoutDialog::uploadToStrava);
         }
         if (hasIcu) {
-            auto *btn = new QPushButton(tr("Upload to Intervals.icu"), widgetPostWorkout);
-            btn->setObjectName("btnIntervalsIcu");
-            connect(btn, &QPushButton::clicked, this, &WorkoutDialog::uploadToIntervalsIcu);
-            layout->addWidget(btn);
+            if (!account->intervals_icu_auto_upload) {
+                auto *btn = new QPushButton(tr("Upload to Intervals.icu"), widgetPostWorkout);
+                btn->setObjectName("btnIntervalsIcu");
+                connect(btn, &QPushButton::clicked, this, &WorkoutDialog::uploadToIntervalsIcu);
+                layout->addWidget(btn);
+            }
+            auto *lbl = new QLabel(widgetPostWorkout);
+            lbl->setObjectName("lblIntervalsIcu");
+            lbl->setWordWrap(true);
+            lbl->setStyleSheet("font-size: 11pt;");
+            // Allow the "View on Intervals.icu" link (shown on success) to
+            // open the activity in the user's browser.
+            lbl->setOpenExternalLinks(true);
+            if (account->intervals_icu_auto_upload)
+                lbl->setText(tr("Uploading to Intervals.icu…"));
+            layout->addWidget(lbl);
+            if (account->intervals_icu_auto_upload)
+                QTimer::singleShot(0, this, &WorkoutDialog::uploadToIntervalsIcu);
         }
     }
 
@@ -3986,11 +4002,23 @@ void WorkoutDialog::slotPostStravaStatusDone()
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Updates the post-workout Intervals.icu status — the manual button
+// (auto-upload off) or the status label (auto-upload on), whichever is present.
+void WorkoutDialog::setIntervalsIcuPostStatus(const QString &text, bool retryable)
+{
+    if (!widgetPostWorkout) return;
+    if (auto *lbl = widgetPostWorkout->findChild<QLabel*>("lblIntervalsIcu"))
+        lbl->setText(text);
+    if (auto *btn = widgetPostWorkout->findChild<QPushButton*>("btnIntervalsIcu"))
+        btn->setEnabled(retryable);
+    widgetPostWorkout->adjustSize();
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutDialog::uploadToIntervalsIcu()
 {
     if (fitFilePath.isEmpty()) return;
-    auto *btn = widgetPostWorkout ? widgetPostWorkout->findChild<QPushButton*>("btnIntervalsIcu") : nullptr;
 
     auto *svc = new IntervalsIcuService(this);
     svc->setCredentials(account->intervals_icu_api_key, account->intervals_icu_athlete_id);
@@ -4000,10 +4028,10 @@ void WorkoutDialog::uploadToIntervalsIcu()
     svc->deleteLater();
 
     if (!replyPostIntervalsIcuUpload) {
-        if (btn) btn->setText(tr("Upload to Intervals.icu (Failed — Retry)"));
+        setIntervalsIcuPostStatus(tr("✗ Intervals.icu upload could not start — check your connection."), true);
         return;
     }
-    if (btn) { btn->setEnabled(false); btn->setText(tr("Uploading…")); }
+    setIntervalsIcuPostStatus(tr("Uploading to Intervals.icu…"), false);
     connect(replyPostIntervalsIcuUpload, &QNetworkReply::finished,
             this, &WorkoutDialog::slotPostIntervalsIcuUploadDone);
 }
@@ -4015,19 +4043,37 @@ void WorkoutDialog::slotPostIntervalsIcuUploadDone()
     reply->deleteLater();
     replyPostIntervalsIcuUpload = nullptr;
 
-    auto *btn = widgetPostWorkout ? widgetPostWorkout->findChild<QPushButton*>("btnIntervalsIcu") : nullptr;
     if (reply->error() != QNetworkReply::NoError) {
         const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (httpStatus == 409) {
-            if (btn) btn->setText(tr("✓ Activity already on Intervals.icu"));
+            setIntervalsIcuPostStatus(tr("✓ Activity already on Intervals.icu"), false);
         } else {
             LOG_WARN("WorkoutDialog", QStringLiteral("Intervals.icu upload failed: ") + reply->errorString());
-            if (btn) { btn->setEnabled(true); btn->setText(tr("Upload to Intervals.icu (Failed — Retry)")); }
+            setIntervalsIcuPostStatus(tr("✗ Intervals.icu upload failed: %1").arg(reply->errorString()), true);
         }
         return;
     }
-    if (btn) btn->setText(tr("✓ Uploaded to Intervals.icu"));
-    LOG_INFO("WorkoutDialog", "Intervals.icu upload succeeded");
+
+    // HTTP 201 returns the created activity object; deep-link to it like the
+    // Strava panel does (link colour ≈ the intervals.icu logo red).
+    const QJsonObject activity = QJsonDocument::fromJson(reply->readAll()).object();
+    const QJsonValue idValue = activity.value(QStringLiteral("id"));
+    const QString activityId = idValue.isString()
+            ? idValue.toString()
+            : (idValue.isDouble() ? QString::number(static_cast<qint64>(idValue.toDouble()))
+                                  : QString());
+    if (!activityId.isEmpty()) {
+        const QString link =
+            QStringLiteral("<a style=\"color:#e8485c; text-decoration:underline;\" "
+                           "href=\"https://intervals.icu/activities/%1\">%2</a>")
+                .arg(activityId)
+                .arg(tr("View on Intervals.icu"));
+        setIntervalsIcuPostStatus(tr("✓ Uploaded to Intervals.icu") + "<br>" + link, false);
+    } else {
+        setIntervalsIcuPostStatus(tr("✓ Uploaded to Intervals.icu"), false);
+    }
+    LOG_INFO("WorkoutDialog",
+             QStringLiteral("Intervals.icu upload succeeded (activity ") + activityId + QStringLiteral(")"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -219,6 +219,7 @@ private slots:
     void doStravaUpload();   ///< the actual upload, after any token refresh
     void setStravaPostStatus(const QString &text, bool retryable);
     void uploadToIntervalsIcu();
+    void setIntervalsIcuPostStatus(const QString &text, bool retryable);
     void slotPostIntervalsIcuUploadDone();
     void slotPostStravaUploadDone();
     void slotPostStravaCheckStatus();


### PR DESCRIPTION
Follow-up to #261. The post-workout panel now treats Intervals.icu exactly like Strava — which is also what the User Guide already documents.

## Before

- The panel always showed a manual **Upload to Intervals.icu** button, even with *Auto-upload completed activities to Intervals.icu* enabled.
- Meanwhile `MainWindow::checkToUploadFile()` silently auto-uploaded the same FIT file in parallel, reporting only via a transient bottom-bar message (and nothing in the log on success). The two paths were deduped only by the server's 409.

## After

- **Auto-upload on** → the panel uploads on its own and shows live status; on success it deep-links **View on Intervals.icu** to the created activity (`id` parsed from the HTTP 201 response), mirroring the "View on Strava" link.
- **Auto-upload off** → manual button + word-wrapped status label (link on success, full error text and retry on failure, 409 shown as "already on Intervals.icu").
- The duplicate MainWindow auto-upload path is deleted (`slotIntervalsIcuUploadFinished`, `replyIntervalsIcuUpload`), and successful uploads are now logged with the activity id.

## Testing

- Validated manually on Linux: completed a workout with auto-upload enabled — the panel uploaded automatically and the link opened the activity on intervals.icu.
- Full app build clean; no doc changes needed (the User Guide's Upload section already describes exactly this behavior for both platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
