### PR TITLE
ci: retry intervals.icu live test + capture its output to the log

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -580,7 +580,26 @@ jobs:
         make -j$(nproc)
 
     - name: Run Intervals.icu integration tests
-      run: ./build/tests/intervals_icu_integration_tests -v2
+      run: |
+        # Live test against intervals.icu: retry transient network/API blips
+        # before failing the job. -o writes results to a file we echo into the
+        # log, so failures stay diagnosable even if stdout is buffered/lost.
+        attempts=3
+        for i in $(seq 1 $attempts); do
+          echo "::group::Intervals.icu integration tests (attempt $i/$attempts)"
+          code=0
+          ./build/tests/intervals_icu_integration_tests -v2 -o results.txt,txt || code=$?
+          if [ -f results.txt ]; then cat results.txt; fi
+          echo "::endgroup::"
+          if [ "$code" -eq 0 ]; then
+            echo "Passed on attempt $i."
+            exit 0
+          fi
+          echo "Attempt $i failed with exit code $code."
+          if [ "$i" -lt "$attempts" ]; then sleep $((i * 15)); fi
+        done
+        echo "::error::Intervals.icu integration tests failed after $attempts attempts (likely a transient intervals.icu/network issue if no assertion appears above)."
+        exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
   # Online Mode Authentication Test – Linux

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -433,7 +433,26 @@ jobs:
         make -j$(sysctl -n hw.logicalcpu)
 
     - name: Run Intervals.icu integration tests
-      run: ./build/tests/intervals_icu_integration_tests -v2
+      run: |
+        # Live test against intervals.icu: retry transient network/API blips
+        # before failing the job. -o writes results to a file we echo into the
+        # log, so failures stay diagnosable even if stdout is buffered/lost.
+        attempts=3
+        for i in $(seq 1 $attempts); do
+          echo "::group::Intervals.icu integration tests (attempt $i/$attempts)"
+          code=0
+          ./build/tests/intervals_icu_integration_tests -v2 -o results.txt,txt || code=$?
+          if [ -f results.txt ]; then cat results.txt; fi
+          echo "::endgroup::"
+          if [ "$code" -eq 0 ]; then
+            echo "Passed on attempt $i."
+            exit 0
+          fi
+          echo "Attempt $i failed with exit code $code."
+          if [ "$i" -lt "$attempts" ]; then sleep $((i * 15)); fi
+        done
+        echo "::error::Intervals.icu integration tests failed after $attempts attempts (likely a transient intervals.icu/network issue if no assertion appears above)."
+        exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
   # Online Mode Authentication Test – macOS

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -587,8 +587,25 @@ jobs:
       shell: powershell
 
     - name: Run Intervals.icu integration tests
-      run: .\build\tests\intervals_icu_integration_tests.exe -v2
       shell: powershell
+      run: |
+        # Live test against intervals.icu: retry transient network/API blips
+        # before failing the job. QtTest's stdout is swallowed on the Windows
+        # runner, so -o writes results to a file we echo into the log — failures
+        # stay diagnosable instead of surfacing as a bare "exit code 1".
+        $attempts = 3
+        for ($i = 1; $i -le $attempts; $i++) {
+          Write-Host "::group::Intervals.icu integration tests (attempt $i/$attempts)"
+          & .\build\tests\intervals_icu_integration_tests.exe -v2 -o "results.txt,txt"
+          $code = $LASTEXITCODE
+          if (Test-Path results.txt) { Get-Content results.txt }
+          Write-Host "::endgroup::"
+          if ($code -eq 0) { Write-Host "Passed on attempt $i."; exit 0 }
+          Write-Host "Attempt $i failed with exit code $code."
+          if ($i -lt $attempts) { Start-Sleep -Seconds ($i * 15) }
+        }
+        Write-Host "::error::Intervals.icu integration tests failed after $attempts attempts (likely a transient intervals.icu/network issue if no assertion appears above)."
+        exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
   # Online Mode Authentication Test – Windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,28 +55,31 @@ Note: the AppImage/release build only bundles the `xcb` platform plugin (no
 
 ---
 
-## Git / PR workflow (IMPORTANT — fork-based)
+## Git / PR workflow (IMPORTANT — direct upstream access)
 
