### PR TITLE
fix(intervals): load workouts planned directly on the calendar (#288)

### DIFF
--- a/src/persistence/db/intervals_icu_api.cpp
+++ b/src/persistence/db/intervals_icu_api.cpp
@@ -135,6 +135,25 @@ QNetworkReply* IntervalsIcuApi::downloadWorkoutZwo(const QString &athleteId,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v1/athlete/{id}/events/{eventId}/download.zwo
+QNetworkReply* IntervalsIcuApi::downloadEventZwo(const QString &athleteId,
+                                                     const QString &eventId,
+                                                     const QString &apiKey)
+{
+    QNetworkAccessManager *manager =
+        qApp->property("NetworkManagerWS").value<QNetworkAccessManager*>();
+    if (!manager) {
+        LOG_WARN("IntervalsIcuApi", QStringLiteral("downloadEventZwo: NetworkManagerWS not available"));
+        return nullptr;
+    }
+
+    const QString url = QLatin1String(BASE_URL) + QStringLiteral("/athlete/") + athleteId
+                        + QStringLiteral("/events/") + eventId
+                        + QStringLiteral("/download.zwo");
+    return manager->get(buildRequest(url, apiKey));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GET /api/v1/athlete/{id}/workouts/{workoutId}.mrc
 QNetworkReply* IntervalsIcuApi::downloadWorkoutMrc(const QString &athleteId,
                                                        const QString &workoutId,

--- a/src/persistence/db/intervals_icu_api.h
+++ b/src/persistence/db/intervals_icu_api.h
@@ -57,6 +57,14 @@ public:
                                              const QString &workoutId,
                                              const QString &apiKey);
 
+    /// Download a planned calendar event's structured workout as a ZWO file.
+    /// Calendar-authored workouts have no library workout_id — the steps live
+    /// in the event itself — so the download is keyed on the event id.
+    /// GET /athlete/{id}/events/{eventId}/download.zwo
+    static QNetworkReply* downloadEventZwo(const QString &athleteId,
+                                           const QString &eventId,
+                                           const QString &apiKey);
+
     /// Create a workout in the athlete's library.
     /// POST /athlete/{id}/workouts
     /// @param json  UTF-8 encoded JSON object describing the new workout.

--- a/src/persistence/db/intervalsicuservice.cpp
+++ b/src/persistence/db/intervalsicuservice.cpp
@@ -89,16 +89,16 @@ QNetworkReply *IntervalsIcuService::fetchCalendar(const QDate &oldest,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-QNetworkReply *IntervalsIcuService::downloadWorkoutZwo(const QString &workoutId)
+QNetworkReply *IntervalsIcuService::downloadEventZwo(const QString &eventId)
 {
     const QString path =
-        QString("/athlete/%1/workouts/%2.zwo")
-            .arg(m_athleteId, workoutId);
+        QString("/athlete/%1/events/%2/download.zwo")
+            .arg(m_athleteId, eventId);
 
     auto *mgr = qApp->property("NetworkManagerWS")
                     .value<QNetworkAccessManager *>();
     if (!mgr) {
-        LOG_WARN("IntervalsIcuService", QStringLiteral("downloadWorkoutZwo: NetworkManagerWS not available"));
+        LOG_WARN("IntervalsIcuService", QStringLiteral("downloadEventZwo: NetworkManagerWS not available"));
         return nullptr;
     }
     return mgr->get(buildRequest(path));
@@ -192,9 +192,10 @@ IntervalsIcuService::parseEvents(const QByteArray &data)
         ev.duration_sec = obj["moving_time"].toInt(0);
         ev.description = obj["description"].toString();
 
-        // workout_id may be absent (free event, not a structured workout)
-        if (obj.contains("workout_id") && !obj["workout_id"].isNull())
-            ev.workout_id = QString::number(obj["workout_id"].toVariant().toLongLong());
+        // category distinguishes structured workouts ("WORKOUT") from notes,
+        // races and other calendar entries. Workouts are downloadable via the
+        // event id regardless of whether a library workout_id is linked.
+        ev.category    = obj["category"].toString();
 
         // start_date_local is ISO 8601 "YYYY-MM-DDThh:mm:ss"
         const QString dateStr =

--- a/src/persistence/db/intervalsicuservice.h
+++ b/src/persistence/db/intervalsicuservice.h
@@ -36,8 +36,17 @@ public:
         QDate   date;
         QString type;
         int     duration_sec;   ///< moving_time in seconds (0 if unavailable)
-        QString workout_id;     ///< workout id for .zwo download ("" if none)
+        QString category;       ///< event category, e.g. "WORKOUT"
         QString description;
+
+        /// True when the event is a structured/planned workout that can be
+        /// downloaded as a .zwo file via its event id. Workouts authored
+        /// directly on the calendar carry no separate workout_id — the steps
+        /// live in the event itself — so downloadability is keyed on category.
+        bool isDownloadableWorkout() const
+        {
+            return category == QLatin1String("WORKOUT");
+        }
     };
 
     explicit IntervalsIcuService(QObject *parent = nullptr);
@@ -59,8 +68,9 @@ public:
     /// GET /api/v1/athlete/{id}/events  — calendar events in [oldest, newest].
     QNetworkReply *fetchCalendar(const QDate &oldest, const QDate &newest);
 
-    /// GET /api/v1/athlete/{id}/workouts/{workoutId}.zwo
-    QNetworkReply *downloadWorkoutZwo(const QString &workoutId);
+    /// GET /api/v1/athlete/{id}/events/{eventId}/download.zwo
+    /// Downloads a planned calendar event's structured workout as a .zwo file.
+    QNetworkReply *downloadEventZwo(const QString &eventId);
 
     /// POST /api/v1/athlete/0/activities — upload a FIT/TCX file.
     /// @param filePath  Absolute path to the activity file (.fit or .tcx).

--- a/src/ui/tab_intervals_icu.cpp
+++ b/src/ui/tab_intervals_icu.cpp
@@ -123,8 +123,8 @@ TabIntervalsIcu::TabIntervalsIcu(QWidget *parent)
                 const int row =
                     ui->tableWidget_calendar->currentRow();
                 const bool hasWorkout =
-                    row >= 0 && row < m_rowWorkoutIds.size() &&
-                    !m_rowWorkoutIds[row].isEmpty();
+                    row >= 0 && row < m_rowEventIds.size() &&
+                    !m_rowEventIds[row].isEmpty();
                 ui->pushButton_loadWorkout->setEnabled(hasWorkout);
             });
 }
@@ -156,7 +156,7 @@ void TabIntervalsIcu::refreshCredentials()
         // Clear any stale calendar data so the old content isn't visible
         // with credentials that may no longer be valid.
         ui->tableWidget_calendar->setRowCount(0);
-        m_rowWorkoutIds.clear();
+        m_rowEventIds.clear();
         ui->pushButton_loadWorkout->setEnabled(false);
 
         // Also abort any in-flight requests
@@ -281,7 +281,7 @@ void TabIntervalsIcu::onPrevWeekClicked()
     m_weekStart = m_weekStart.addDays(-7);
     updateWeekLabel();
     ui->tableWidget_calendar->setRowCount(0);
-    m_rowWorkoutIds.clear();
+    m_rowEventIds.clear();
     ui->pushButton_loadWorkout->setEnabled(false);
 }
 
