### PR TITLE
fix: stop native video/web widgets from breaking the game view and hint label

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -87,6 +87,16 @@ int main(int argc, char *argv[]) {
     // surfaced only after the Qt6 migration.
     QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 
+    // The workout view mixes QQuickWidget (retro race) with NATIVE siblings
+    // (QVideoWidget, QtWebEngine). By default Qt forces every sibling of a
+    // native child widget to go native too — a native QQuickWidget cannot
+    // render at all (it warns "QQuickWidget cannot be used as a native child
+    // widget" on every frame and stays blank), and the media player's overlay
+    // hint label stops compositing until a hide/show cycle. This attribute
+    // stops the nativeness from propagating; the video/web widgets themselves
+    // stay native and keep working.
+    QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+
     QApplication app(argc, argv);
 
     // Do NOT auto-quit when the last window closes. On Qt6, QtWebEngine spins up


### PR DESCRIPTION
## Problem

With the released AppImage, the retro race game never loads: the view stays blank while the log loops the warning below. First reported on a fresh Ubuntu install, but the machine is irrelevant — it reproduces on any machine running the AppImage (verified on a dev machine), while locally built Qt 6.10 binaries are immune, which is why development never caught it.

```
[WARN] [Qt] QQuickWidget cannot be used as a native child widget. Consider setting Qt::AA_DontCreateNativeWidgetSiblings
```

The embedded media player also fails to show its white "Right-click to open a video file or URL" hint the first time it is shown — it only appears after switching to another widget and back.

## Root cause

The workout dialog mixes the game's `QQuickWidget` with widgets that create **native** windows (the QtMultimedia `QVideoWidget`, the preloaded QtWebEngine web player). By default, Qt forces every sibling of a native child widget to become native too. A native `QQuickWidget` cannot render at all — `QQuickWidgetPrivate::texture()` emits the warning above on every backing-store flush (hence the loop) and the view stays blank. The same forced nativeness breaks first-paint composition of the media player's overlay hint label.

This is Qt-runtime dependent, which is why dev builds never showed it:

- **AppImage (CI Qt 6.7.3): bug reproduces.** Running the released v0.0.147 AppImage on a dev machine yields 4 native-child warnings at startup and the `--screenshots` workout capture is solid black (the native cascade also defeats `QWidget::grab()`).
- **Local dev build (system Qt 6.10): bug cannot occur.** A standalone test shows `QVideoWidget` no longer creates a native window there, so the sibling propagation never starts.

## Fix

Set `Qt::AA_DontCreateNativeWidgetSiblings` before constructing the `QApplication` — the remedy the warning itself prescribes. The video/web widgets themselves remain native and keep working; only the forced nativeness of their siblings is suppressed.

## Validation

An AppImage was packaged from this branch via the fork's Build + Release-Linux workflows (same Qt 6.7.3 pin) and run in `--screenshots` mode on the machine that reproduced the bug:

| | v0.0.147 AppImage | this branch's AppImage |
|---|---|---|
| native-child warnings | 4 (looping) | **0** |
| workout view capture | solid black | game renders correctly |

The full screenshot suite (main window, sensors, editor, workout, studio, plan, history) captured normally with no regressions; the locally built Qt 6.10 binary also ran the full suite cleanly with the fix.

Note: `build_windows / test_workout_ui` failed on the fork's build run — the known pre-existing Windows failure being investigated separately on `debug-workout-ui-windows`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

