### PR TITLE
Workout view fixes: video first-load, race pacer perspective, unified distance, interval button, free-ride tweaks

### DIFF
--- a/src/game/qml/RetroRace.qml
+++ b/src/game/qml/RetroRace.qml
@@ -564,30 +564,28 @@ Item {
     }
 
     // ---------------------------------------------------------------- riders
-    // Opponent: shown up the road only while ahead of you (you are behind).
+    // Opponent: recedes UP the road (perspective) while ahead of you, so it
+    // visibly pulls away toward the vanishing point — and grows back toward you
+    // as the gap closes, until it draws level and you pass it (then it moves to
+    // the rear-view mirror). The gap is also shown on the HUD bubble.
     BackBike {
         id: oppBike
         readonly property real ahead: -race.gapMeters
-        readonly property real f: 55 / (55 + Math.max(0, ahead))     // 1 near .. ->0 far
-        // Keep the ghost riding right beside you (near the player's level and
-        // size) across the whole racing range — the gap is conveyed by the HUD.
-        readonly property real op: 0.60 + 0.16 * f                   // 0.60 .. 0.76 (always close)
-        readonly property real oz: (1.0 / Math.max(0.03, op)) * 38 + race.visualDist
-        visible: race.started && !race.finished && ahead > 0.5 && ahead < 250
-        s: Math.min(2.15, 1.45 + 0.7 * f)                            // near the player's size
+        // Perspective fraction: ~1 when right in front of you, →0 far up the road.
+        // ~20 m reads as "just ahead / drawing level".
+        readonly property real f: 20 / (20 + Math.max(0, ahead))
+        readonly property real oz: (1.0 / Math.max(0.05, f)) * 30 + race.visualDist
+        visible: race.started && !race.finished && ahead > 0.5 && ahead < 400
+        // Shrinks from the player's size when adjacent down to a speck far up the road.
+        s: 0.45 + 1.70 * f
         body: "#7fd0ff"; helmet: "#15323f"; alpha: 0.85   // cyan so it stands out on grey + the dash
         phase: race.oppCrankRev
         lean: root.curveAt(oz) * 13
         armUp: root.animT < root.oppCelebrateUntil ? 1 : 0   // brief flex after passing you
-        // Sit in the LEFT lane (offset grows as it nears) so you pull up
-        // alongside it rather than staring at its back wheel. Converges toward
-        // the centre/vanishing point when it is far up the road.
-        // Sit just to the LEFT of the player, almost touching — offset by the
-        // riders' own pixel widths (NOT maxHalfW, which scales with the window
-        // and otherwise flings the ghost far away on a wide screen). The player
-        // is centred at width/2 with half-width ≈ 62 px (s = 2.15).
-        x: root.width / 2 - width - 64
-        y: root.horizonY + root.roadH * (0.60 + 0.16 * f) - height
+        // Centred on the road (you see its back, directly ahead); rides from the
+        // player's level when adjacent (f→1) up to the vanishing point (f→0).
+        x: root.width / 2 - width / 2
+        y: root.horizonY + (playerBike.y - root.horizonY) * f - height * f
     }
     // Player: fixed near the bottom centre, large.
     BackBike {
@@ -608,9 +606,9 @@ Item {
         id: gapChip
         readonly property real absGap: Math.abs(race.gapMeters)
         readonly property bool hot: !root.leading && absGap < 15
-        // A 1-2 m lead is noise, not news — drop the "behind" bubble until the
-        // ghost actually loses contact (it still shows in the mirror).
-        visible: race.started && !race.finished && (!root.leading || absGap >= 3)
+        // A sub-2 m gap is noise, not news — only show the bubble (ahead OR
+        // behind) once there's a real gap.
+        visible: race.started && !race.finished && absGap >= 2
         z: 40
         anchors.horizontalCenter: parent.horizontalCenter
         y: playerBike.y - height - 12
@@ -779,7 +777,7 @@ Item {
         Connections { target: race
             function onUpdated() {
                 if (!race.started || race.finished) return
-                var km = Math.floor(race.playerDistanceM / 1000)
+                var km = Math.floor(race.displayDistanceM / 1000)
                 if (km > root.lastKm) { root.lastKm = km; root.score += 100; kmText.text = km + " KM  +100"; kmAnim.restart() }
             }
         }
@@ -822,7 +820,7 @@ Item {
             Text { text: value; color: vcolor; font.family: "monospace"; font.pixelSize: 18; font.bold: true }
         }
         Stat { label: "TIME";  value: root.fmtTime(race.workoutElapsedSec) }
-        Stat { label: "DIST";  value: (race.playerDistanceM / 1000).toFixed(2) + " km" }
+        Stat { label: "DIST";  value: (race.displayDistanceM / 1000).toFixed(2) + " km" }
         Stat { label: "SPEED"; value: race.playerSpeedKmh.toFixed(1) + " km/h" }
         Stat { label: "SCORE"; value: Math.floor(root.score).toString(); vcolor: "#ffe24a" }
     }
@@ -998,7 +996,7 @@ Item {
                color: race.gapMeters >= 0 ? "#5dff5d" : "#ff6b6b"
                font.family: "monospace"; font.pixelSize: 22; font.bold: true }
         Text { anchors.horizontalCenter: parent.horizontalCenter
-               text: (race.playerDistanceM / 1000).toFixed(2) + " km   ·   vs " + root.shortName(race.oppName, 24)
+               text: (race.displayDistanceM / 1000).toFixed(2) + " km   ·   vs " + root.shortName(race.oppName, 24)
                color: "#cde"; font.family: "monospace"; font.pixelSize: 14 }
         Text { anchors.horizontalCenter: parent.horizontalCenter
                text: "SCORE " + Math.floor(root.score)

--- a/src/game/retroracecontroller.h
+++ b/src/game/retroracecontroller.h
@@ -29,6 +29,10 @@ class RetroRaceController : public QObject
     Q_OBJECT
     Q_PROPERTY(double  elapsedSec      READ elapsedSec      NOTIFY updated)
     Q_PROPERTY(double  playerDistanceM READ playerDistanceM NOTIFY updated)
+    // The distance shown to the rider — fed from the workout's real ride distance
+    // so the race HUD matches the session widget. Falls back to the internal
+    // power-model distance (used for the opponent gap) until the workout feeds one.
+    Q_PROPERTY(double  displayDistanceM READ displayDistanceM NOTIFY updated)
     Q_PROPERTY(double  oppDistanceM    READ oppDistanceM    NOTIFY updated)
     Q_PROPERTY(double  gapMeters       READ gapMeters       NOTIFY updated)
     Q_PROPERTY(double  playerSpeedKmh  READ playerSpeedKmh  NOTIFY updated)
@@ -117,6 +121,10 @@ public:
 
     double  elapsedSec() const      { return m_elapsedSec; }
     double  playerDistanceM() const { return m_playerDistM; }
+    double  displayDistanceM() const { return m_displayDistM >= 0.0 ? m_displayDistM : m_playerDistM; }
+    /// Feed the workout's real ride distance (metres) so the HUD matches the
+    /// session widget. The internal power-model distance still drives the gap.
+    void    setDisplayDistanceM(double m) { m_displayDistM = m; }
     double  oppDistanceM() const    { return m_oppDistM; }
     double  gapMeters() const       { return m_playerDistM - m_oppDistM; }
     double  playerSpeedKmh() const  { return m_playerV * 3.6; }
@@ -245,6 +253,7 @@ private:
     double m_playerV     = 0.0;   // m/s
     double m_oppV        = 0.0;   // m/s
     double m_playerDistM = 0.0;
+    double m_displayDistM = -1.0;   // <0 = not fed yet; falls back to m_playerDistM
     double m_oppDistM    = 0.0;
     double m_playerPowerW = 0.0;
     double m_oppPowerW    = 0.0;

--- a/src/ui/components/clock.cpp
+++ b/src/ui/components/clock.cpp
@@ -1,5 +1,6 @@
 #include "clock.h"
 #include "myconstants.h"
+#include "cyclingphysics.h"   // shared power→speed model (also used by the retro race)
 
 #include <QDebug>
 
@@ -178,23 +179,11 @@ void Clock::timerSpeedTimeout() {
 
             //            qDebug() << "Calculating speed for user:" << i;
 
-            double powerRequiredRolling = calculateProlling(i);
-            double powerRequiredWind = calculatePwind(i);
-            double powerRequiredGravity = calculatePgravity(i);
-
-            // Net power available to accelerate relates to speed by
-            // P_net = m·v·(dv/dt), so dv/dt = P_net / (m·v) — NOT P_net / m
-            // (which omits the ·v and makes acceleration independent of speed).
-            // Floor v in the denominator to avoid a div-by-zero / runaway push
-            // from a standstill.
-            double speedForAccel = currentSpeedMS[i] < 0.5 ? 0.5 : currentSpeedMS[i];
-            double netPowerW = currentPowerWatts[i]
-                             - (powerRequiredRolling + powerRequiredWind + powerRequiredGravity);
-            double accelerationMs = netPowerW / (weightKG[i] * speedForAccel);
-            accelerationMs = accelerationMs * fractionSecond;
-            currentSpeedMS[i] = currentSpeedMS[i] + accelerationMs;
-            if (currentSpeedMS[i] < 0)
-                currentSpeedMS[i] = 0;
+            // Flat-road power→speed via the shared CyclingPhysics model (the same
+            // one the retro race integrates), so virtual speed and the race agree.
+            // Uses rider+bike mass (weightKG) and the rider's CdA.
+            currentSpeedMS[i] = CyclingPhysics::stepSpeed(
+                currentSpeedMS[i], currentPowerWatts[i], weightKG[i], cda[i], fractionSecond);
 
 
             //        qDebug() << "fractionSecond:" << fractionSecond << "diffTime" << diffTime;
@@ -224,43 +213,4 @@ void Clock::timerSpeedTimeout() {
 
 
 
-
-//P = Crr x N x v,
-//------------------------------------------------------------------------------
-//user ID is 0 to 39
-double Clock::calculateProlling(int pos) {
-
-    if (currentSpeedMS[pos] <= 0)
-        return 0;
-
-
-    return (0.005 * 9.8067 * weightKG[pos] * currentSpeedMS[pos]);
-
-    // insignifiant under 1 m/s, still calculate so user get to 0 eventually if stop pedalling
-    //    if (currentSpeedMS < 1)
-    //        return powerRequiredRolling + 1;
-
-}
-
-
-//P = 0.5 x ρ x v3 x Cd x A,
-//------------------------------------------------------------------------------
-double Clock::calculatePwind(int pos) {
-
-    // insignifiant under 1 m/s
-    if (currentSpeedMS[pos] < 1)
-        return 0;
-
-    return (0.5 * 1.275 * (currentSpeedMS[pos] * currentSpeedMS[pos] * currentSpeedMS[pos]) * cda[pos]);
-}
-
-//https://strava.zendesk.com/entries/20959332-Power-Calculations
-//P = m x g x sin(arctan(grade)) x v
-//------------------------------------------------------------------------------
-double Clock::calculatePgravity(int pos) {
-
-    // 0 for now, will adjust with slope later
-    Q_UNUSED(pos);
-    return 0;
-}
 

--- a/src/ui/components/clock.h
+++ b/src/ui/components/clock.h
@@ -50,9 +50,6 @@ private slots:
 
 
 private :
-    double calculateProlling(int userID);
-    double calculatePwind(int userID);
-    double calculatePgravity(int userID);
 
 private :
 

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -492,9 +492,12 @@ void DialogConfig::initUi() {
     ui->comboBox_powerAverage->setCurrentIndex(account->averaging_power);
     ui->spinBox_offsetPower->setValue(account->offset_power);
 
-    // The Game (index 2) is single-rider and unavailable in multi-rider studio
-    // mode — drop it from the selector there so it can't be picked.
-    if (account->enable_studio_mode && ui->comboBox_displayVideo->count() > 2)
+    // The Game (index 2) is single-rider (no use in multi-rider studio) and
+    // makes no sense in free ride (no targets/finish) — drop it from the
+    // selector in both cases so it can't be picked.
+    const bool freeRide = parentDialog
+            && parentDialog->workout.getWorkoutNameEnum() == Workout::OPEN_RIDE;
+    if ((account->enable_studio_mode || freeRide) && ui->comboBox_displayVideo->count() > 2)
         ui->comboBox_displayVideo->removeItem(2);
     ui->comboBox_displayVideo->setCurrentIndex(
         qMin(account->display_video, ui->comboBox_displayVideo->count() - 1));

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -649,11 +649,14 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
             workout.getWorkoutNameEnum() == Workout::CP5min_TEST || workout.getWorkoutNameEnum() == Workout::CP20min_TEST ||
             workout.getWorkoutNameEnum() == Workout::MAP_TEST ) {
         isTestWorkout = true;
-        ui->widget_topMenu->setButtonLapVisible(false);
     }
     else {
         isTestWorkout = false;
     }
+
+    // The lap / "Interval" button only makes sense in free ride (manual laps);
+    // structured workouts and tests advance intervals automatically, so hide it.
+    ui->widget_topMenu->setButtonLapVisible(workout.getWorkoutNameEnum() == Workout::OPEN_RIDE);
 
 
     initUI();
@@ -3191,7 +3194,14 @@ void WorkoutDialog::showEvent(QShowEvent *event) {
     // fully mapped first.
     if (!webPlayerLoaded) {
         webPlayerLoaded = true;
-        QTimer::singleShot(0, this, [this]() { ensureWebPlayer()->loadHomePageIfNeeded(); });
+        QTimer::singleShot(0, this, [this]() {
+            ensureWebPlayer()->loadHomePageIfNeeded();
+            // Re-assert the selected content view now that the dialog is mapped.
+            // The native QVideoWidget (Standard video) does not paint when first
+            // shown pre-map during init, leaving a black pane until the dropdown
+            // is toggled; re-applying here fixes the first-load black screen.
+            showVideoPlayer(account->display_video);
+        });
     }
 }
 
@@ -4059,6 +4069,11 @@ void WorkoutDialog::connectDataWorkout() {
     connect(arrDataWorkout[0], SIGNAL(tssChanged(double)), ui->wid_5_infoWorkout, SLOT(TSS_Changed(double)) );
     connect(arrDataWorkout[0], SIGNAL(caloriesWorkoutChanged(double)), ui->wid_5_infoWorkout, SLOT(calories_Changed(double)) );
     connect(arrDataWorkout[0], SIGNAL(totalDistanceChanged(double)), ui->wid_5_infoWorkout, SLOT(distanceChanged(double)) );
+    // Mirror the workout's real ride distance into the race HUD so the game's
+    // DIST readout matches the session widget (the race keeps its own internal
+    // power-model distance only for the player-vs-opponent gap).
+    connect(arrDataWorkout[0], &DataWorkout::totalDistanceChanged, this,
+            [this](double meters) { if (raceController) raceController->setDisplayDistanceM(meters); });
     //    }
 
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2798,9 +2798,11 @@ void WorkoutDialog::onToggleGameFullscreen() {
 // so switching only toggles which player is shown.
 void WorkoutDialog::showVideoPlayer(int choice) {
 
-    // The game is a single-rider ghost race — it has no defined "player" in the
-    // multi-rider studio mode, so it is unavailable there: fall back to video.
-    if (account->enable_studio_mode && choice == 2)
+    // The game (retro race) is unavailable in multi-rider studio mode (no single
+    // "player") and in free ride (no targets/finish — it doesn't make sense yet):
+    // fall back to video in both cases.
+    if ((account->enable_studio_mode
+         || workout.getWorkoutNameEnum() == Workout::OPEN_RIDE) && choice == 2)
         choice = 0;
 
     if (raceView) raceView->setVisible(false);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1752,17 +1752,13 @@ void WorkoutDialog::start_or_pause_workout() {
 void WorkoutDialog::sendLastSecondData(int seconds) {
 
     if (raceController) {
-        // Free ride is open-ended (its placeholder interval is a 5 s default),
-        // so it has no progress or finish line — never feed those in OPEN_RIDE,
-        // otherwise the finish line rides in over the first few seconds.
-        const bool openRide = workout.getWorkoutNameEnum() == Workout::OPEN_RIDE;
         const double tot = Util::convertQTimeToSecD(workout.getDurationQTime());
-        if (tot > 0 && !openRide) raceController->setWorkoutProgress(qBound(0.0, seconds / tot, 1.0));
+        if (tot > 0) raceController->setWorkoutProgress(qBound(0.0, seconds / tot, 1.0));
         raceController->setWorkoutElapsedSec(seconds);
         // timeInterval / the timers are decremented just AFTER this call, so the
         // values here read 1 s high vs the on-screen graph & timer widgets —
         // subtract 1 so the game's interval/finish countdowns stay in sync.
-        if (tot > 0 && !openRide) raceController->setFinishIn(qMax(0.0, tot - seconds - 1.0));
+        if (tot > 0) raceController->setFinishIn(qMax(0.0, tot - seconds - 1.0));
 
         // Preview the upcoming interval's target on the road ahead.
         const double secsToNext = qMax(0.0, Util::convertQTimeToSecD(timeInterval) - 1.0);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1752,13 +1752,17 @@ void WorkoutDialog::start_or_pause_workout() {
 void WorkoutDialog::sendLastSecondData(int seconds) {
 
     if (raceController) {
+        // Free ride is open-ended (its placeholder interval is a 5 s default),
+        // so it has no progress or finish line — never feed those in OPEN_RIDE,
+        // otherwise the finish line rides in over the first few seconds.
+        const bool openRide = workout.getWorkoutNameEnum() == Workout::OPEN_RIDE;
         const double tot = Util::convertQTimeToSecD(workout.getDurationQTime());
-        if (tot > 0) raceController->setWorkoutProgress(qBound(0.0, seconds / tot, 1.0));
+        if (tot > 0 && !openRide) raceController->setWorkoutProgress(qBound(0.0, seconds / tot, 1.0));
         raceController->setWorkoutElapsedSec(seconds);
         // timeInterval / the timers are decremented just AFTER this call, so the
         // values here read 1 s high vs the on-screen graph & timer widgets —
         // subtract 1 so the game's interval/finish countdowns stay in sync.
-        if (tot > 0) raceController->setFinishIn(qMax(0.0, tot - seconds - 1.0));
+        if (tot > 0 && !openRide) raceController->setFinishIn(qMax(0.0, tot - seconds - 1.0));
 
         // Preview the upcoming interval's target on the road ahead.
         const double secsToNext = qMax(0.0, Util::convertQTimeToSecD(timeInterval) - 1.0);


### PR DESCRIPTION
Workout-view fixes from on-trainer testing.

## Changes
- **Multimedia first load** — re-assert `showVideoPlayer()` once the dialog is mapped (in `showEvent`). The native `QVideoWidget` (Standard video) didn't paint when shown pre-map during init, leaving a black pane until the dropdown was toggled.
- **Retro race pacer** — when ahead, the opponent now **recedes up the road in perspective** (shrinks toward the vanishing point) instead of sitting beside you, so it visibly passes / pulls away and grows back as it closes. Gap bubble now shows only past a **2 m** gap (both ahead and behind), not sub-metre noise.
- **Distance** — unify the workout's virtual-speed onto the shared `CyclingPhysics` model (same math the race uses; drop the duplicate rolling/wind/gravity calc in `Clock`), and feed the workout's real ride distance into the race HUD (`displayDistanceM`) so the race **DIST** readout matches the session widget. The race keeps its own power-model distance only for the player-vs-opponent gap.
- **Interval button** — hidden outside free ride (`OPEN_RIDE`); structured workouts and tests advance intervals automatically.
- **Free ride: no Race mode** — the retro race needs targets/finish, so it's removed from the content selector in free ride (and falls back to video). This also makes the free-ride finish-line issue moot (the race controller is never created in free ride). Revisit a dedicated free-ride race later.

## Testing
- Desktop builds clean; workout view + race render verified (screenshot mode, no QML errors).
- Pacer perspective validated with a standalone render of the new formula (opponent shrinks/rises toward the horizon as the gap grows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
