### PR TITLE
Workout session fixes: FTMS ERG control, YouTube fullscreen, radio persistence + dance stations

### DIFF
--- a/resources/data/default_radios.json
+++ b/resources/data/default_radios.json
@@ -78,5 +78,53 @@
         "bitrate": "192",
         "lang": "FR",
         "url": "https://icecast.radiofrance.fr/francemusique-midfi.mp3"
+    },
+    {
+        "name": "SomaFM The Trip",
+        "genre": "Progressive House / Trance",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://ice1.somafm.com/thetrip-128-mp3"
+    },
+    {
+        "name": "Dance Wave!",
+        "genre": "Dance / EDM",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://dancewave.online/dance.mp3"
+    },
+    {
+        "name": "TechnoBase.FM",
+        "genre": "Techno / HandsUp / Dance",
+        "gotAds": "0",
+        "bitrate": "192",
+        "lang": "DE/EN",
+        "url": "https://listen.technobase.fm/tunein-mp3"
+    },
+    {
+        "name": "HouseTime.FM",
+        "genre": "House / Electro / EDM",
+        "gotAds": "0",
+        "bitrate": "192",
+        "lang": "DE/EN",
+        "url": "https://listen.housetime.fm/tunein-mp3"
+    },
+    {
+        "name": "90s90s Dance",
+        "genre": "90s Dance / EuroDance",
+        "gotAds": "1",
+        "bitrate": "192",
+        "lang": "DE",
+        "url": "https://streams.90s90s.de/dance/mp3-192/"
+    },
+    {
+        "name": "Nightride FM",
+        "genre": "Synthwave / Retro Electro",
+        "gotAds": "0",
+        "bitrate": "128",
+        "lang": "EN",
+        "url": "https://stream.nightride.fm/nightride.mp3"
     }
 ]

--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRegularExpression>
+#include <QCryptographicHash>
 
 #include "account.h"
 #include "settings.h"
