### PR TITLE
ci(publish): re-sync instead of rebase on concurrent wasm deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,21 +452,31 @@ jobs:
     - name: Deploy Wasm files to docs/app/
       if: steps.download_wasm.outcome == 'success'
       run: |
-        mkdir -p repo/docs/app
-        unzip -o MaximumTrainer-wasm.zip -d repo/docs/app/
         cd repo
         git config user.name  "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add docs/app/
-        git diff --cached --quiet || git commit -m "chore: deploy Wasm build artifacts for ${{ needs.compute_version.outputs.new_tag }}"
         # master moves while this run is in flight (any merge during the ~40 min
-        # pipeline); a plain push then fails non-fast-forward. Rebase and retry.
+        # pipeline), so a plain push fails non-fast-forward. This deploy is a pure
+        # overwrite of docs/app with the freshly built artifacts, so on a rejected
+        # push we hard-reset to current origin/master and re-apply the artifacts —
+        # NOT `git pull --rebase`: git can't merge the binary MaximumTrainer.wasm,
+        # so a concurrent deploy dead-conflicts the rebase (the bug this replaces).
         for attempt in 1 2 3; do
+          git fetch origin master
+          git reset --hard origin/master
+          mkdir -p docs/app
+          unzip -o ../MaximumTrainer-wasm.zip -d docs/app/
+          git add docs/app/
+          if git diff --cached --quiet; then
+            echo "docs/app already up to date — nothing to deploy"
+            exit 0
+          fi
+          git commit -m "chore: deploy Wasm build artifacts for ${{ needs.compute_version.outputs.new_tag }}"
           git push origin HEAD:refs/heads/master && exit 0
-          echo "Push rejected (attempt $attempt) — rebasing onto current master"
-          git pull --rebase origin master
+          echo "Push rejected (attempt $attempt) — re-syncing to origin/master and retrying"
         done
-        git push origin HEAD:refs/heads/master
+        echo "::error::Wasm deploy could not push after 3 attempts"
+        exit 1
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem

Master went red after #282 merged — but **every build and test job passed**. The only failure was the `publish` job ([run](https://github.com/MaximumTrainer/MaximumTrainer_Redux/actions/runs/27485463835)):

```
warning: Cannot merge binary files: docs/app/MaximumTrainer.wasm
CONFLICT (content): Merge conflict in docs/app/MaximumTrainer.wasm
error: could not apply ... chore: deploy Wasm build artifacts for v0.0.160
Process completed with exit code 1
```

`publish` deploys the WASM build by committing `docs/app/` back to `master`. #281 and #282 merged back-to-back, so the second run's push was rejected non-fast-forward. The existing retry then ran `git pull --rebase origin master` — but git **cannot merge the binary `MaximumTrainer.wasm`**, so the rebase dead-conflicts and the job fails. This is a race that recurs any time two merges land within the ~40-min pipeline window.

## Fix

The deploy is a pure overwrite of `docs/app` with the freshly built artifacts, so the binary "conflict" is meaningless. On a rejected push, **hard-reset to current `origin/master` and re-extract the artifacts on top**, then retry — no rebase, no binary merge:

```bash
for attempt in 1 2 3; do
  git fetch origin master
  git reset --hard origin/master
  unzip -o ../MaximumTrainer-wasm.zip -d docs/app/
  git add docs/app/
  git diff --cached --quiet && exit 0   # already up to date
  git commit -m "...deploy..."
  git push origin HEAD:refs/heads/master && exit 0
done
exit 1   # fail loudly if all attempts exhausted
```

Also makes the job **fail loudly** if all 3 attempts are exhausted (the old version fell through to a bare final push).

## Validation
- `yaml.safe_load` parses the workflow.
- `bash -n` on the extracted run block (GHA expressions neutralized) passes.
- `git push … && exit 0` is safe under `set -e` (left operand of `&&` doesn't trigger exit-on-error), so the loop continues on a rejected push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
