### PR TITLE
playwright: mock the /sport-settings endpoint in setupOAuthMock

### DIFF
--- a/tests/playwright/pages/WasmAppPage.ts
+++ b/tests/playwright/pages/WasmAppPage.ts
@@ -593,25 +593,36 @@ export class WasmAppPage {
       },
     );
 
-    // Mock the athlete profile and settings endpoints that DialogLogin calls
-    // after the token exchange to verify the login and populate the account.
-    // Without this, tests that don't call mockIntervalsIcuApi() (e.g. the BLE
-    // GATT test) will see 404 WARN messages in the log overlay.
-    // Use a regex to match ONLY /athlete/{id} and /athlete/{id}/settings —
+    // Mock the athlete profile and sport-settings endpoints that DialogLogin
+    // calls after the token exchange to verify the login and populate the
+    // account. Without this, tests that don't call mockIntervalsIcuApi()
+    // (e.g. the BLE GATT test) will see 404 WARN messages in the log overlay.
+    // Use a regex to match ONLY /athlete/{id} and /athlete/{id}/sport-settings —
     // NOT calendar/event sub-paths — to avoid intercepting functional test routes.
     await this.page.route(
-      /^https:\/\/(?:intervals\.icu\/api\/v1\/athlete\/[^/]+(?:\/settings)?|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/api\/v1\/athlete\/[^/]+(?:\/settings)?)(?:\?.*)?$/,
+      /^https:\/\/(?:intervals\.icu\/api\/v1\/athlete\/[^/]+(?:\/sport-settings)?|mt-intervals-proxy\.intervals-login\.workers\.dev\/proxy\/api\/v1\/athlete\/[^/]+(?:\/sport-settings)?)(?:\?.*)?$/,
       async (route) => {
         if (route.request().method() === 'OPTIONS') {
           await route.fulfill({ status: 204, headers: corsHeaders });
           return;
         }
-        const isSettings = route.request().url().includes('/settings');
+        const isSportSettings = route.request().url().includes('/sport-settings');
         await route.fulfill({
           status: 200,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          body: isSettings
-            ? JSON.stringify({})
+          body: isSportSettings
+            // Shape of GET /athlete/{id}/sport-settings: array of per-sport
+            // entries; power_zones are % of FTP, hr_zones absolute bpm.
+            ? JSON.stringify([
+                {
+                  types:       ['Ride', 'VirtualRide'],
+                  ftp:         250,
+                  indoor_ftp:  240,
+                  lthr:        160,
+                  power_zones: [55, 75, 90, 105, 120, 150],
+                  hr_zones:    [120, 140, 155, 165, 175, 190],
+                },
+              ])
             : JSON.stringify({
                 id:        WasmAppPage.FAKE_ATHLETE_ID,
                 firstname: 'Test',


### PR DESCRIPTION
## Problem

`test_playwright` on master fails in two WASM specs (`wasm_btle_api`, `wasm_webapp`) with:

```
WASM overlay shows "Not Found" — backend API requests are failing:
[WARN] [DialogLogin] Intervals.icu settings fetch failed: Not Found
```

#272 switched DialogLogin's post-login profile fetch from the nonexistent `/athlete/{id}/settings` endpoint to `/athlete/{id}/sport-settings`, but `setupOAuthMock()` in `tests/playwright/pages/WasmAppPage.ts` still only intercepted `/athlete/{id}` and the old `/settings` path. The new request escapes the mock to the real network, comes back 404, and trips the "no Not Found lines in the log overlay" assertion.

## Fix

- Match `/athlete/{id}/sport-settings` on both hosts (direct + CORS-proxy) in the OAuth mock route.
- Answer it with a realistic sport-settings payload: an **array** of per-sport entries (what `Util::parseJsonIntervalsIcuSettings` expects), with `power_zones` as % of FTP and `hr_zones` in absolute bpm.

## Validation

Ran locally against the fresh WASM artifact from failed run 27449710444 (the committed `docs/app` binary predates #272): the two failing tests pass, and the full `wasm-chromium` project is green — 31 passed, 7 skipped (the functional tests that need real `INTERVALS_ICU_API_KEY` credentials, unchanged).

Note: while tracing the 404 I found the deployed `mt-intervals-proxy` worker is currently serving the docs static site instead of the CORS proxy (every `/proxy/*` request 404s — Intervals.icu login is broken in production). That is independent of this fix; re-running the "Deploy intervals-cors-proxy Worker" workflow restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