-This repo has **two remotes**:
-- `origin` → `MaximumTrainer/MaximumTrainer_Redux` (upstream; **no push access**)
-- `fork`   → `maximus321/MaximumTrainer_Redux` (push here)
+`maximus321` now has **write access to upstream**, so we branch and PR directly
+on the main repo. **Do not use the fork** — fork PRs don't receive CI secrets
+(`INTERVALS_ICU_*`, Strava), so the live integration tests would `QSKIP` instead
+of actually running.
+
+- `origin` → `MaximumTrainer/MaximumTrainer_Redux` (upstream; **push here**)
+- `fork`   → `maximus321/MaximumTrainer_Redux` (legacy; **don't use for now**)
 
 **Standard flow for any change:**
 ```bash
 git checkout master && git fetch origin master:master   # sync upstream
 git checkout -b my-feature-branch
 # ... work, commit ...
-git push -u fork my-feature-branch
+git push -u origin my-feature-branch          # build.yml runs on push (with secrets)
 gh pr create --repo MaximumTrainer/MaximumTrainer_Redux \
-  --base master --head maximus321:my-feature-branch --title "..." --body-file /tmp/body.md
+  --base master --head my-feature-branch --title "..." --body-file /tmp/body.md
 ```
 
+- Pushing to an upstream branch triggers the full cross-platform `build.yml`
+  immediately (`on: push: branches: ["**"]`); superseded runs auto-cancel.
+- **Prune merged branches** off the shared repo: `git push origin --delete <branch>`.
+
 **Gotchas learned the hard way:**
-- **The fork's `master` drifts.** A `github-actions[bot]` workflow runs on the
-  fork and periodically commits stale "deploy Wasm artifacts for vX.Y.Z" commits
-  straight to `fork/master`. Before syncing, expect to discard these (force-push
-  upstream's master over them: `git push fork master:master --force-with-lease=...`).
-  Consider disabling `build.yml`/`release.yml`/`pages.yml` on the fork to stop it.
 - **`gh pr edit` / `gh pr create` may print a GraphQL error** about "Projects
   (classic) deprecation" and silently fail the edit. Workaround: use the REST
   API — `gh api -X PATCH repos/OWNER/REPO/pulls/N --input payload.json` (build


### PR DESCRIPTION
## What

Hardens the live **Intervals.icu integration test** job (Windows/macOS/Linux) and fixes its diagnosability.

### 1. Retry transient network/API blips
The `intervals_icu_integration` job makes real HTTPS requests to `https://intervals.icu/api/v1`, so a single network hiccup, timeout, or rate-limit reds the whole pipeline even though nothing in the repo changed (e.g. a recent Windows-only failure where Linux/macOS passed the same commit). The run step now retries up to **3× with linear backoff (15s, 30s)** before failing. A genuine regression still fails (all attempts fail), and the final error message flags the likely-transient case.

### 2. Capture the test output reliably
QtTest's stdout was being **swallowed on the Windows runner** — the original failure surfaced as a bare `Process completed with exit code 1` with zero diagnostics. The step now runs with `-o results.txt,txt` and echoes the file into the log, so results are captured regardless of stdout buffering.

### 3. Docs: direct-upstream Git/PR flow
`maximus321` now has write access to upstream, so `CLAUDE.md`'s "Git / PR workflow" section is updated to branch + PR directly on `origin` instead of via the fork. Fork PRs don't receive CI secrets, so the live integration tests would `QSKIP` rather than run — pushing to upstream is required to validate them. Drops the now-irrelevant fork/master drift gotcha.

## Validation
Pushed to the upstream branch (so CI ran **with** the `INTERVALS_ICU_*` secrets). The full build matrix is green, and the Windows job now shows the captured output that was previously missing:

```
::group:: Intervals.icu integration tests (attempt 1/3)
********* Start testing of TstIntervalsIcuIntegration *********
PASS   : TstIntervalsIcuIntegration::testGetAthlete()
PASS   : TstIntervalsIcuIntegration::testGetEvents()
PASS   : TstIntervalsIcuIntegration::testGetWorkouts()
PASS   : TstIntervalsIcuIntegration::testBadApiKey()
Totals: 6 passed, 0 failed, 0 skipped, 611ms
Passed on attempt 1.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
