### PR TITLE
Game: stop the rider's legs at 0 W when no cadence feed (no more phantom pedalling)

### DIFF
--- a/src/game/retroracecontroller.cpp
+++ b/src/game/retroracecontroller.cpp
@@ -250,8 +250,16 @@ void RetroRaceController::tick()
     const double gain = qBound(1.0, 1.0 + (kmh - 20.0) * 0.055, 2.4);
     m_visualSpeed = m_playerV * gain;
     m_visualDist += m_visualSpeed * dt;
-    // Live cadence drives the legs; otherwise mirror the opponent's pace.
-    m_playerCadence = (m_liveCadenceRpm >= 0.0) ? m_liveCadenceRpm : m_oppCadence;
+    // Legs: live cadence when a sensor feeds it.  With live power but no
+    // cadence feed (yet), infer pedalling from power so the legs don't spin
+    // while the rider is stopped (0 W).  Only the pure demo — no hardware at
+    // all — mirrors the opponent's cadence.
+    if (m_liveCadenceRpm >= 0.0)
+        m_playerCadence = m_liveCadenceRpm;
+    else if (m_livePowerW >= 0.0)
+        m_playerCadence = (m_playerPowerW > 5.0) ? m_oppCadence : 0.0;
+    else
+        m_playerCadence = m_oppCadence;
     m_playerCrankRev += (m_playerCadence / 60.0) * dt;
 
     emit updated();


### PR DESCRIPTION
Fixes the race rider visibly pedalling while the real rider is stopped.

**Cause:** until the first cadence packet arrives, the player's legs fell back to mirroring the **opponent's** cadence — a fallback meant only for the no-hardware demo. With a trainer connected but cadence not (yet) reporting, the sprite spun at the ghost's pace regardless of the rider.

**Fix:** the opponent-mirror fallback is now reserved for the pure demo (no hardware at all). With live power but no cadence feed, the legs are inferred from power: **0 W → legs stop**, pedalling → animate at the opponent's pace until real cadence arrives. A reporting cadence sensor drives the legs exactly as before (including 0 = stopped).

| Situation | Legs |
|---|---|
| Cadence sensor reporting | rider's real cadence (0 = stopped) |
| Live power, no cadence packets | inferred from power (0 W → stop) |
| Pure demo (`--retrorace`, no hardware) | mirror the opponent (unchanged) |

Verified: clean build; the standalone `--retrorace` demo still animates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
