### PR TITLE
feat(game): ERG team race — draft to catch back + leashed pace partner

### DIFF
--- a/src/game/qml/RetroRace.qml
+++ b/src/game/qml/RetroRace.qml
@@ -33,6 +33,9 @@ Item {
         : Math.min(1.0, Math.abs(race.playerPowerW - race.targetPower) / Math.max(40, race.targetPower * 0.35))
     // Race position (1st / 2nd) from the gap sign — a racing-game staple.
     readonly property bool leading: race.gapMeters >= 0
+    // ERG cooperative race: the pace partner is a team-mate (draft + leash), not a
+    // rival — so the finish is framed as teamwork, not win/lose.
+    readonly property bool teamMode: race.ergMode && race.oppIsBot
     // Final sprint: the last 15 s before the finish line.
     readonly property bool finalSprint: race.started && !race.finished
         && race.finishSecs > 0 && race.finishSecs <= 15
@@ -805,6 +808,21 @@ Item {
             color: "white"; font.family: "monospace"; font.pixelSize: 13; font.bold: true }
     }
 
+    // ERG team pill (below the effort-zone pill): the cooperative-race cue —
+    // drafting in the partner's slipstream, or the partner easing to wait for you.
+    Rectangle {
+        visible: race.started && !race.finished && race.ergMode
+                 && (race.drafting || race.partnerEasing)
+        anchors { left: parent.left; leftMargin: 12; top: parent.top; topMargin: 110 }
+        width: teamTxt.implicitWidth + 22; height: 26; radius: 13
+        color: race.partnerEasing ? "#9e6b1f" : "#1f8f3f"
+        border.color: "#ffe24a"; border.width: race.drafting && race.draftFactor > 0.6 ? 2 : 1
+        Text { id: teamTxt; anchors.centerIn: parent
+            text: race.partnerEasing ? "🤝 PARTNER WAITING — bridge up!"
+                : "🤝 ON THE WHEEL — drafting »"
+            color: "white"; font.family: "monospace"; font.pixelSize: 13; font.bold: true }
+    }
+
     // ---------------------------------------------------------------- HUD
     Rectangle { anchors { top: parent.top; left: parent.left; right: parent.right }
         height: 72; color: "#000000"; opacity: 0.45 }
