### PR TITLE
Fix the failing Cloudflare Workers Builds check: root config now deploys the real proxy

### DIFF
--- a/.github/workflows/deploy-intervals-proxy.yml
+++ b/.github/workflows/deploy-intervals-proxy.yml
@@ -23,7 +23,7 @@ jobs:
         id: deploy
         working-directory: workers/intervals-cors-proxy
         # --config pinned: wrangler v4 can otherwise resolve the repo-root
-        # wrangler.jsonc (the docs static site) and deploy THAT over the proxy.
+        # wrangler.jsonc (the Workers Builds config) instead of this directory.
         run: |
           DEPLOY_OUTPUT=$(npx wrangler deploy --config wrangler.toml 2>&1)
           echo "$DEPLOY_OUTPUT"

--- a/.github/workflows/deploy-strava-proxy.yml
+++ b/.github/workflows/deploy-strava-proxy.yml
@@ -23,7 +23,7 @@ jobs:
         id: deploy
         working-directory: workers/strava-token-proxy
         # --config pinned: wrangler v4 can otherwise resolve the repo-root
-        # wrangler.jsonc (the docs static site) and deploy THAT over the worker.
+        # wrangler.jsonc (the Workers Builds config) instead of this directory.
         run: |
           DEPLOY_OUTPUT=$(npx wrangler deploy --config wrangler.toml 2>&1)
           echo "$DEPLOY_OUTPUT"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,7 @@ jobs:
           fi
           npm install -g wrangler
           # --config pinned: wrangler v4 can otherwise resolve the repo-root
-          # wrangler.jsonc (docs static site) and deploy THAT over the proxy.
+          # wrangler.jsonc (the Workers Builds config) instead of this directory.
           DEPLOY_OUTPUT=$(wrangler deploy --config wrangler.toml 2>&1)
           echo "$DEPLOY_OUTPUT"
           # Extract the workers.dev URL from wrangler output

--- a/workers/intervals-cors-proxy/README.md
+++ b/workers/intervals-cors-proxy/README.md
@@ -63,10 +63,11 @@ easiest way to deploy correctly.
 >   -d 'grant_type=authorization_code&client_id=259&code=x&redirect_uri=http://localhost:1/'
 > ```
 > should return an intervals.icu JSON error (e.g. *invalid code*), **not** an
-> empty 404.  As of 2026-06-12, `mt-intervals-proxy.intervals-login.workers.dev`
-> serves the GitHub Pages landing page instead of this worker — the proxy must
-> be (re)deployed for WASM login and the no-local-secret desktop fallback to
-> work.
+> empty 404.  (That empty-404 failure happened in production until 2026-06-12:
+> the Cloudflare Workers Builds Git integration deployed the repo-root
+> `wrangler.jsonc` — then a static-assets config — under this worker's name on
+> every master push.  The root config now deploys this same worker, so both
+> paths agree; see the comments in `/wrangler.jsonc`.)
 
 ### 5 — Note the worker URL
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,23 +1,23 @@
-// Cloudflare config for hosting the docs/ static site (assets-only worker).
+// Root Wrangler config — used by the Cloudflare *Workers Builds* Git
+// integration, which builds this repo on every push as the Worker
+// "mt-intervals-proxy" (the maintainer's dashboard connection; see #264).
 //
-// ⚠️ The name here must NEVER be "mt-intervals-proxy": that is the
-// intervals.icu CORS proxy (workers/intervals-cors-proxy/wrangler.toml).
-// This file previously reused that name, so any `wrangler deploy` that
-// resolved this root config silently REPLACED the proxy with the static
-// site (empty 404s on /proxy/* → broken Intervals.icu login, #207).
-// Wrangler v4 can resolve this root config even when run from a worker
-// subdirectory — always pass --config explicitly in CI.
+// It MUST therefore deploy the real intervals.icu CORS proxy.  An earlier
+// revision served docs/ as static assets under the proxy's name, so every
+// master push silently REPLACED the proxy with the landing page (empty 404s
+// on /proxy/* → broken Intervals.icu login, #207).  Keep this config and
+// workers/intervals-cors-proxy/wrangler.toml pointing at the same code.
+//
+// CI deploys (deploy-intervals-proxy.yml, pages.yml) pin
+// `--config workers/intervals-cors-proxy/wrangler.toml` explicitly and also
+// install the INTERVALS_CLIENT_SECRET Worker secret; secrets persist across
+// deployments, so builds from this config keep it.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "mt-docs-site",
+  "name": "mt-intervals-proxy",
+  "main": "workers/intervals-cors-proxy/worker.js",
   "compatibility_date": "2026-06-04",
   "observability": {
     "enabled": true
-  },
-  "assets": {
-    "directory": "docs"
-  },
-  "compatibility_flags": [
-    "nodejs_compat"
-  ]
+  }
 }


### PR DESCRIPTION
Fixes the permanent red **Workers Builds: mt-intervals-proxy** check (#264) from the repo side — no Cloudflare dashboard access needed.

## Why this approach

The Cloudflare Workers Builds Git integration builds the **repo-root `wrangler.jsonc`** as the Worker `mt-intervals-proxy` on every push. It can't be fixed via API from CI: the Builds API requires a *user-scoped* token (the repo's CI token is account-scoped), and there is no API to disconnect a Git integration. Since #261 renamed the root config, the integration fails Cloudflare's name check on every push — safe (a failed build deploys nothing) but a permanent ✗ on every PR.

## The fix

Make the root config **be the proxy**: `name: mt-intervals-proxy`, `main: workers/intervals-cors-proxy/worker.js`, no assets. Now:

- Workers Builds deploys the **correct** worker on master pushes → check goes green.
- The accidental static-site-over-proxy deployment that originally broke #207 becomes impossible by construction (both configs point at the same code).
- Worker secrets persist across deployments, so the CI-installed `INTERVALS_CLIENT_SECRET` survives builds from either path.

Also updates the now-stale "root config = docs static site" comments in the three deploy workflows and the proxy README.

## Verification

- Local `wrangler dev` resolving the root config (exactly what Workers Builds resolves): `GET /` returns the proxy's 403 allow-list response — not the landing page — and `POST /proxy/api/oauth/token` without a body secret gets `"Client and/or secret not found"` from intervals.icu, proving server-side secret injection still works.
- The **Workers Builds check on this very PR** is the end-to-end test: it should build this branch's config successfully (green) instead of failing the name check.

@MaximumTrainer: with this merged, no dashboard action is strictly required anymore. Optional cleanups on your side: point the integration's "root directory" at `workers/intervals-cors-proxy` if you'd rather have one canonical config, and connect a *separate* Worker for the docs site if you still want it hosted on Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
