### PR TITLE
feat(login): add MaximumTrainer → Log Out menu item

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QTimer>
+#include <functional>
 #include <QFontDatabase>
 #ifdef Q_OS_WIN
 #include <QOperatingSystemVersion>
@@ -345,12 +346,24 @@ int main(int argc, char *argv[]) {
     // bypassed in screenshot mode). Heap-allocated so it outlives this scope;
     // the app quits explicitly from MainWindow::closeEvent (we disabled
     // quitOnLastWindowClosed above).
-    auto launchMainWindow = [&]() -> MainWindow * {
+    // Mutually-recursive: launching the main window wires Log Out back to
+    // showLogin(), and a successful login launches the main window. Declared as
+    // std::function so each can call the other (both live for the whole run).
+    std::function<MainWindow *()> launchMainWindow;
+    std::function<void()> showLogin;
+
+    launchMainWindow = [&]() -> MainWindow * {
         // Re-apply theme based on user preference now that the Account is loaded.
         if (auto *account = qApp->property("Account").value<Account*>())
             AppTheme::apply(qApp, static_cast<AppTheme::Mode>(account->app_theme));
 
         auto *mainWin = new MainWindow();
+        // Log Out tears this window down and returns to the login screen
+        // in-process (no app relaunch).
+        QObject::connect(mainWin, &MainWindow::logoutRequested, mainWin, [&showLogin, mainWin]() {
+            mainWin->deleteLater();
+            showLogin();
+        });
 #ifndef Q_OS_WASM
         splash.setProgress(100);
         splash.finish(mainWin);
@@ -433,31 +446,34 @@ int main(int argc, char *argv[]) {
     // clicks "Sign in with Intervals.icu". Running on the main app.exec() loop
     // (as the WASM path always has) removes that nested loop and the hazard.
     // MainWindow is created only once the user has successfully logged in.
-    auto *loginDlg = new DialogLogin(nullptr);
-    QObject::connect(loginDlg, &QDialog::accepted, loginDlg, [loginDlg, launchMainWindow]() {
-        // getGotUpdate(): the dialog redirected the user to a new-version
-        // download and rejected itself, so accepted() never fires in that case.
-        launchMainWindow();
-        loginDlg->deleteLater();
-    });
-    QObject::connect(loginDlg, &QDialog::rejected, loginDlg, [loginDlg]() {
-        // Login refused, or redirected to a version download (getGotUpdate()).
-        loginDlg->deleteLater();
-        qApp->quit();
-    });
-    loginDlg->show();
-    // The login dialog is the first window the user sees; some Linux window
-    // managers stack a freshly-shown, terminal-launched window behind others.
-    // Force it to the front and focused, re-issuing once the event loop has
-    // processed the map (raise()/activateWindow() right after show() can be a
-    // no-op before the window is mapped). Clear any stale minimized state too.
-    loginDlg->setWindowState((loginDlg->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-    loginDlg->raise();
-    loginDlg->activateWindow();
-    QTimer::singleShot(0, loginDlg, [loginDlg]() {
+    showLogin = [&]() {
+        auto *loginDlg = new DialogLogin(nullptr);
+        QObject::connect(loginDlg, &QDialog::accepted, loginDlg, [&launchMainWindow, loginDlg]() {
+            // getGotUpdate(): the dialog redirected the user to a new-version
+            // download and rejected itself, so accepted() never fires in that case.
+            launchMainWindow();
+            loginDlg->deleteLater();
+        });
+        QObject::connect(loginDlg, &QDialog::rejected, loginDlg, [loginDlg]() {
+            // Login refused, or redirected to a version download (getGotUpdate()).
+            loginDlg->deleteLater();
+            qApp->quit();
+        });
+        loginDlg->show();
+        // The login dialog is the first window the user sees; some Linux window
+        // managers stack a freshly-shown, terminal-launched window behind others.
+        // Force it to the front and focused, re-issuing once the event loop has
+        // processed the map (raise()/activateWindow() right after show() can be a
+        // no-op before the window is mapped). Clear any stale minimized state too.
+        loginDlg->setWindowState((loginDlg->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
         loginDlg->raise();
         loginDlg->activateWindow();
-    });
+        QTimer::singleShot(0, loginDlg, [loginDlg]() {
+            loginDlg->raise();
+            loginDlg->activateWindow();
+        });
+    };
+    showLogin();
 
     return app.exec();
 }

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -453,6 +453,25 @@ void Account::saveIntervalsIcuCredentials() {
     CredentialStore::store("intervals_icu", "refresh_token", intervals_icu_refresh_token);
 }
 
+void Account::logout()
+{
+    // OAuth tokens (encrypted store).
+    CredentialStore::remove("intervals_icu", "access_token");
+    CredentialStore::remove("intervals_icu", "refresh_token");
+    intervals_icu_access_token.clear();
+    intervals_icu_refresh_token.clear();
+
+    // Manual API key + athlete id (the athlete id is what auto-logs the app in).
+    intervals_icu_api_key.clear();
+    intervals_icu_athlete_id.clear();
+
+    QSettings settings;
+    settings.beginGroup("account");
+    settings.remove("intervals_icu_api_key");
+    settings.remove("intervals_icu_athlete_id");
+    settings.endGroup();
+}
+
 void Account::saveStravaCredentials()
 {
     CredentialStore::store("strava", "access_token",  strava_access_token);

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -23,6 +23,10 @@ public:
     /// restart and offline use. Edited from the Preferences dialog.
     void saveProfileFields(int ftp, int lthr, double weightKg);
     void saveIntervalsIcuCredentials();
+    /// Sign out: clear the Intervals.icu identity (OAuth tokens, manual API key
+    /// and athlete id) from memory, the encrypted credential store and QSettings.
+    /// The next launch shows the login screen again.
+    void logout();
     void saveSensorDropoutSettings();
     void saveBatteryWarningThreshold();
     void saveIntervalSummarySettings();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1144,6 +1144,13 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
     qDebug () << "closeEvent Done mainWindow";
 
+    // On logout, hand back to the login screen in-process rather than quitting;
+    // main.cpp tears this window down and re-shows the login dialog.
+    if (m_loggingOut) {
+        emit logoutRequested();
+        return;
+    }
+
     // quitOnLastWindowClosed is disabled (see main.cpp), so quit explicitly
     // once the main window has finished closing.
     qApp->quit();
@@ -1153,6 +1160,24 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 /////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::on_actionExit_triggered()
 {
+    this->close();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+void MainWindow::on_actionLogout_triggered()
+{
+    if (QMessageBox::question(
+            this, tr("Log Out"),
+            tr("Log out of Intervals.icu and return to the login screen?"))
+        != QMessageBox::Yes)
+        return;
+
+    if (account)
+        account->logout();
+
+    // close() runs the normal save path; closeEvent then re-shows the login
+    // screen in-process (instead of quitting) because we're logging out.
+    m_loggingOut = true;
     this->close();
 }
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -60,6 +60,9 @@ public:
 signals :
     void isExpanded(bool isExpanded);
     void ftpAndTabProfileChanged();
+    /// Emitted from closeEvent when the user chose Log Out, so the app can
+    /// return to the login screen in-process instead of quitting.
+    void logoutRequested();
 
 
 public slots:
@@ -156,6 +159,7 @@ private slots:
 
     void on_actionOpen_Ride_triggered();
     void on_actionExit_triggered();
+    void on_actionLogout_triggered();
 
 
     void on_actionSingle_Workout_triggered();
@@ -224,6 +228,7 @@ private:
     Settings *settings;
     Account *account;
     FancyTabBar *ftb;
+    bool m_loggingOut = false;   // set by Log Out so closeEvent re-shows login
 
     int currentIndexLeftMenu;
     bool isInsideWorkout;

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -373,6 +373,7 @@
      <string>MaximumTrainer</string>
     </property>
     <addaction name="actionPreferences"/>
+    <addaction name="actionLogout"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -413,6 +414,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+,</string>
+   </property>
+  </action>
+  <action name="actionLogout">
+   <property name="text">
+    <string>Log Out</string>
    </property>
   </action>
   <action name="actionAbout_MT">


### PR DESCRIPTION
## What

Adds a **Log Out** action to the `MaximumTrainer` menu (next to Preferences). It clears the Intervals.icu identity and returns to the login screen **in-process — no app relaunch**.

## Why

There was no in-app way to sign out / switch accounts; the only way to clear a cached login was hand-editing the QSettings `.conf`. This also gives a clean way to re-test the login flow.

## How

- `Account::logout()` centralises the teardown: removes the OAuth tokens from the encrypted `CredentialStore`, clears the manual API key + athlete id (the athlete id is what auto-logs the app in), and removes them from QSettings. Strava is left untouched.
- `MainWindow` emits `logoutRequested()` from `closeEvent` (guarded by `m_loggingOut`) instead of quitting.
- `main.cpp` now keeps login + main-window launch as mutually-recursive `showLogin()` / `launchMainWindow()` lambdas, so logout deletes the window and re-shows the login dialog on the running event loop.

## Test

Built locally (Qt 6.10 / QWT 6.3). Manually validated: MaximumTrainer → Log Out → confirm → returns to the login dialog; re-login via Intervals.icu OAuth works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
