### PR TITLE
ci: dedupe branch runs, stop release self-retrigger, fix publish race, un-silence playwright

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ["**"]
     tags-ignore: ["**"]  # tag pushes are handled by release.yml, not build.yml
+    # docs/** is the GitHub Pages site, deployed by pages.yml. Skipping it here
+    # mainly stops the publish job's own "deploy Wasm artifacts" commit from
+    # triggering another full build (and minting another release) every time.
+    paths-ignore: ['docs/**']
   # Build every PR targeting master so cross-platform breakage (Windows/macOS/
   # WASM) is caught before merge — including PRs from forks, whose branches do
   # not trigger the push event on this repo. compute_version is master-only and
@@ -14,10 +18,13 @@ on:
 # Auto-cancel superseded runs: a new push to the same branch/PR cancels the
 # older in-flight run, so rapid iteration only pays for the latest commit's
 # full cross-platform matrix (Linux/Windows/macOS/WASM) instead of all of them.
-# head_ref (PR source branch) collapses the push + pull_request events for fork
-# PRs into one lane; master is never cancelled so every release build completes.
+# ref_name (not ref) so the push event ("my-branch") and the pull_request
+# event (head_ref "my-branch") land in the SAME group — an upstream branch
+# with an open PR previously ran the whole pipeline twice per push because
+# "refs/heads/my-branch" != "my-branch". Master is never cancelled so every
+# release build completes.
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -267,7 +274,6 @@ jobs:
   test_playwright:
     needs: [build_wasm]
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     env:
@@ -443,6 +449,13 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add docs/app/
         git diff --cached --quiet || git commit -m "chore: deploy Wasm build artifacts for ${{ needs.compute_version.outputs.new_tag }}"
+        # master moves while this run is in flight (any merge during the ~40 min
+        # pipeline); a plain push then fails non-fast-forward. Rebase and retry.
+        for attempt in 1 2 3; do
+          git push origin HEAD:refs/heads/master && exit 0
+          echo "Push rejected (attempt $attempt) — rebasing onto current master"
+          git pull --rebase origin master
+        done
         git push origin HEAD:refs/heads/master
 
     - name: Create GitHub Release


### PR DESCRIPTION
Four targeted fixes for the pipeline being long and flaky (no job restructuring yet — the test-shard consolidation discussed separately is a follow-up):

## 1. Branch pushes with an open PR ran the whole pipeline twice
The `push` (`branches: ["**"]`) and `pull_request` events both fire for upstream branches, and the concurrency groups never collapsed because `github.ref` is `refs/heads/my-branch` while `github.head_ref` is `my-branch`. Example: `ftms-command-queue` had paired full runs at 23:43 and 23:46 yesterday. Using `ref_name` puts both events in the same group so the newer run cancels the duplicate. Fork PRs are unaffected (their push events never reach this repo).

## 2. Every release re-triggered a full build
The `publish` job commits the WASM bundle to `docs/app/` on master, which triggered another full ~55-job run, minted another version tag, and cut another release. `paths-ignore: ['docs/**']` on the push event breaks the loop. `pages.yml` still deploys the site (it has its own `docs/**` trigger), and `pull_request` runs are untouched, so docs-only PRs still get checks.

## 3. `publish` failed whenever master moved during a run
Confirmed in runs 27446167097 / 27437754300: `! [rejected] HEAD -> master (fetch first)`. Any merge landing during the ~40-minute pipeline made the plain push fail. The step now rebases onto current master and retries up to 3 times.

## 4. `test_playwright` failures were invisible
The job had `continue-on-error: true`, so run 27449710444 reports overall conclusion **success** despite the red playwright job — the sport-settings breakage (#276) was only noticed by clicking into the job. Now that the suite is deterministic again, a red playwright job fails the run.

## Validation
- YAML parses cleanly.
- The publish retry only changes behavior on push rejection (previously a guaranteed job failure).
- Caveat for #1: when both events fire simultaneously for the same branch, one run cancels the other — the surviving run's checks attach to the same commit SHA, so PR checks are still reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
