### PR TITLE
Playwright: fix WASM OAuth mock for the /api/oauth/token path (master red)

### DIFF
--- a/tests/playwright/pages/WasmAppPage.ts
+++ b/tests/playwright/pages/WasmAppPage.ts
@@ -570,10 +570,10 @@ export class WasmAppPage {
     };
 
     await this.page.route(
-      // Token endpoint moved to /api/oauth/token (#261); keep matching the old
-      // /oauth/token path too so the mock can't silently stop intercepting
-      // again if the path changes back.
-      /^https:\/\/(?:intervals\.icu\/(?:api\/)?oauth\/token|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/(?:api\/)?oauth\/token)(?:\?.*)?$/,
+      // Token endpoint is /api/oauth/token (#261).  Deliberately exact: if
+      // the app ever calls a different token URL again, the request escapes
+      // the mock and the login test fails — the regression signal we want.
+      /^https:\/\/(?:intervals\.icu\/api\/oauth\/token|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/api\/oauth\/token)(?:\?.*)?$/,
       async (route) => {
         if (route.request().method() === 'OPTIONS') {
           await route.fulfill({ status: 204, headers: corsHeaders });

--- a/tests/playwright/pages/WasmAppPage.ts
+++ b/tests/playwright/pages/WasmAppPage.ts
@@ -570,7 +570,10 @@ export class WasmAppPage {
     };
 
     await this.page.route(
-      /^https:\/\/(?:intervals\.icu\/oauth\/token|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/oauth\/token)(?:\?.*)?$/,
+      // Token endpoint moved to /api/oauth/token (#261); keep matching the old
+      // /oauth/token path too so the mock can't silently stop intercepting
+      // again if the path changes back.
+      /^https:\/\/(?:intervals\.icu\/(?:api\/)?oauth\/token|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/(?:api\/)?oauth\/token)(?:\?.*)?$/,
       async (route) => {
         if (route.request().method() === 'OPTIONS') {
           await route.fulfill({ status: 204, headers: corsHeaders });


### PR DESCRIPTION
Fixes the `test_playwright` failures on master (e.g. [this run](https://github.com/MaximumTrainer/MaximumTrainer_Redux/actions/runs/27431768227/job/81086151694)).

**Root cause:** `WasmAppPage.setupOAuthMock()` intercepts the OAuth token exchange with an exact-URL regex that still pointed at the old `/proxy/oauth/token` path. Since #261 moved the endpoint to `/proxy/api/oauth/token`, the WASM app's exchange request slipped past the mock, hit the real Cloudflare worker from the Playwright test origin, and died with HTTP 0 (CORS) — visible in the job log as:

```
[WARN] [Qt] QNetworkAccess: got HTTP status code 0 ... /proxy/api/oauth/token
[WARN] [DialogLogin] WASM OAuth: token exchange failed (HTTP 0, err 399)
```

The mocked login then never completed, timing out every Layer-B test (2.1 m each, with retries).

**Fix:** the route regex now matches both the new `/api/oauth/token` and the legacy `/oauth/token` paths on both hosts, so a future path change can't silently un-mock the exchange again. The other specs already use substring matching and were unaffected.

The `test_playwright` job on this PR is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
