### PR TITLE
CI: fix Windows test_workout_ui DLL-not-found crash (deploy qwt.dll's Qt deps)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -720,8 +720,16 @@ jobs:
         name: windows
         path: build
 
+    # QTest stdout from Windows GUI-subsystem processes is not reliably
+    # captured by the runner; write results to a file and print it so
+    # failures are diagnosable from the log.
     - name: Run workout UI test
-      run: .\build\tests\workout_ui_tests.exe -v2
+      run: |
+        .\build\tests\workout_ui_tests.exe -v2 -o workout_ui_results.txt,txt
+        $code = $LASTEXITCODE
+        Write-Host "QTest exit code: $code"
+        if (Test-Path workout_ui_results.txt) { Get-Content workout_ui_results.txt }
+        exit $code
       shell: powershell
 
     - name: Upload workout UI screenshot

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -351,26 +351,26 @@ jobs:
           $src = "$env:OPENSSL_BIN\$dll"
           if (Test-Path $src) { Copy-Item $src "build\tests\" -Force }
         }
-        # qwt.dll is a third-party DLL not discovered by windeployqt; any test
-        # binary that directly instantiates QwtPlot/QwtPlotCurve will fail to
-        # load without it.  Copy it alongside the test executables.
+        # qwt.dll is a third-party DLL not discovered by windeployqt when it
+        # scans the test executables (it resolves direct Qt imports only); any
+        # test binary that instantiates QwtPlot/QwtPlotCurve fails to load
+        # without it.  Copy it alongside the test executables, then run
+        # windeployqt ON qwt.dll so its own Qt dependency set (Qt6OpenGL,
+        # Qt6OpenGLWidgets, Qt6PrintSupport, …) is deployed too.  Those DLLs
+        # previously arrived only as a side effect of login_screen_tests
+        # linking QtWebEngine; when that dependency was dropped (#261),
+        # workout_ui_tests started aborting at load with 0xC0000135
+        # (STATUS_DLL_NOT_FOUND).
         $qwtDll = "$env:QWT_INSTALL_DIR\lib\qwt.dll"
         if (Test-Path $qwtDll) {
           Copy-Item $qwtDll "build\tests\" -Force
           Write-Host "Copied qwt.dll to build\tests\"
+          & "$env:QTDIR\bin\windeployqt.exe" --release `
+              --no-translations `
+              --no-system-d3d-compiler `
+              "build\tests\qwt.dll"
         } else {
           Write-Warning "qwt.dll not found at $qwtDll - workout_ui_tests may fail to load"
-        }
-        # qwt.dll depends on Qt6OpenGLWidgets.dll, which windeployqt does not
-        # deploy for binaries that link qwt only transitively (it scans direct
-        # Qt imports only). Any test that pulls in qwt — or launches
-        # MaximumTrainer.exe — aborts at load with 0xC0000135 without it.
-        $openGlWidgets = "$env:QTDIR\bin\Qt6OpenGLWidgets.dll"
-        if (Test-Path $openGlWidgets) {
-          Copy-Item $openGlWidgets "build\tests\" -Force
-          Write-Host "Copied Qt6OpenGLWidgets.dll to build\tests\"
-        } else {
-          Write-Warning "Qt6OpenGLWidgets.dll not found at $openGlWidgets"
         }
         # FFmpeg DLLs for the QtMultimedia backend: tests that construct a
         # WorkoutDialog (workout_ui_tests) or launch MaximumTrainer.exe


### PR DESCRIPTION
Fixes the `build_windows / test_workout_ui` failure that has hit every PR since #261 merged.

## Root cause

`workout_ui_tests.exe` is the only test binary linking `qwt.dll`, and `qwt.dll` imports `Qt6OpenGL.dll` and `Qt6PrintSupport.dll`. Neither was ever deployed deliberately — they reached `build\tests\` **only as a side effect of `login_screen_tests` linking QtWebEngine**, whose windeployqt pass dragged in the whole WebEngine cascade. When #261 (correctly) dropped WebEngine from the login tests, those DLLs vanished and the exe started aborting at load with `STATUS_DLL_NOT_FOUND` (0xC0000135).

Diagnosis was painful because Windows GUI-subsystem QTest output is not captured by the runner and PowerShell surfaced the crash as a bare "exit code 1" with zero output.

## Fix

- After copying `qwt.dll` next to the test executables, run **windeployqt on `qwt.dll` itself** so its true Qt dependency set is always deployed — no more hand-maintained DLL list that silently rots when an unrelated test changes its links (this replaces the manual `Qt6OpenGLWidgets.dll` copy, which the scan now covers).
- Keep Windows QTest failures diagnosable: write results with `-o workout_ui_results.txt,txt`, print the file, and propagate the **real** exit code (`$LASTEXITCODE`), so the next failure shows actual test output instead of a silent exit 1.

## Verification

`build-windows.yml` dispatched on this branch: full run green, including `test_workout_ui` ([run 27425901632](https://github.com/MaximumTrainer/MaximumTrainer_Redux/actions/runs/27425901632)). The first dispatch (diagnostics only) captured the real exit code 0xC0000135 that pinpointed the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