@@ -291,7 +291,7 @@ void TabIntervalsIcu::onNextWeekClicked()
     m_weekStart = m_weekStart.addDays(7);
     updateWeekLabel();
     ui->tableWidget_calendar->setRowCount(0);
-    m_rowWorkoutIds.clear();
+    m_rowEventIds.clear();
     ui->pushButton_loadWorkout->setEnabled(false);
 }
 
@@ -299,11 +299,11 @@ void TabIntervalsIcu::onNextWeekClicked()
 void TabIntervalsIcu::onLoadWorkoutClicked()
 {
     const int row = ui->tableWidget_calendar->currentRow();
-    if (row < 0 || row >= m_rowWorkoutIds.size())
+    if (row < 0 || row >= m_rowEventIds.size())
         return;
 
-    const QString workoutId = m_rowWorkoutIds[row];
-    if (workoutId.isEmpty())
+    const QString eventId = m_rowEventIds[row];
+    if (eventId.isEmpty())
         return;
 
     if (m_downloadReply) {
@@ -326,7 +326,7 @@ void TabIntervalsIcu::onLoadWorkoutClicked()
     // Disable selection while download is in progress
     ui->tableWidget_calendar->setSelectionMode(QAbstractItemView::NoSelection);
 
-    m_downloadReply = m_service->downloadWorkoutZwo(workoutId);
+    m_downloadReply = m_service->downloadEventZwo(eventId);
     connect(m_downloadReply, &QNetworkReply::finished,
             this, &TabIntervalsIcu::onWorkoutDownloadFinished);
 }
@@ -439,7 +439,7 @@ void TabIntervalsIcu::populateTable(
     const QList<IntervalsIcuService::CalendarEvent> &events)
 {
     ui->tableWidget_calendar->setRowCount(0);
-    m_rowWorkoutIds.clear();
+    m_rowEventIds.clear();
     ui->pushButton_loadWorkout->setEnabled(false);
 
     for (const IntervalsIcuService::CalendarEvent &ev : events) {
@@ -465,7 +465,7 @@ void TabIntervalsIcu::populateTable(
         ui->tableWidget_calendar->setItem(
             row, 3, new QTableWidgetItem(durStr));
 
-        m_rowWorkoutIds.append(ev.workout_id);
+        m_rowEventIds.append(ev.isDownloadableWorkout() ? ev.id : QString());
     }
 }
 
@@ -556,7 +556,7 @@ void TabIntervalsIcu::onSyncCalendarFetched()
         IntervalsIcuService::parseEvents(data);
 
     for (const IntervalsIcuService::CalendarEvent &ev : allEvents) {
-        if (!ev.workout_id.isEmpty())
+        if (ev.isDownloadableWorkout())
             m_syncQueue.append(ev);
     }
 
@@ -587,9 +587,9 @@ void TabIntervalsIcu::downloadNextSyncWorkout()
     const IntervalsIcuService::CalendarEvent ev = m_syncQueue.takeFirst();
     m_pendingSyncWorkoutName = ev.name.trimmed();
     if (m_pendingSyncWorkoutName.isEmpty())
-        m_pendingSyncWorkoutName = ev.workout_id;
+        m_pendingSyncWorkoutName = ev.id;
 
-    m_syncDownloadReply = m_service->downloadWorkoutZwo(ev.workout_id);
+    m_syncDownloadReply = m_service->downloadEventZwo(ev.id);
     connect(m_syncDownloadReply, &QNetworkReply::finished,
             this, &TabIntervalsIcu::onSyncWorkoutDownloaded);
 }

--- a/src/ui/tab_intervals_icu.h
+++ b/src/ui/tab_intervals_icu.h
@@ -82,9 +82,10 @@ private:
     QNetworkReply *m_downloadReply  = nullptr;
     QString        m_pendingWorkoutName; ///< name captured at download start
 
-    // Parallel list of workout IDs for each table row (empty string = no
-    // downloadable workout for that event)
-    QList<QString> m_rowWorkoutIds;
+    // Parallel list of event IDs for each table row (empty string = the event
+    // is not a downloadable workout). Loadable rows store the event id used by
+    // the /events/{id}/download.zwo endpoint.
+    QList<QString> m_rowEventIds;
 
     // Batch sync state
     QNetworkReply *m_syncCalendarReply  = nullptr;

--- a/tests/integration/tst_online_mode.cpp
+++ b/tests/integration/tst_online_mode.cpp
@@ -1116,10 +1116,15 @@ void TstOnlineMode::testCalendarPlan()
     const QString eventName = QString("MaximumTrainer CI Plan [%1]").arg(timestamp);
     const QDate   tomorrow  = QDate::currentDate().addDays(1);
 
+    // The 'description' of a WORKOUT event is intervals.icu's native workout
+    // text format. Providing structured steps here makes the event downloadable
+    // as a .zwo via /events/{id}/download.zwo — the exact path the app uses when
+    // a user loads a workout planned directly on the calendar (no workout_id).
     const QJsonObject eventJson {
         { "category",         "WORKOUT"                    },
         { "type",             "Ride"                       },
         { "name",             eventName                    },
+        { "description",      "- 10m 60%\n- 5m 75%"        },
         { "start_date_local", QDateTime(tomorrow, QTime(0, 0)).toString(Qt::ISODate) }
     };
     const QByteArray eventBody = QJsonDocument(eventJson).toJson(QJsonDocument::Compact);
@@ -1168,19 +1173,47 @@ void TstOnlineMode::testCalendarPlan()
     const QJsonDocument listDoc = QJsonDocument::fromJson(listBody);
     QVERIFY2(listDoc.isArray(), "getEvents response is not a JSON array");
 
-    bool found = false;
+    QJsonObject foundEvent;
     for (const QJsonValue &v : listDoc.array()) {
         if (v.toObject().value("id").toVariant().toString() == m_createdEventId) {
-            found = true;
+            foundEvent = v.toObject();
             break;
         }
     }
 
-    QVERIFY2(found,
+    QVERIFY2(!foundEvent.isEmpty(),
              qPrintable(QString("Created event id %1 ('%2') not found in calendar for %3")
                         .arg(m_createdEventId, eventName, tomorrow.toString())));
 
     qDebug().noquote() << "[testCalendarPlan] Event" << m_createdEventId
                        << "confirmed in calendar for" << tomorrow.toString();
+
+    // The event is a structured workout (category WORKOUT) and carries no
+    // separate workout_id — this is the exact shape that previously left the
+    // "Load Selected Workout" button disabled (issue #288). The app keys
+    // downloadability on category, so verify that holds for a real event.
+    QCOMPARE(foundEvent.value("category").toString(), QStringLiteral("WORKOUT"));
+
+    // ── Download the planned workout via the event endpoint ──────────────────
+    QNetworkReply *zwoReply = IntervalsIcuApi::downloadEventZwo(
+        m_athleteId, m_createdEventId, m_apiKey);
+    QVERIFY2(zwoReply, "downloadEventZwo returned null reply");
+    waitForReply(zwoReply, 30'000);
+
+    const int zwoStatus = zwoReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray zwoBody = zwoReply->readAll();
+    zwoReply->deleteLater();
+
+    qDebug().noquote() << "[testCalendarPlan] downloadEventZwo HTTP" << zwoStatus
+                       << "bytes" << zwoBody.size();
+    QVERIFY2(zwoStatus == 200,
+             qPrintable(QString("Expected event download HTTP 200, got %1: %2")
+                        .arg(zwoStatus).arg(QString(zwoBody.left(300)))));
+    QVERIFY2(zwoBody.contains("<workout_file"),
+             qPrintable(QString("Event download did not return a ZWO file: %1")
+                        .arg(QString(zwoBody.left(300)))));
+
+    qDebug().noquote() << "[testCalendarPlan] Planned workout downloaded as ZWO ("
+                       << zwoBody.size() << "bytes)";
 }
 QTEST_MAIN(TstOnlineMode)

--- a/tests/intervals_icu/tst_intervals_icu_service.cpp
+++ b/tests/intervals_icu/tst_intervals_icu_service.cpp
@@ -122,6 +122,7 @@ private slots:
     void testConvertWorkoutToZwo_authHeader();
     void testDownloadZwo_authHeader();
     void testDownloadMrc_authHeader();
+    void testDownloadEvent_authHeader();
 
     // ── Accept header ───────────────────────────────────────────────────────
     void testGetAthlete_acceptHeader();
@@ -134,6 +135,7 @@ private slots:
     void testConvertWorkoutToZwo_url();
     void testDownloadZwo_url();
     void testDownloadMrc_url();
+    void testDownloadEvent_url();
 
     // ── getEvents query parameters ──────────────────────────────────────────
     void testGetEvents_queryParams();
@@ -147,6 +149,7 @@ private:
     static constexpr const char ATHLETE_ID[] = "i12345";
     static constexpr const char API_KEY[]    = "testApiKey";
     static constexpr const char WORKOUT_ID[] = "w99";
+    static constexpr const char EVENT_ID[]   = "55512345";
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -245,6 +248,18 @@ void TstIntervalsIcuService::testDownloadMrc_authHeader()
 {
     QNetworkReply *reply = IntervalsIcuApi::downloadWorkoutMrc(
         ATHLETE_ID, WORKOUT_ID, API_KEY);
+    QVERIFY(reply != nullptr);
+    QCOMPARE(m_manager->callCount, 1);
+    reply->deleteLater();
+
+    const QByteArray header = m_manager->lastRequest.rawHeader("Authorization");
+    QCOMPARE(header, expectedBasicHeader(API_KEY));
+}
+
+void TstIntervalsIcuService::testDownloadEvent_authHeader()
+{
+    QNetworkReply *reply = IntervalsIcuApi::downloadEventZwo(
+        ATHLETE_ID, EVENT_ID, API_KEY);
     QVERIFY(reply != nullptr);
     QCOMPARE(m_manager->callCount, 1);
     reply->deleteLater();
@@ -357,6 +372,22 @@ void TstIntervalsIcuService::testDownloadMrc_url()
 
     const QString url = m_manager->lastRequest.url().toString();
     QVERIFY(url.contains(QStringLiteral("/workouts/") + WORKOUT_ID + QStringLiteral(".mrc")));
+}
+
+void TstIntervalsIcuService::testDownloadEvent_url()
+{
+    QNetworkReply *reply = IntervalsIcuApi::downloadEventZwo(
+        ATHLETE_ID, EVENT_ID, API_KEY);
+    QVERIFY(reply != nullptr);
+    QCOMPARE(m_manager->callCount, 1);
+    reply->deleteLater();
+
+    const QString url = m_manager->lastRequest.url().toString();
+    QVERIFY(url.contains(QStringLiteral("/athlete/") + ATHLETE_ID
+                         + QStringLiteral("/events/") + EVENT_ID
+                         + QStringLiteral("/download.zwo")));
+    // A calendar event download must NOT hit the library /workouts/ endpoint.
+    QVERIFY(!url.contains(QStringLiteral("/workouts/")));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem (#288)

After logging in with an Intervals.icu API key, a workout planned for today shows up after **Refresh** (`1 event(s) loaded`) but **Load Selected Workout** stays disabled, and **Sync All This Week** reports no workouts.

## Root cause — one bug, both symptoms

A workout authored **directly on the Intervals.icu calendar** embeds its structured steps in the event itself and has **no `workout_id`**. That field is only populated when an event links a *saved library workout*.

`TabIntervalsIcu` gated everything on a non-empty `workout_id`:

- **Load button** (`itemSelectionChanged`) and **`populateTable`** stored `ev.workout_id` per row → empty → button never enables.
- **Sync** (`onSyncCalendarFetched`) queued only events `if (!ev.workout_id.isEmpty())` → nothing to download.

The download endpoint was also wrong: `/athlete/{id}/workouts/{workoutId}.zwo` hits the **library**, not the calendar event.

## Fix

- Decide downloadability by event **category** (`"WORKOUT"`) via `CalendarEvent::isDownloadableWorkout()`; remove the dead `workout_id` field and parse `category` instead.
- Download planned events **by event id** through the correct endpoint:
  `GET /athlete/{id}/events/{eventId}/download.zwo`
  (new `IntervalsIcuService::downloadEventZwo` + `IntervalsIcuApi::downloadEventZwo` helper).

This covers both calendar-authored and library-linked planned workouts (both are category `WORKOUT`).

## Tests

- **Unit** (`tst_intervals_icu_service`): assert the event-download URL is `/events/{id}/download.zwo` (and *not* `/workouts/`) plus the auth header. 21/21 pass locally.
- **Integration** (`testCalendarPlan`, runs with CI Intervals secrets): now creates a **structured** workout event, verifies it parses as category `WORKOUT` with no `workout_id`, and round-trips it through the event-download endpoint as a valid ZWO.

## Validation

- App + both test projects build clean locally (Qt 6.10 / QWT 6.3).
- The live calendar load/download path is exercised by the integration test in CI (which has the `INTERVALS_ICU_*` secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
