### PR TITLE
fix(ui): widen settings spin boxes so values aren't cramped on Windows

### DIFF
--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -1106,6 +1106,8 @@ void DialogConfig::buildIntervalSummaryGroup()
     spinIntervalSummaryDuration = new QSpinBox(grpSummary);
     spinIntervalSummaryDuration->setRange(2, 15);
     spinIntervalSummaryDuration->setValue(5);
+    // Native Windows spin buttons crowd a short value; reserve room.
+    spinIntervalSummaryDuration->setMinimumWidth(80);
     durRow->addWidget(spinIntervalSummaryDuration);
     durRow->addStretch();
     grpSummaryLayout->addLayout(durRow);

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -122,6 +122,8 @@ void SensorsWidget::buildUi()
     m_ergRampSpin = new QSpinBox(trainerGroup);
     m_ergRampSpin->setRange(0, 30);
     m_ergRampSpin->setSuffix(tr(" s"));
+    // Native Windows spin buttons crowd a short value/suffix; reserve room.
+    m_ergRampSpin->setMinimumWidth(80);
     m_ergRampSpin->setToolTip(tr("Seconds to linearly ramp ERG resistance between intervals.\n"
                                  "Set to 0 to disable smoothing (instant resistance changes)."));
     connect(m_ergRampSpin, qOverload<int>(&QSpinBox::valueChanged),
@@ -155,6 +157,7 @@ void SensorsWidget::buildUi()
     m_dropoutTimeoutSpin = new QSpinBox(dropoutGroup);
     m_dropoutTimeoutSpin->setRange(2, 30);
     m_dropoutTimeoutSpin->setSuffix(tr(" s"));
+    m_dropoutTimeoutSpin->setMinimumWidth(80);
     connect(m_dropoutTimeoutSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, &SensorsWidget::onSensorDropoutChanged);
     dropoutRow->addWidget(m_dropoutTimeoutSpin);
@@ -180,6 +183,7 @@ void SensorsWidget::buildUi()
     m_batteryThresholdSpin = new QSpinBox(batteryGroup);
     m_batteryThresholdSpin->setRange(5, 50);
     m_batteryThresholdSpin->setSuffix(tr(" %"));
+    m_batteryThresholdSpin->setMinimumWidth(80);
     connect(m_batteryThresholdSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, &SensorsWidget::onBatteryThresholdChanged);
     batteryRow->addWidget(m_batteryThresholdSpin);

--- a/src/ui/studiowidget.cpp
+++ b/src/ui/studiowidget.cpp
@@ -89,6 +89,7 @@ void StudioWidget::buildUi()
     m_riderCountLabel = new QLabel(tr("Number of riders:"), this);
     topRow->addWidget(m_riderCountLabel);
     m_riderCountCombo = new QComboBox(this);
+    m_riderCountCombo->setMinimumWidth(70);
     for (int i = 1; i <= kMaxRiders; ++i)
         m_riderCountCombo->addItem(QString::number(i), i);
     connect(m_riderCountCombo, qOverload<int>(&QComboBox::currentIndexChanged),
@@ -170,10 +171,13 @@ QGroupBox *StudioWidget::buildRiderCard(int riderIndex)
     card.ftpSpin = new QSpinBox(box);
     card.ftpSpin->setRange(0, 600);
     card.ftpSpin->setSuffix(tr(" W"));
+    // Native Windows spin buttons crowd a short value/suffix; reserve room.
+    card.ftpSpin->setMinimumWidth(80);
     idRow->addWidget(card.ftpSpin);
     idRow->addWidget(new QLabel(tr("LTHR"), box));
     card.lthrSpin = new QSpinBox(box);
     card.lthrSpin->setRange(0, 230);
+    card.lthrSpin->setMinimumWidth(80);
     idRow->addWidget(card.lthrSpin);
     cardLayout->addLayout(idRow);
 
@@ -230,6 +234,7 @@ QGroupBox *StudioWidget::buildRiderCard(int riderIndex)
     card.ergRampSpin = new QSpinBox(box);
     card.ergRampSpin->setRange(0, 30);
     card.ergRampSpin->setSuffix(tr(" s"));
+    card.ergRampSpin->setMinimumWidth(80);
     ergRow->addWidget(card.ergRampSpin);
     cardLayout->addLayout(ergRow);
 


### PR DESCRIPTION
## Problem

On Windows several settings spin boxes (and the Studio rider-count combo) render cramped: the heavier native up/down arrows crowd a short value/suffix, so values like `5 s` get clipped against the buttons.

## Fix

Give the affected code-created controls a minimum width so the value + suffix stay legible across platforms. No behavior change; layout only.

**Widened:**
- **Sensors** (`sensorswidget.cpp`): ERG transition ramp duration, Dropout timeout, Battery Warning threshold.
- **Studio** (`studiowidget.cpp`): per-rider FTP, LTHR, ERG ramp spin boxes + the rider-count combo.
- **Display** (`dialogconfig.cpp`): interval-summary display-duration spin box.

**Left alone (already fine):** the radio-bitrate (`dialogconfig`) and log-level (`dialogmainwindowconfig`) controls sit in form layouts that expand them, and the difficulty spin box (`workoutplot`) already has a fixed width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