@@ -958,7 +976,8 @@ Item {
         BigButton { title: "🏁  Race your last performance"
             subtitle: race.hasLastRide ? "your most recent ride of this workout" : "no previous ride for this workout yet"
             active: race.hasLastRide; onPicked: race.chooseGhost() }
-        BigButton { title: "🤖  Race the Pacer"; subtitle: "holds the workout's target watts"
+        BigButton { title: race.ergMode ? "🤝  Ride with your Pace Partner" : "🤖  Race the Pacer"
+            subtitle: race.ergMode ? "team up — draft to hold the wheel" : "holds the workout's target watts"
             onPicked: race.choosePacer() }
     }
     Column {   // step 2: ready
@@ -973,7 +992,8 @@ Item {
     Repeater {   // confetti — a reward, so it only rains when you actually won
         model: 28
         Rectangle {
-            readonly property bool celebrate: race.finished && race.gapMeters >= 0
+            // Finishing with your partner is a win too — celebrate the team finish.
+            readonly property bool celebrate: race.finished && (race.gapMeters >= 0 || root.teamMode)
             visible: celebrate
             width: 8; height: 8
             color: ["#e23b3b", "#5dff5d", "#3aa0ff", "#ffe08a", "#ff6bd6"][index % 5]
@@ -988,12 +1008,14 @@ Item {
     Column {
         anchors.centerIn: parent; spacing: 10; visible: race.finished
         Text { anchors.horizontalCenter: parent.horizontalCenter
-               text: race.gapMeters >= 0 ? "🏆  YOU WIN!" : "🏁  FINISH!"
+               text: root.teamMode ? "🤝  GREAT TEAMWORK!"
+                                   : (race.gapMeters >= 0 ? "🏆  YOU WIN!" : "🏁  FINISH!")
                color: "#ffe08a"; font.family: "monospace"; font.pixelSize: 46; font.bold: true }
         Text { anchors.horizontalCenter: parent.horizontalCenter
-               text: race.gapMeters >= 0 ? "You won by " + race.gapMeters.toFixed(0) + " m! 🎉"
-                                         : "Beaten by " + (-race.gapMeters).toFixed(0) + " m"
-               color: race.gapMeters >= 0 ? "#5dff5d" : "#ff6b6b"
+               text: root.teamMode ? "You rode the whole workout with your partner 🎉"
+                   : (race.gapMeters >= 0 ? "You won by " + race.gapMeters.toFixed(0) + " m! 🎉"
+                                          : "Beaten by " + (-race.gapMeters).toFixed(0) + " m")
+               color: (root.teamMode || race.gapMeters >= 0) ? "#5dff5d" : "#ff6b6b"
                font.family: "monospace"; font.pixelSize: 22; font.bold: true }
         Text { anchors.horizontalCenter: parent.horizontalCenter
                text: (race.displayDistanceM / 1000).toFixed(2) + " km   ·   vs " + root.shortName(race.oppName, 24)

--- a/src/game/qml/RetroRace.qml
+++ b/src/game/qml/RetroRace.qml
@@ -566,6 +566,35 @@ Item {
                    font.family: "monospace"; font.bold: true; font.pixelSize: Math.max(7, 17*finishLine.p) } }
     }
 
+    // Slipstream: wind streaks fanning down past the player while you're in the
+    // partner's draft — so the draft reads on the bike itself, no need to watch
+    // the top-left pill. Intensity tracks the draft strength; drawn under the
+    // riders so the bikes stay crisp on top.
+    Item {
+        id: slipstream
+        anchors.fill: parent
+        visible: race.started && !race.finished && race.drafting
+        opacity: Math.min(1.0, race.draftFactor * 1.2)
+        z: 5
+        Repeater {
+            model: 14
+            Rectangle {
+                readonly property int  side: index % 2 === 0 ? -1 : 1
+                readonly property int  seed: Math.floor(index / 2)            // 0..6
+                readonly property real spread: 0.13 + 0.075 * (seed % 3)      // how far it fans out
+                // 0 at the vanishing point → 1 at the player; scrolls with animT,
+                // staggered per streak so they rush down continuously.
+                readonly property real p: ((root.animT * 0.9 + seed * 0.17) % 1)
+                width: 2 + 3 * p; radius: width / 2
+                height: 12 + 30 * p
+                color: "#eaf6ff"
+                opacity: 0.5 * p                                              // brighten as it nears you
+                x: root.width / 2 + side * (root.width * spread) * p - width / 2
+                y: root.horizonY + p * (playerBike.y - root.horizonY)
+            }
+        }
+    }
+
     // ---------------------------------------------------------------- riders
     // Opponent: recedes UP the road (perspective) while ahead of you, so it
     // visibly pulls away toward the vanishing point — and grows back toward you
@@ -578,16 +607,25 @@ Item {
         // ~20 m reads as "just ahead / drawing level".
         readonly property real f: 20 / (20 + Math.max(0, ahead))
         readonly property real oz: (1.0 / Math.max(0.05, f)) * 30 + race.visualDist
-        visible: race.started && !race.finished && ahead > 0.5 && ahead < 400
+        // Overtake lane: dead-centre (directly ahead) while you're behind or level,
+        // so drafting reads as sitting right on the partner's wheel. Only drifts a
+        // little to the right during the actual pass (ahead<0), leading into the
+        // mirror. Capped small so it never leaves the tarmac.
+        readonly property real lane: root.width * 0.10 * Math.max(0, Math.min(1, -ahead / 2))
+        // On-road until you're 2 m past; the mirror takes over beyond that (no
+        // overlap → never drawn twice).
+        visible: race.started && !race.finished && ahead > -2 && ahead < 400
         // Shrinks from the player's size when adjacent down to a speck far up the road.
         s: 0.45 + 1.70 * f
         body: "#7fd0ff"; helmet: "#15323f"; alpha: 0.85   // cyan so it stands out on grey + the dash
         phase: race.oppCrankRev
         lean: root.curveAt(oz) * 13
-        armUp: root.animT < root.oppCelebrateUntil ? 1 : 0   // brief flex after passing you
-        // Centred on the road (you see its back, directly ahead); rides from the
-        // player's level when adjacent (f→1) up to the vanishing point (f→0).
-        x: root.width / 2 - width / 2
+        // Brief flex after passing you — a competitive taunt, so suppressed for the
+        // cooperative pace partner (team mode); kept for the "race your last ride" ghost.
+        armUp: (!root.teamMode && root.animT < root.oppCelebrateUntil) ? 1 : 0
+        // Rides from the player's level when adjacent (f→1) up to the vanishing
+        // point (f→0), drifting to the right lane as the gap closes (see lane).
+        x: root.width / 2 - width / 2 + lane
         y: root.horizonY + (playerBike.y - root.horizonY) * f - height * f
     }
     // Player: fixed near the bottom centre, large.
@@ -636,7 +674,9 @@ Item {
         id: mirror
         readonly property real behindM: race.gapMeters
         readonly property real f: 30 / (30 + Math.max(0, behindM))   // 1 close .. →0 far
-        visible: race.started && !race.finished && behindM > 0.5
+        // Takes over exactly where the on-road sprite stops (2 m past) — no gap,
+        // no overlap, so the partner is never drawn twice.
+        visible: race.started && !race.finished && behindM > 2
         z: 40   // above the effort glow, like the HUD
         width: 148; height: 88
         // Ride just off the player's right shoulder, like a bar-end mirror —
@@ -669,7 +709,7 @@ Item {
                 s: 0.30 + 0.78 * mirror.f
                 body: "#7fd0ff"; helmet: "#15323f"; alpha: 0.95
                 phase: race.oppCrankRev
-                armUp: root.ghostMood === 1 ? 1 : 0
+                armUp: (!root.teamMode && root.ghostMood === 1) ? 1 : 0
                 // weaves side to side hunting for a way past
                 x: glass.width/2 - width/2
                    + (root.ghostMood === 2 ? Math.sin(root.animT*5.5) * glass.width * 0.07 : 0)

--- a/src/game/retroracecontroller.cpp
+++ b/src/game/retroracecontroller.cpp
@@ -2,6 +2,15 @@
 
 #include <QDir>
 #include <QFileInfo>
+#include <QtGlobal>
+
+namespace {
+// ERG team-race tuning. In ERG the rider can't out-power the target, so catching
+// back relies on drafting; the partner is leashed so it never drops you.
+constexpr double kDraftRangeM     = 12.0;  // slipstream reaches this far back
+constexpr double kDraftMaxCdaCut  = 0.35;  // up to 35% less drag right on the wheel
+constexpr double kPartnerLeashM   = 15.0;  // partner never pulls more than this ahead
+}
 
 RetroRaceController::RetroRaceController(QObject *parent)
     : QObject(parent)
@@ -66,7 +75,7 @@ void RetroRaceController::useComputerPacer(double watts)
 void RetroRaceController::useWorkoutPacer()
 {
     m_oppIsBot = true;
-    m_oppName  = QStringLiteral("Workout Pacer");
+    m_oppName  = QStringLiteral("Pace Partner");
     auto src   = std::make_unique<LivePowerSource>(150.0);
     m_pacerLive = src.get();
     m_opponent  = std::move(src);
@@ -241,8 +250,38 @@ void RetroRaceController::tick()
     m_playerPowerW = (m_livePowerW >= 0.0)
                    ? m_livePowerW
                    : m_oppPowerW * m_playerForm;
-    m_playerV     = CyclingPhysics::stepSpeed(m_playerV, m_playerPowerW, m_weightKg, m_cda, dt);
+
+    // ERG drafting: in ERG you can't out-power the target, so the only honest way
+    // to claw back a gap is the partner's slipstream — when you're behind, lower
+    // drag means the SAME watts carry you faster until you're back on the wheel.
+    double playerCda = m_cda;
+    m_drafting    = false;
+    m_draftFactor = 0.0;
+    if (m_ergMode) {
+        const double behindM = m_oppDistM - m_playerDistM;   // >0 = player behind
+        if (behindM > 0.0) {
+            m_draftFactor = qBound(0.0, (kDraftRangeM - behindM) / kDraftRangeM, 1.0);
+            playerCda     = m_cda * (1.0 - kDraftMaxCdaCut * m_draftFactor);
+            m_drafting    = m_draftFactor > 0.05;
+        }
+    }
+    m_playerV     = CyclingPhysics::stepSpeed(m_playerV, m_playerPowerW, m_weightKg, playerCda, dt);
     m_playerDistM += m_playerV * dt;
+
+    // Partner leash: a cooperative pace partner never drops you. If it would pull
+    // more than kPartnerLeashM ahead it soft-pedals (eases) so you can always get
+    // back into draft range. Only the bot partner waits — a recorded ghost (your
+    // past self) stays honest and never holds back.
+    m_partnerEasing = false;
+    if (m_ergMode && m_oppIsBot) {
+        const double leadM = m_oppDistM - m_playerDistM;
+        if (leadM > kPartnerLeashM) {
+            m_oppDistM      = m_playerDistM + kPartnerLeashM;
+            m_oppV          = qMin(m_oppV, m_playerV);   // stop pulling away
+            m_oppPowerW    *= 0.7;                        // shown as easing on the HUD
+            m_partnerEasing = true;
+        }
+    }
 
     // Scenery scroll is amplified with speed for a stronger sense of speed:
     // ~1× at/under 20 km/h, ramping to ~2.4× at high speed.

--- a/src/game/retroracecontroller.h
+++ b/src/game/retroracecontroller.h
@@ -84,6 +84,12 @@ class RetroRaceController : public QObject
     Q_PROPERTY(double  routeLengthM    READ routeLengthM    NOTIFY opponentChanged)
     Q_PROPERTY(bool    oppChosen       READ oppChosen       NOTIFY opponentChanged)
     Q_PROPERTY(bool    hasLastRide     READ hasLastRide     NOTIFY opponentChanged)
+    // ERG team-race state (only meaningful when the workout is in ERG mode and
+    // the opponent is the cooperative pace partner — see setErgMode()).
+    Q_PROPERTY(bool    ergMode         READ ergMode         NOTIFY ergModeChanged)
+    Q_PROPERTY(bool    drafting        READ drafting        NOTIFY updated)  // you're in the partner's slipstream
+    Q_PROPERTY(double  draftFactor     READ draftFactor     NOTIFY updated)  // 0..1 slipstream strength
+    Q_PROPERTY(bool    partnerEasing   READ partnerEasing   NOTIFY updated)  // partner soft-pedalling to wait for you
 
 public:
     explicit RetroRaceController(QObject *parent = nullptr);
@@ -170,6 +176,10 @@ public:
     double  routeLengthM() const    { return m_opponent ? m_opponent->totalDistanceM() : 0.0; }
     bool    oppChosen() const       { return m_oppChosen; }
     bool    hasLastRide() const     { return m_hasLastRide; }
+    bool    ergMode() const         { return m_ergMode; }
+    bool    drafting() const        { return m_drafting; }
+    double  draftFactor() const     { return m_draftFactor; }
+    bool    partnerEasing() const   { return m_partnerEasing; }
 
 public slots:
     void start();          // arm: riders idle at the start line, legs free-spin
@@ -182,6 +192,11 @@ public slots:
     void setLivePowerWatts(double watts) { m_livePowerW = watts; }
     /// Feed live trainer cadence (rpm) for the leg animation. Negative → ignore.
     void setLiveCadenceRpm(double rpm) { m_liveCadenceRpm = rpm; }
+    /// Tell the race whether the workout is in ERG mode. In ERG the rider's power
+    /// is pinned to target so a head-to-head can't be won by effort; instead the
+    /// pace partner becomes a cooperative team-mate — drafting lets you catch back
+    /// when behind, and the partner is leashed so it never drops you (see tick()).
+    void setErgMode(bool erg) { if (m_ergMode != erg) { m_ergMode = erg; emit ergModeChanged(); } }
     /// Feed live heart rate (bpm) for the HUD.
     void setLiveHr(double bpm) { m_playerHr = bpm; emit updated(); }
     /// Push the current workout targets (value ± range; <=0 = no target).
@@ -225,6 +240,7 @@ signals:
     void nextChanged();
     void finishChanged();
     void metricsChanged();
+    void ergModeChanged();
 
 private:
     void tick();
@@ -236,6 +252,12 @@ private:
     bool    m_oppIsBot     = false;
     bool    m_oppChosen    = false;
     bool    m_hasLastRide  = false;
+
+    // ERG team-race state (see setErgMode() / tick()).
+    bool    m_ergMode       = false;
+    bool    m_drafting      = false;
+    double  m_draftFactor   = 0.0;   // 0..1 slipstream strength this frame
+    bool    m_partnerEasing = false; // partner soft-pedalling to stay catchable
 
     QTimer        m_timer;
     QElapsedTimer m_clock;

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2483,6 +2483,8 @@ void WorkoutDialog::targetPowerChanged_f(double percentageTarget, int range) {
                                             : qRound(0.45 * account->FTP));
         // Drive the game's power target indicator (same threshold as the alerts).
         raceController->setTargetPower(currentTargetPower, currentTargetPowerRange);
+        // Keep the team-race (draft/leash) in step with the current ERG/slope mode.
+        raceController->setErgMode(!isUsingSlopeMode && account->control_trainer_resistance);
     }
     ui->widget_time->setTargetPower(percentageTarget, range);
     ui->widget_topMenu->setTargetPower(percentageTarget, range);
@@ -2695,6 +2697,9 @@ QQuickWidget *WorkoutDialog::ensureRaceView() {
         raceController->setRiderParams(account->bike_weight_kg + account->weight_kg,
                                        account->userCda);
         raceController->setLiveMode(true);
+        // In ERG the partner is a cooperative team-mate (draft + leash); in slope/
+        // free-ride it stays a straight effort-vs-effort race.
+        raceController->setErgMode(!isUsingSlopeMode && account->control_trainer_resistance);
         raceController->setWorkoutName(workout.getName());   // enables the chooser
         raceController->setWorkoutProfile(buildWorkoutProfile());  // "what's next" strip
         raceController->setIntervalMessage(currentIntervalObj.getDisplayMessage());


### PR DESCRIPTION
## What

Makes the retro race meaningful in **ERG mode**, where the trainer pins your power to target — so the gap to the pacer used to just freeze (no way to catch back). The pacer becomes a cooperative **pace partner**:

- **Draft to catch back:** when you're behind the partner you're in its slipstream, so the *same* target watts carry you faster (reduced CdA, up to ~35% on the wheel) until you're back on — an honest catch-up that doesn't require out-powering ERG.
- **Leash:** the partner never pulls more than ~15 m ahead; beyond that it soft-pedals so you can always bridge back into draft range. Only the bot partner waits — a recorded ghost stays honest.
- **ERG only:** slope / free-ride keep the existing pure effort-vs-effort race.

## Feel / rendering (after play-testing)

- Partner sits **directly ahead** while you're on the wheel, drifts a little aside only during the actual pass (capped to the road), then hands off to the rear-view mirror — continuous, never drawn twice, never vanishes.
- **Slipstream** wind-streak cue while drafting so it reads on the bike, not just the HUD pill.
- Pacer renamed **"Pace Partner"**; pre-start option and finish overlay reframed as teamwork ("🤝 GREAT TEAMWORK!"); the opponent's celebratory arm-raise is suppressed for the cooperative partner.

## Plumbing

`RetroRaceController` gains `setErgMode()` + `drafting`/`draftFactor`/`partnerEasing` properties; the workout dialog feeds ERG state (from `isUsingSlopeMode` + `control_trainer_resistance`). Feel tunables live at the top of `retroracecontroller.cpp` (`kDraftRangeM`, `kDraftMaxCdaCut`, `kPartnerLeashM`).

## Test

Built locally (Qt 6.10 / QWT 6.3); validated by riding an ERG workout in the app — drop off the pace, partner waits, draft pulls you back on the wheel, pass drifts cleanly into the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