@@ -1260,19 +1261,24 @@ QList<Radio> Util::loadLocalRadioList() {
     if (path.isEmpty())
         return fallbackToDefaults();
 
-    // One-time refresh when the bundled default list changes: overwrite the
-    // user's radios.json with the new defaults (users re-add their custom
-    // stations).  Bump kRadioDefaultsVersion whenever default_radios.json
-    // gains/changes stations that existing installs should pick up.
-    constexpr int kRadioDefaultsVersion = 2;
+    // Whenever the bundled default list changes (any release that edits
+    // default_radios.json), the user's radios.json is REPLACED wholesale with
+    // the new defaults — nothing from the old file is kept; users re-add
+    // their custom stations.  Keyed on a content hash of the bundled JSON so
+    // no version constant has to be bumped by hand.
     {
-        QSettings settings;
-        const int seenVersion =
-            settings.value(QStringLiteral("radios/defaultsVersion"), 1).toInt();
-        if (seenVersion < kRadioDefaultsVersion) {
-            settings.setValue(QStringLiteral("radios/defaultsVersion"),
-                              kRadioDefaultsVersion);
-            return fallbackToDefaults();
+        QFile bundled(QStringLiteral(":/data/resources/data/default_radios.json"));
+        if (bundled.open(QIODevice::ReadOnly)) {
+            const QString bundledHash = QString::fromLatin1(
+                QCryptographicHash::hash(bundled.readAll(),
+                                         QCryptographicHash::Sha256).toHex());
+            QSettings settings;
+            const QString seenHash =
+                settings.value(QStringLiteral("radios/defaultsHash")).toString();
+            if (seenHash != bundledHash) {
+                settings.setValue(QStringLiteral("radios/defaultsHash"), bundledHash);
+                return fallbackToDefaults();
+            }
         }
     }
 

--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -1260,6 +1260,22 @@ QList<Radio> Util::loadLocalRadioList() {
     if (path.isEmpty())
         return fallbackToDefaults();
 
+    // One-time refresh when the bundled default list changes: overwrite the
+    // user's radios.json with the new defaults (users re-add their custom
+    // stations).  Bump kRadioDefaultsVersion whenever default_radios.json
+    // gains/changes stations that existing installs should pick up.
+    constexpr int kRadioDefaultsVersion = 2;
+    {
+        QSettings settings;
+        const int seenVersion =
+            settings.value(QStringLiteral("radios/defaultsVersion"), 1).toInt();
+        if (seenVersion < kRadioDefaultsVersion) {
+            settings.setValue(QStringLiteral("radios/defaultsVersion"),
+                              kRadioDefaultsVersion);
+            return fallbackToDefaults();
+        }
+    }
+
     QFile file(path);
     if (!file.exists())
         return fallbackToDefaults();

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -97,6 +97,8 @@ void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
 
     m_firstCscMeasurement   = true;
     m_ftmsControlRequested  = false;
+    m_ftmsControlGranted    = false;
+    m_lastFtmsCommand       = FtmsCommand::None;
     m_reconnectDevice   = device;
     m_reconnectAttempts = 0;
 
@@ -148,6 +150,11 @@ void BtleHub::setLoad(int antID, double watts)
     if (!m_ftmsService)
         return;
 
+    // Remember the target so it can be re-sent once the trainer grants
+    // control (commands sent before the grant are rejected by the trainer).
+    m_lastFtmsCommand      = FtmsCommand::TargetPower;
+    m_lastFtmsCommandValue = watts;
+
     // FTMS: Set Target Power (opcode 0x05), value = int16 watts
     QLowEnergyCharacteristic cp =
         m_ftmsService->characteristic(BtleUuid::FtmsControlPoint);
@@ -161,6 +168,8 @@ void BtleHub::setLoad(int antID, double watts)
     cmd[2] = static_cast<char>((w >> 8) & 0xFF);
     m_ftmsService->writeCharacteristic(cp, cmd,
                                        QLowEnergyService::WriteWithResponse);
+    LOG_DEBUG("BtleHub", QStringLiteral("FTMS Set Target Power: %1 W (control granted: %2)")
+                             .arg(w).arg(m_ftmsControlGranted));
 }
 
 void BtleHub::setSlope(int antID, double grade)
@@ -170,6 +179,9 @@ void BtleHub::setSlope(int antID, double grade)
 
     if (!m_ftmsService)
         return;
+
+    m_lastFtmsCommand      = FtmsCommand::Slope;
+    m_lastFtmsCommandValue = grade;
 
     // FTMS: Set Indoor Bike Simulation (opcode 0x11)
     // Parameters: wind speed (int16, 0.001 m/s), grade (int16, 0.01 %), crr, cw
@@ -301,6 +313,14 @@ void BtleHub::setupService(QLowEnergyService *service)
             this, &BtleHub::onServiceStateChanged);
     connect(service, &QLowEnergyService::characteristicChanged,
             this, &BtleHub::onCharacteristicChanged);
+    connect(service, &QLowEnergyService::descriptorWritten,
+            this, &BtleHub::onDescriptorWritten);
+    connect(service, &QLowEnergyService::errorOccurred,
+            this, [this, service](QLowEnergyService::ServiceError error) {
+                LOG_WARN("BtleHub", QStringLiteral("Service error %1 on %2")
+                                        .arg(int(error))
+                                        .arg(service->serviceUuid().toString()));
+            });
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if (service->state() == QLowEnergyService::RemoteService)
@@ -322,6 +342,18 @@ void BtleHub::enableNotification(QLowEnergyService *service,
         service->writeDescriptor(cccd, QByteArray::fromHex("0100")); // enable notifications
 }
 
+void BtleHub::enableIndication(QLowEnergyService *service,
+                               const QLowEnergyCharacteristic &characteristic)
+{
+    if (!characteristic.isValid())
+        return;
+
+    QLowEnergyDescriptor cccd =
+        characteristic.descriptor(BtleUuid::ClientCharacteristicConfig);
+    if (cccd.isValid())
+        service->writeDescriptor(cccd, QByteArray::fromHex("0200")); // enable indications
+}
+
 void BtleHub::requestFtmsControl()
 {
     if (!m_ftmsService || m_ftmsControlRequested)
@@ -336,6 +368,55 @@ void BtleHub::requestFtmsControl()
     m_ftmsService->writeCharacteristic(cp, QByteArray(1, '\x00'),
                                        QLowEnergyService::WriteWithResponse);
     m_ftmsControlRequested = true;
+    LOG_INFO("BtleHub", QStringLiteral("FTMS Request Control sent"));
+}
+
+void BtleHub::onDescriptorWritten(const QLowEnergyDescriptor &descriptor,
+                                  const QByteArray &value)
+{
+    // The FTMS Control Point requires indications (CCCD = 0x0200) to be
+    // enabled before the trainer will process commands; Request Control is
+    // therefore only sent once that descriptor write is confirmed.
+    if (m_ftmsService &&
+        descriptor.uuid() == BtleUuid::ClientCharacteristicConfig &&
+        value == QByteArray::fromHex("0200")) {
+        LOG_INFO("BtleHub", QStringLiteral("FTMS Control Point indications enabled"));
+        requestFtmsControl();
+    }
+}
+
+void BtleHub::handleFtmsControlPointResponse(const QByteArray &value)
+{
+    // Indication format: [0x80, request opcode, result code]
+    // result 0x01 = success; anything else is a refusal (0x02 not supported,
+    // 0x03 invalid parameter, 0x04 operation failed, 0x05 control not permitted).
+    if (value.size() < 3 || quint8(value[0]) != 0x80)
+        return;
+
+    const quint8 requestOp = quint8(value[1]);
+    const quint8 result    = quint8(value[2]);
+
+    if (result != 0x01) {
+        LOG_WARN("BtleHub", QStringLiteral("FTMS control point refused opcode 0x%1 (result 0x%2)")
+                                .arg(requestOp, 2, 16, QLatin1Char('0'))
+                                .arg(result, 2, 16, QLatin1Char('0')));
+        if (requestOp == 0x00)
+            m_ftmsControlGranted = false;
+        return;
+    }
+
+    if (requestOp == 0x00) {   // Request Control granted
+        m_ftmsControlGranted = true;
+        LOG_INFO("BtleHub", QStringLiteral("FTMS control granted by trainer"));
+        // Re-issue the last target: anything commanded before the grant was
+        // rejected, which previously left the trainer stuck on its default
+        // resistance for the rest of the interval.
+        switch (m_lastFtmsCommand) {
+        case FtmsCommand::TargetPower: setLoad(m_userID, m_lastFtmsCommandValue);  break;
+        case FtmsCommand::Slope:       setSlope(m_userID, m_lastFtmsCommandValue); break;
+        case FtmsCommand::None:        break;
+        }
+    }
 }
 
 void BtleHub::onServiceStateChanged(QLowEnergyService::ServiceState state)
@@ -367,7 +448,12 @@ void BtleHub::onServiceStateChanged(QLowEnergyService::ServiceState state)
     else if (service == m_ftmsService) {
         enableNotification(service,
             service->characteristic(BtleUuid::FtmsIndoorBikeData));
-        requestFtmsControl();
+        // Control Point needs INDICATIONS, and Request Control must wait for
+        // the descriptor write to be confirmed (see onDescriptorWritten) —
+        // trainers ignore/refuse control commands on an unconfigured control
+        // point, which left ERG mode stuck at the trainer's default load.
+        enableIndication(service,
+            service->characteristic(BtleUuid::FtmsControlPoint));
     }
     else if (service == m_moxyService) {
         enableNotification(service,
@@ -401,6 +487,8 @@ void BtleHub::onCharacteristicChanged(const QLowEnergyCharacteristic &characteri
         parsePowerMeasurement(value);
     else if (uuid == BtleUuid::FtmsIndoorBikeData)
         parseFtmsIndoorBikeData(value);
+    else if (uuid == BtleUuid::FtmsControlPoint)
+        handleFtmsControlPointResponse(value);
     else if (uuid == BtleUuid::MoxyMeasurement)
         parseMoxyMeasurement(value);
     else if (uuid == BtleUuid::BatteryLevel)

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -92,6 +92,8 @@ private slots:
     void onServiceStateChanged(QLowEnergyService::ServiceState state);
     void onCharacteristicChanged(const QLowEnergyCharacteristic &characteristic,
                                  const QByteArray &value);
+    void onDescriptorWritten(const QLowEnergyDescriptor &descriptor,
+                             const QByteArray &value);
     void onCscStopTimer();
     void onReconnectTimer();
 
@@ -99,7 +101,10 @@ private:
     void setupService(QLowEnergyService *service);
     void enableNotification(QLowEnergyService *service,
                             const QLowEnergyCharacteristic &characteristic);
+    void enableIndication(QLowEnergyService *service,
+                          const QLowEnergyCharacteristic &characteristic);
     void requestFtmsControl();
+    void handleFtmsControlPointResponse(const QByteArray &value);
 
     void parseHrMeasurement(const QByteArray &data);
     void parseCscMeasurement(const QByteArray &data);
@@ -119,6 +124,13 @@ private:
     QLowEnergyService *m_batteryService  = nullptr;
 
     bool m_ftmsControlRequested = false;
+    bool m_ftmsControlGranted   = false;
+
+    // Last commanded target, re-sent once the trainer grants control so a
+    // target issued before the grant is not silently lost.
+    enum class FtmsCommand { None, TargetPower, Slope };
+    FtmsCommand m_lastFtmsCommand      = FtmsCommand::None;
+    double      m_lastFtmsCommandValue = 0.0;
 
     // Zero-out cadence / speed after a few missed messages
     QTimer *m_cscStopTimer = nullptr;

--- a/src/ui/components/webbrowserview.cpp
+++ b/src/ui/components/webbrowserview.cpp
@@ -3,6 +3,7 @@
 #include <QWebEngineView>
 #include <QWebEnginePage>
 #include <QWebEngineSettings>
+#include <QWebEngineFullScreenRequest>
 #include <QGridLayout>
 #include <QToolBar>
 #include <QLineEdit>
@@ -27,12 +28,24 @@ WebBrowserView::WebBrowserView(QWidget *parent) : QWidget(parent)
 
     webEngineView = new QWebEngineView(this);
     webEngineView->settings()->setAttribute(QWebEngineSettings::PluginsEnabled, true);
+    // Without FullScreenSupportEnabled + an accepted fullScreenRequested,
+    // YouTube greys out its fullscreen button ("Full screen is unavailable").
+    webEngineView->settings()->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);
 
 #ifndef GC_WASM_BUILD
     // On WASM the QWebEngineView stub opens URLs in a browser tab and emits none
     // of these signals, so the connections are desktop-only.
     connect(webEngineView, &QWebEngineView::loadFinished, this, &WebBrowserView::adjustLocation);
     connect(webEngineView, &QWebEngineView::urlChanged, this, &WebBrowserView::updateUrlOfLineEdit);
+    connect(webEngineView->page(), &QWebEnginePage::fullScreenRequested,
+            this, [this](QWebEngineFullScreenRequest request) {
+                request.accept();
+                // The video element now fills the webview; hide the browser
+                // chrome so "fullscreen" means the whole workout video area
+                // (it reappears on mouse/keyboard activity as usual).
+                if (request.toggleOn())
+                    toolBar->hide();
+            });
 #endif
 
     toolBar = new QToolBar(this);

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -112,8 +112,27 @@ DialogConfig::DialogConfig(QList<Radio> lstRadio, QWidget *parent,  WorkoutDialo
     ui->tableView_radio->verticalHeader()->setDefaultSectionSize(30);
     ui->tableView_radio->verticalHeader()->setVisible(false);
 
-    //first one
-    currentRadioIndex = ui->tableView_radio->model()->index(0, 0);
+    // Preselect the station from the last session (falls back to the first
+    // row), so play resumes on the same radio after reopening the workout.
+    {
+        QSettings radioSettings;
+        radioSettings.beginGroup(QStringLiteral("radioPlayer"));
+        const QString lastStation =
+            radioSettings.value(QStringLiteral("lastStation")).toString();
+        radioSettings.endGroup();
+
+        int lastRow = 0;
+        for (int row = 0; row < lstRadio.size(); ++row) {
+            if (!lastStation.isEmpty() && lstRadio.at(row).getName() == lastStation) {
+                lastRow = row;
+                break;
+            }
+        }
+        currentRadioIndex = ui->tableView_radio->model()->index(lastRow, 0);
+        ui->tableView_radio->selectionModel()->select(
+            currentRadioIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+        ui->tableView_radio->scrollTo(currentRadioIndex);
+    }
 
 
     //    ui->tableView_radio->sortByColumn(0, Qt::AscendingOrder);
@@ -217,6 +236,14 @@ void DialogConfig::RadioDoubleClicked(QModelIndex index) {
     qDebug() << "Done getting radio from model...";
     currentRadioName = radio.getName();
     qDebug() << "Radio url is" << radio.getUrl();
+
+    // Remember the station so the next workout session starts on the same one.
+    {
+        QSettings radioSettings;
+        radioSettings.beginGroup(QStringLiteral("radioPlayer"));
+        radioSettings.setValue(QStringLiteral("lastStation"), currentRadioName);
+        radioSettings.endGroup();
+    }
 
 
     isConnecting = true;

--- a/workers/intervals-cors-proxy/wrangler.toml
+++ b/workers/intervals-cors-proxy/wrangler.toml
@@ -1,4 +1,4 @@
-name            = "mt-intervals-proxy"
+name = "mt-intervals-proxy"
 main            = "worker.js"
 compatibility_date = "2024-01-01"
 


### PR DESCRIPTION
Fixes three issues found during a real workout session on Linux, plus radio catalogue improvements.

## 1. ERG mode stuck at the trainer's default load (~130 W)

Real bug in the BLE hub: the **FTMS Control Point requires indications (CCCD 0x0200)** before a trainer processes commands. The hub never enabled them — it only enabled notifications on the data characteristic, then fired `Request Control` at an unconfigured control point, so trainers silently refused every subsequent `Set Target Power` (matching the symptom: stuck at default resistance, ERG toggle irrelevant).

Now the hub:
- enables indications on the Control Point, and sends `Request Control` only after the descriptor write is confirmed;
- parses control-point response indications and **logs refusals with their FTMS result codes** (previously silent);
- **re-issues the last commanded target once control is granted**, so a target sent before the grant isn't lost;
- logs service errors and target writes for field diagnosis.

⚠️ Hardware validation pending: requires a physical trainer (will be tested by @maximus321 post-merge; the new log lines `FTMS Control Point indications enabled` → `Request Control sent` → `control granted by trainer` make the outcome diagnosable either way).

## 2. YouTube fullscreen greyed out in the web video player

`QWebEngineView` needs `FullScreenSupportEnabled` **and** an accepted `fullScreenRequested` — neither was set. The video now fills the player view (toolbar hides on entry).

## 3. Last radio station not remembered

Only the volume was persisted; the selection reset to row 0 every session. The station is now saved on selection (`radioPlayer/lastStation`) and preselected next time — making the User Guide's existing "saved for next time" claim true.

## 4. New dance/electronic radio stations + one-time list refresh

Six new defaults, **stream URLs verified live** (ICY headers checked): SomaFM The Trip (prog house/trance, ad-free), Dance Wave! (EDM, ad-free), TechnoBase.FM (HandsUp/dance, ad-free), HouseTime.FM (house/EDM, ad-free), 90s90s Dance (90s EuroDance — has ads, flagged), Nightride FM (synthwave, ad-free).

Whenever a release changes the bundled station list, the user's `radios.json` is **replaced wholesale** on first start — nothing from the old list is kept (custom stations must be re-added, by design). Keyed on a content hash of the bundled JSON, so future station updates trigger the refresh automatically with no version constant to bump. Verified end-to-end locally: a user list with a custom station → app start → exactly the 16 bundled stations on disk.

Also: wrangler.toml `name` key spacing normalized so the Cloudflare bot stops auto-opening rename PRs (#270).

## Testing

- Full build clean; BLE API tests pass; radio migration verified live; fullscreen/radio behavior validated locally.
- ERG fix: code-level validation + diagnostics; hardware pass by @maximus321 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

