### PR TITLE
feat(btle): use trainer-bridged heart rate (0x180D) in workouts + "provided by trainer" UI

### DIFF
--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -273,6 +273,7 @@ void BtleHub::onControllerDisconnected()
 {
     LOG_INFO("BtleHub", QStringLiteral("Device disconnected"));
     m_cscStopTimer->stop();
+    m_ftmsHrSeen = false;
     emit deviceDisconnected();
 
     if (m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS)
@@ -790,8 +791,13 @@ void BtleHub::parseFtmsIndoorBikeData(const QByteArray &data)
     // strap fold the reading in here rather than exposing a separate 0x180D
     // service, so this is the only place we'd ever see it for those devices.
     if (flags & 0x0200) {
-        if (offset < data.size())
+        if (offset < data.size()) {
             emit signal_hr(m_userID, static_cast<quint8>(data[offset]));
+            if (!m_ftmsHrSeen) {
+                m_ftmsHrSeen = true;
+                emit signal_trainerProvidesHr(m_userID);
+            }
+        }
         offset += 1;
     }
 }

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -273,7 +273,7 @@ void BtleHub::onControllerDisconnected()
 {
     LOG_INFO("BtleHub", QStringLiteral("Device disconnected"));
     m_cscStopTimer->stop();
-    m_ftmsHrSeen = false;
+    m_hrSeen = false;
     emit deviceDisconnected();
 
     if (m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS)
@@ -593,6 +593,13 @@ void BtleHub::parseHrMeasurement(const QByteArray &data)
     }
 
     emit signal_hr(m_userID, hr);
+
+    // HR can reach us via a bridged 0x180D service on the trainer connection (not
+    // just the FTMS bike-data field), so flag the capability here too.
+    if (!m_hrSeen) {
+        m_hrSeen = true;
+        emit signal_trainerProvidesHr(m_userID);
+    }
 }
 
 // CSC Measurement (0x2A5B) – speed/cadence computation
@@ -793,8 +800,8 @@ void BtleHub::parseFtmsIndoorBikeData(const QByteArray &data)
     if (flags & 0x0200) {
         if (offset < data.size()) {
             emit signal_hr(m_userID, static_cast<quint8>(data[offset]));
-            if (!m_ftmsHrSeen) {
-                m_ftmsHrSeen = true;
+            if (!m_hrSeen) {
+                m_hrSeen = true;
                 emit signal_trainerProvidesHr(m_userID);
             }
         }

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -594,8 +594,9 @@ void BtleHub::parseHrMeasurement(const QByteArray &data)
 
     emit signal_hr(m_userID, hr);
 
-    // HR can reach us via a bridged 0x180D service on the trainer connection (not
-    // just the FTMS bike-data field), so flag the capability here too.
+    // A trainer that bridges an HR strap exposes it as a 0x180D service on the
+    // trainer connection, so the first reading here flags the capability for the
+    // "provided by trainer" UI (the trainer hub is the only listener).
     if (!m_hrSeen) {
         m_hrSeen = true;
         emit signal_trainerProvidesHr(m_userID);
@@ -786,26 +787,6 @@ void BtleHub::parseFtmsIndoorBikeData(const QByteArray &data)
     if (!(flags & 0x0040)) {
         qint16 power = static_cast<qint16>(readU16());
         emit signal_power(m_userID, static_cast<int>(power));
-    }
-
-    // Bit 7: Average Power present
-    if (flags & 0x0080) offset += 2;
-
-    // Bit 8: Expended Energy present (Total uint16 + PerHour uint16 + PerMinute uint8)
-    if (flags & 0x0100) offset += 5;
-
-    // Bit 9: Heart Rate present (uint8 bpm). Trainers that bridge an ANT+/BLE HR
-    // strap fold the reading in here rather than exposing a separate 0x180D
-    // service, so this is the only place we'd ever see it for those devices.
-    if (flags & 0x0200) {
-        if (offset < data.size()) {
-            emit signal_hr(m_userID, static_cast<quint8>(data[offset]));
-            if (!m_hrSeen) {
-                m_hrSeen = true;
-                emit signal_trainerProvidesHr(m_userID);
-            }
-        }
-        offset += 1;
     }
 }
 

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -779,6 +779,21 @@ void BtleHub::parseFtmsIndoorBikeData(const QByteArray &data)
         qint16 power = static_cast<qint16>(readU16());
         emit signal_power(m_userID, static_cast<int>(power));
     }
+
+    // Bit 7: Average Power present
+    if (flags & 0x0080) offset += 2;
+
+    // Bit 8: Expended Energy present (Total uint16 + PerHour uint16 + PerMinute uint8)
+    if (flags & 0x0100) offset += 5;
+
+    // Bit 9: Heart Rate present (uint8 bpm). Trainers that bridge an ANT+/BLE HR
+    // strap fold the reading in here rather than exposing a separate 0x180D
+    // service, so this is the only place we'd ever see it for those devices.
+    if (flags & 0x0200) {
+        if (offset < data.size())
+            emit signal_hr(m_userID, static_cast<quint8>(data[offset]));
+        offset += 1;
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -69,6 +69,11 @@ signals:
     /// \param percentage  Battery level 0–100 (%)
     void signal_battery(QString sensorType, int percentage);
 
+    /// Emitted once per connection, the first time the trainer's FTMS Indoor Bike
+    /// Data carries a Heart Rate field (i.e. it bridges an HR strap). Lets the UI
+    /// mark the Heart Rate slot "provided by trainer".
+    void signal_trainerProvidesHr(int userID);
+
     // ----------- Connection status signals ---------------------------------
     void deviceConnected();
     void deviceDisconnected();
@@ -181,6 +186,10 @@ private:
     quint16 m_lastCrankRevolutions  = 0;
     quint16 m_lastCrankEventTime    = 0;
     bool    m_firstCscMeasurement   = true;
+
+    // Latched once an FTMS bike-data packet has included a Heart Rate field, so
+    // signal_trainerProvidesHr fires only once per connection.
+    bool    m_ftmsHrSeen            = false;
 };
 
 #endif // BTLE_HUB_H

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -69,10 +69,10 @@ signals:
     /// \param percentage  Battery level 0–100 (%)
     void signal_battery(QString sensorType, int percentage);
 
-    /// Emitted once per connection, the first time this connection produces a
-    /// heart-rate reading — whether from the FTMS Indoor Bike Data field or a
-    /// bridged 0x180D Heart Rate service. Wired only for the trainer hub, it lets
-    /// the UI mark the Heart Rate slot "provided by trainer".
+    /// Emitted once per connection, the first time it produces a heart-rate
+    /// reading. Trainers that bridge an HR strap expose it as a standard 0x180D
+    /// Heart Rate service on the trainer connection; wired only for the trainer
+    /// hub, this lets the UI mark the Heart Rate slot "provided by trainer".
     void signal_trainerProvidesHr(int userID);
 
     // ----------- Connection status signals ---------------------------------
@@ -188,8 +188,8 @@ private:
     quint16 m_lastCrankEventTime    = 0;
     bool    m_firstCscMeasurement   = true;
 
-    // Latched once this connection has produced any heart-rate reading (FTMS
-    // field or 0x180D service), so signal_trainerProvidesHr fires only once.
+    // Latched once this connection has produced a heart-rate reading (via the
+    // 0x180D service), so signal_trainerProvidesHr fires only once.
     bool    m_hrSeen               = false;
 };
 

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -69,9 +69,10 @@ signals:
     /// \param percentage  Battery level 0–100 (%)
     void signal_battery(QString sensorType, int percentage);
 
-    /// Emitted once per connection, the first time the trainer's FTMS Indoor Bike
-    /// Data carries a Heart Rate field (i.e. it bridges an HR strap). Lets the UI
-    /// mark the Heart Rate slot "provided by trainer".
+    /// Emitted once per connection, the first time this connection produces a
+    /// heart-rate reading — whether from the FTMS Indoor Bike Data field or a
+    /// bridged 0x180D Heart Rate service. Wired only for the trainer hub, it lets
+    /// the UI mark the Heart Rate slot "provided by trainer".
     void signal_trainerProvidesHr(int userID);
 
     // ----------- Connection status signals ---------------------------------
@@ -187,9 +188,9 @@ private:
     quint16 m_lastCrankEventTime    = 0;
     bool    m_firstCscMeasurement   = true;
 
-    // Latched once an FTMS bike-data packet has included a Heart Rate field, so
-    // signal_trainerProvidesHr fires only once per connection.
-    bool    m_ftmsHrSeen            = false;
+    // Latched once this connection has produced any heart-rate reading (FTMS
+    // field or 0x180D service), so signal_trainerProvidesHr fires only once.
+    bool    m_hrSeen               = false;
 };
 
 #endif // BTLE_HUB_H

--- a/src/btle/btle_scanner_dialog.cpp
+++ b/src/btle/btle_scanner_dialog.cpp
@@ -69,6 +69,9 @@ void BtleScannerDialog::init()
             this, &BtleScannerDialog::stopScan);
     connect(ui->pushButton_connect, &QPushButton::clicked,
             this, &BtleScannerDialog::onConnectClicked);
+    // Double-clicking a device connects to it, like double-clicking a file.
+    connect(ui->tableView_devices, &QAbstractItemView::doubleClicked,
+            this, &BtleScannerDialog::onConnectClicked);
     connect(ui->tableView_devices->selectionModel(),
             &QItemSelectionModel::selectionChanged,
             this, &BtleScannerDialog::onSelectionChanged);

--- a/src/btle/btle_sensor_store.cpp
+++ b/src/btle/btle_sensor_store.cpp
@@ -23,6 +23,25 @@ bool BtleSensorStore::roleCoveredByTrainer(BtleSensorRole role)
     return role == BtleSensorRole::Power || role == BtleSensorRole::CadenceSpeed;
 }
 
+static constexpr const char *kTrainerProvidesHrKey = "trainerProvidesHr";
+
+bool BtleSensorStore::trainerProvidesHr(int riderIndex)
+{
+    QSettings settings;
+    settings.beginGroup(groupForRider(riderIndex));
+    const bool provides = settings.value(QLatin1String(kTrainerProvidesHrKey), false).toBool();
+    settings.endGroup();
+    return provides;
+}
+
+void BtleSensorStore::setTrainerProvidesHr(bool provides, int riderIndex)
+{
+    QSettings settings;
+    settings.beginGroup(groupForRider(riderIndex));
+    settings.setValue(QLatin1String(kTrainerProvidesHrKey), provides);
+    settings.endGroup();
+}
+
 QString BtleSensorStore::roleKey(BtleSensorRole role)
 {
     switch (role) {

--- a/src/btle/btle_sensor_store.h
+++ b/src/btle/btle_sensor_store.h
@@ -61,6 +61,13 @@ public:
     /// connection, so the Power and Cadence/Speed slots are covered by it.
     static bool roleCoveredByTrainer(BtleSensorRole role);
 
+    /// Whether the saved trainer was last seen bridging heart rate over FTMS.
+    /// Unlike power/cadence (always carried by FTMS), HR is only present when the
+    /// trainer bridges a strap, so this is learned at runtime and persisted.
+    /// (See \a riderIndex on loadAll().)
+    static bool trainerProvidesHr(int riderIndex = 0);
+    static void setTrainerProvidesHr(bool provides, int riderIndex = 0);
+
 private:
     static constexpr const char *kGroup = "btleSensors";
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1613,7 +1613,8 @@ void MainWindow::startWorkoutWithHubs(const Workout &workout,
 // Called once for solo and once per rider in Studio mode.
 void MainWindow::wireHubsToDialog(WorkoutDialog *w,
                                   const QMap<BtleSensorRole, BtleHub*> &hubsByRole,
-                                  QSet<BtleHub*> &allHubs)
+                                  QSet<BtleHub*> &allHubs,
+                                  int riderIndex)
 {
     QSet<BtleHub*> uniqueHubs;
     for (BtleHub *hub : hubsByRole)
@@ -1629,6 +1630,13 @@ void MainWindow::wireHubsToDialog(WorkoutDialog *w,
     BtleHub *powerHub   = nullptr;
     BtleHub *cadenceHub = nullptr;
     BtleHub *speedHub   = nullptr;
+    BtleHub *hrHub      = nullptr;
+
+    auto wireHr = [&](BtleHub *hub) {
+        if (hrHub == hub) return;
+        hrHub = hub;
+        connect(hub, SIGNAL(signal_hr(int,int)), w, SLOT(HrDataReceived(int,int)));
+    };
 
     auto wirePower = [&](BtleHub *hub) {
         if (powerHub == hub) return;          // already wired from this device
@@ -1655,6 +1663,10 @@ void MainWindow::wireHubsToDialog(WorkoutDialog *w,
         wirePower(hub);
         wireCadence(hub);
         wireSpeed(hub);
+        // Remember when this trainer bridges an HR strap so the sensors page can
+        // mark the Heart Rate slot "provided by trainer" next time it opens.
+        connect(hub, &BtleHub::signal_trainerProvidesHr, this,
+                [riderIndex]() { BtleSensorStore::setTrainerProvidesHr(true, riderIndex); });
         connect(w, SIGNAL(setLoad(int,double)),  hub, SLOT(setLoad(int,double)));
         connect(w, SIGNAL(setSlope(int,double)), hub, SLOT(setSlope(int,double)));
         w->enableTrainerControl();
@@ -1666,9 +1678,12 @@ void MainWindow::wireHubsToDialog(WorkoutDialog *w,
         wireCadence(hub);
         wireSpeed(hub);
     }
+    // A dedicated HR strap is more reliable than a trainer-bridged reading, so it
+    // takes precedence; otherwise fall back to HR the trainer carries over FTMS.
     if (hubsByRole.contains(BtleSensorRole::HeartRate))
-        connect(hubsByRole.value(BtleSensorRole::HeartRate),
-                SIGNAL(signal_hr(int,int)), w, SLOT(HrDataReceived(int,int)));
+        wireHr(hubsByRole.value(BtleSensorRole::HeartRate));
+    else if (hubsByRole.contains(BtleSensorRole::Trainer))
+        wireHr(hubsByRole.value(BtleSensorRole::Trainer));
     if (hubsByRole.contains(BtleSensorRole::Oxygen))
         connect(hubsByRole.value(BtleSensorRole::Oxygen),
                 SIGNAL(signal_oxygen(int,double,double)), w, SLOT(OxygenValueChanged(int,double,double)));
@@ -1687,7 +1702,7 @@ void MainWindow::startWorkoutWithStudioHubs(const Workout &workout,
 
     QSet<BtleHub*> allHubs;
     for (const QPair<int, QMap<BtleSensorRole, BtleHub*>> &rider : riderHubs)
-        wireHubsToDialog(w, rider.second, allHubs);
+        wireHubsToDialog(w, rider.second, allHubs, rider.first);
 
     connect(w, SIGNAL(fitFileReady(QString, QString, QString)), this, SLOT(checkToUploadFile(QString,QString,QString)));
     connect(w, SIGNAL(ftp_lthr_changed()), ui->tab_workout1, SLOT(updateTableViewMetrics()));

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -98,7 +98,8 @@ private:
     /// \a allHubs for cleanup. Shared by the solo and Studio launch paths.
     void wireHubsToDialog(WorkoutDialog *w,
                           const QMap<BtleSensorRole, BtleHub*> &hubsByRole,
-                          QSet<BtleHub*> &allHubs);
+                          QSet<BtleHub*> &allHubs,
+                          int riderIndex = 0);
 
     /// Launch a Studio-mode workout with each rider's already-connected hubs
     /// (tagged via BtleHub::setUserID). Pairs are (riderIndex, role→hub map).

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -291,8 +291,17 @@ void SensorsWidget::refreshRow(int rowIndex)
     // show why. A previously-saved device stays clearable so it can be removed.
     // (BtleSensorStore is desktop-only; the WASM build never reaches here.)
 #ifndef GC_WASM_BUILD
-    if (BtleSensorStore::roleCoveredByTrainer(slot.role) && trainerPaired()) {
-        slot.scanButton->setEnabled(false);
+    const bool trainerCoversRole = BtleSensorStore::roleCoveredByTrainer(slot.role);
+    // HR is only trainer-covered when the trainer was seen bridging a strap and
+    // no dedicated strap is saved (a saved strap takes precedence over it).
+    const bool trainerCoversHr   = slot.role == BtleSensorRole::HeartRate
+                                   && !slot.current.isValid()
+                                   && BtleSensorStore::trainerProvidesHr();
+    if (trainerPaired() && (trainerCoversRole || trainerCoversHr)) {
+        // Power/Cadence are always carried by FTMS, so their dedicated slots are
+        // redundant — disable scanning. HR can stop (strap removed from the
+        // trainer), so leave its slot scannable and just annotate it.
+        slot.scanButton->setEnabled(trainerCoversHr);
         slot.clearButton->setEnabled(slot.current.isValid());
         slot.deviceLabel->setText(slot.current.isValid()
                                   ? tr("%1 (provided by trainer)").arg(slot.current.name)

--- a/src/ui/studiowidget.cpp
+++ b/src/ui/studiowidget.cpp
@@ -325,8 +325,16 @@ void StudioWidget::refreshSensorSlot(int riderIndex, int slotIdx)
     // A paired FTMS trainer covers this rider's Power and Cadence/Speed slots
     // (one connection carries all three), so disable scanning them and show why.
     const bool trainerPaired = saved.value(BtleSensorRole::Trainer, BtleSavedSensor{}).isValid();
-    if (BtleSensorStore::roleCoveredByTrainer(slot.role) && trainerPaired) {
-        slot.scanButton->setEnabled(false);
+    const bool trainerCoversRole = BtleSensorStore::roleCoveredByTrainer(slot.role);
+    // HR is only trainer-covered when this rider's trainer was seen bridging a
+    // strap and no dedicated strap is saved (a saved strap takes precedence).
+    const bool trainerCoversHr = slot.role == BtleSensorRole::HeartRate
+                                 && !s.isValid()
+                                 && BtleSensorStore::trainerProvidesHr(riderIndex);
+    if (trainerPaired && (trainerCoversRole || trainerCoversHr)) {
+        // Power/Cadence are always carried by FTMS — disable scanning. HR can stop
+        // (strap removed from the trainer), so leave its slot scannable.
+        slot.scanButton->setEnabled(trainerCoversHr);
         slot.clearButton->setEnabled(s.isValid());
         slot.deviceLabel->setText(s.isValid()
                                   ? tr("%1 (provided by trainer)").arg(s.name)

--- a/tests/btle/btle_device_simulator.h
+++ b/tests/btle/btle_device_simulator.h
@@ -159,17 +159,13 @@ inline QByteArray ftmsIndoorBikeData(double speedKmh,
                                      qint16 powerW,
                                      bool includeSpeed   = true,
                                      bool includeCadence = true,
-                                     bool includePower   = true,
-                                     int  heartRateBpm   = -1,    // >= 0: include HR (bit 9)
-                                     bool includeEnergy  = false) // include energy (bit 8)
+                                     bool includePower   = true)
 {
     // Build flags: each "NOT present" bit is set when the field is absent.
     quint16 flags = 0;
-    if (!includeSpeed)     flags |= 0x0001; // bit 0: "More Data" / speed absent
-    if (!includeCadence)   flags |= 0x0004; // bit 2: cadence absent
-    if (!includePower)     flags |= 0x0040; // bit 6: power absent
-    if (includeEnergy)     flags |= 0x0100; // bit 8: expended energy present
-    if (heartRateBpm >= 0) flags |= 0x0200; // bit 9: heart rate present
+    if (!includeSpeed)   flags |= 0x0001; // bit 0: "More Data" / speed absent
+    if (!includeCadence) flags |= 0x0004; // bit 2: cadence absent
+    if (!includePower)   flags |= 0x0040; // bit 6: power absent
 
     QByteArray pkt;
     pkt.append(static_cast<char>( flags        & 0xFF));
@@ -188,13 +184,6 @@ inline QByteArray ftmsIndoorBikeData(double speedKmh,
     if (includePower) {
         pkt.append(static_cast<char>( powerW        & 0xFF));
         pkt.append(static_cast<char>((powerW >>  8) & 0xFF));
-    }
-    if (includeEnergy) {
-        // Total Energy (uint16) + Energy/Hour (uint16) + Energy/Minute (uint8)
-        for (int i = 0; i < 5; ++i) pkt.append(static_cast<char>(0));
-    }
-    if (heartRateBpm >= 0) {
-        pkt.append(static_cast<char>(heartRateBpm & 0xFF));
     }
     return pkt;
 }

--- a/tests/btle/btle_device_simulator.h
+++ b/tests/btle/btle_device_simulator.h
@@ -159,13 +159,17 @@ inline QByteArray ftmsIndoorBikeData(double speedKmh,
                                      qint16 powerW,
                                      bool includeSpeed   = true,
                                      bool includeCadence = true,
-                                     bool includePower   = true)
+                                     bool includePower   = true,
+                                     int  heartRateBpm   = -1,    // >= 0: include HR (bit 9)
+                                     bool includeEnergy  = false) // include energy (bit 8)
 {
     // Build flags: each "NOT present" bit is set when the field is absent.
     quint16 flags = 0;
-    if (!includeSpeed)   flags |= 0x0001; // bit 0: "More Data" / speed absent
-    if (!includeCadence) flags |= 0x0004; // bit 2: cadence absent
-    if (!includePower)   flags |= 0x0040; // bit 6: power absent
+    if (!includeSpeed)     flags |= 0x0001; // bit 0: "More Data" / speed absent
+    if (!includeCadence)   flags |= 0x0004; // bit 2: cadence absent
+    if (!includePower)     flags |= 0x0040; // bit 6: power absent
+    if (includeEnergy)     flags |= 0x0100; // bit 8: expended energy present
+    if (heartRateBpm >= 0) flags |= 0x0200; // bit 9: heart rate present
 
     QByteArray pkt;
     pkt.append(static_cast<char>( flags        & 0xFF));
@@ -184,6 +188,13 @@ inline QByteArray ftmsIndoorBikeData(double speedKmh,
     if (includePower) {
         pkt.append(static_cast<char>( powerW        & 0xFF));
         pkt.append(static_cast<char>((powerW >>  8) & 0xFF));
+    }
+    if (includeEnergy) {
+        // Total Energy (uint16) + Energy/Hour (uint16) + Energy/Minute (uint8)
+        for (int i = 0; i < 5; ++i) pkt.append(static_cast<char>(0));
+    }
+    if (heartRateBpm >= 0) {
+        pkt.append(static_cast<char>(heartRateBpm & 0xFF));
     }
     return pkt;
 }

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -91,6 +91,10 @@ private slots:
     // ── FTMS multi-field layout (field skipping) ─────────────────────────────
     void testFtms_allOptionalFieldsBeforePowerSkipped();
     void testFtms_negativeInstantPower();
+    void testFtms_heartRate();
+    void testFtms_heartRateAfterEnergy();
+    void testFtms_heartRateAfterAvgPower();
+    void testFtms_heartRateFlagButTruncated_ignored();
 
     // ── SimulatorHub no-op slot verification ─────────────────────────────────
     void testSimulator_noOpSetLoad();
@@ -778,6 +782,89 @@ void TstBtleHub::testFtms_negativeInstantPower()
 
     QCOMPARE(spy.count(), 1);
     QCOMPARE(spy.at(0).at(1).toInt(), -10);
+}
+
+/**
+ * A trainer that bridges an HR strap folds the bpm into the FTMS Indoor Bike
+ * Data stream (bit 9) instead of exposing a separate 0x180D service. Verify the
+ * HR field is decoded and re-emitted on signal_hr alongside the bike metrics.
+ */
+void TstBtleHub::testFtms_heartRate()
+{
+    QSignalSpy spyPwr(hub, &BtleHub::signal_power);
+    QSignalSpy spyHr(hub,  &BtleHub::signal_hr);
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
+        BtlePacketBuilder::ftmsIndoorBikeData(32.4, 88.0, 195,
+            /*includeSpeed=*/true, /*includeCadence=*/true, /*includePower=*/true,
+            /*heartRateBpm=*/152));
+
+    QCOMPARE(spyPwr.count(), 1);
+    QCOMPARE(spyPwr.at(0).at(1).toInt(), 195);
+    QCOMPARE(spyHr.count(), 1);
+    QCOMPARE(spyHr.at(0).at(1).toInt(), 152);
+}
+
+/**
+ * The Expended Energy field (bit 8, 5 bytes) precedes Heart Rate (bit 9). Verify
+ * the parser skips it correctly so the HR byte is read at the right offset.
+ */
+void TstBtleHub::testFtms_heartRateAfterEnergy()
+{
+    QSignalSpy spyHr(hub, &BtleHub::signal_hr);
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
+        BtlePacketBuilder::ftmsIndoorBikeData(0.0, 0.0, 0,
+            /*includeSpeed=*/false, /*includeCadence=*/false, /*includePower=*/false,
+            /*heartRateBpm=*/171, /*includeEnergy=*/true));
+
+    QCOMPARE(spyHr.count(), 1);
+    QCOMPARE(spyHr.at(0).at(1).toInt(), 171);
+}
+
+/**
+ * Average Power (bit 7, 2 bytes) sits between Instantaneous Power and the energy/
+ * HR fields. Verify the parser skips it so the HR byte lands at the right offset.
+ * Built raw because the convenience builder doesn't expose an average-power field.
+ */
+void TstBtleHub::testFtms_heartRateAfterAvgPower()
+{
+    QSignalSpy spyPwr(hub, &BtleHub::signal_power);
+    QSignalSpy spyHr(hub,  &BtleHub::signal_hr);
+
+    // bits: 0 speed-absent, 2 cadence-absent, 6 instant-power-absent,
+    //       7 avg-power present, 9 HR present  → 0x0001|0x0004|0x0040|0x0080|0x0200
+    QByteArray pkt;
+    quint16 flags = 0x02C5;
+    pkt.append(char( flags       & 0xFF));
+    pkt.append(char((flags >> 8) & 0xFF));
+    pkt.append(char(0x00)); pkt.append(char(0x00)); // average power = 0 W
+    pkt.append(char(168));                          // heart rate = 168 bpm
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, pkt);
+
+    QCOMPARE(spyPwr.count(), 0); // instantaneous power absent → no power signal
+    QCOMPARE(spyHr.count(), 1);
+    QCOMPARE(spyHr.at(0).at(1).toInt(), 168);
+}
+
+/**
+ * HR flag set but the bpm byte is missing (truncated packet). The parser must not
+ * read past the buffer or emit a bogus reading.
+ */
+void TstBtleHub::testFtms_heartRateFlagButTruncated_ignored()
+{
+    QSignalSpy spyHr(hub, &BtleHub::signal_hr);
+
+    // Everything before HR absent, HR flagged present, but no HR byte appended.
+    QByteArray pkt;
+    quint16 flags = 0x0001 | 0x0004 | 0x0040 | 0x0200;
+    pkt.append(char( flags       & 0xFF));
+    pkt.append(char((flags >> 8) & 0xFF));
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, pkt);
+
+    QCOMPARE(spyHr.count(), 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -95,6 +95,8 @@ private slots:
     void testFtms_heartRateAfterEnergy();
     void testFtms_heartRateAfterAvgPower();
     void testFtms_heartRateFlagButTruncated_ignored();
+    void testFtms_trainerProvidesHrSignal_firesOnce();
+    void testFtms_noHr_noTrainerProvidesHrSignal();
 
     // ── SimulatorHub no-op slot verification ─────────────────────────────────
     void testSimulator_noOpSetLoad();
@@ -865,6 +867,38 @@ void TstBtleHub::testFtms_heartRateFlagButTruncated_ignored()
     hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, pkt);
 
     QCOMPARE(spyHr.count(), 0);
+}
+
+/**
+ * When the trainer bridges HR over FTMS, signal_trainerProvidesHr fires once per
+ * connection (latched) so the UI can mark the HR slot "provided by trainer"
+ * without re-firing on every packet.
+ */
+void TstBtleHub::testFtms_trainerProvidesHrSignal_firesOnce()
+{
+    QSignalSpy spy(hub, &BtleHub::signal_trainerProvidesHr);
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
+        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180,
+            true, true, true, /*heartRateBpm=*/140));
+    QCOMPARE(spy.count(), 1);
+
+    // A second HR-bearing packet must not re-emit.
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
+        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180,
+            true, true, true, /*heartRateBpm=*/142));
+    QCOMPARE(spy.count(), 1);
+}
+
+/** No HR field in the FTMS stream → the capability signal never fires. */
+void TstBtleHub::testFtms_noHr_noTrainerProvidesHrSignal()
+{
+    QSignalSpy spy(hub, &BtleHub::signal_trainerProvidesHr);
+
+    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
+        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180));
+
+    QCOMPARE(spy.count(), 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -91,13 +91,7 @@ private slots:
     // ── FTMS multi-field layout (field skipping) ─────────────────────────────
     void testFtms_allOptionalFieldsBeforePowerSkipped();
     void testFtms_negativeInstantPower();
-    void testFtms_heartRate();
-    void testFtms_heartRateAfterEnergy();
-    void testFtms_heartRateAfterAvgPower();
-    void testFtms_heartRateFlagButTruncated_ignored();
-    void testFtms_trainerProvidesHrSignal_firesOnce();
     void testHrService_firesTrainerProvidesHr();
-    void testFtms_noHr_noTrainerProvidesHrSignal();
 
     // ── SimulatorHub no-op slot verification ─────────────────────────────────
     void testSimulator_noOpSetLoad();
@@ -788,112 +782,10 @@ void TstBtleHub::testFtms_negativeInstantPower()
 }
 
 /**
- * A trainer that bridges an HR strap folds the bpm into the FTMS Indoor Bike
- * Data stream (bit 9) instead of exposing a separate 0x180D service. Verify the
- * HR field is decoded and re-emitted on signal_hr alongside the bike metrics.
- */
-void TstBtleHub::testFtms_heartRate()
-{
-    QSignalSpy spyPwr(hub, &BtleHub::signal_power);
-    QSignalSpy spyHr(hub,  &BtleHub::signal_hr);
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
-        BtlePacketBuilder::ftmsIndoorBikeData(32.4, 88.0, 195,
-            /*includeSpeed=*/true, /*includeCadence=*/true, /*includePower=*/true,
-            /*heartRateBpm=*/152));
-
-    QCOMPARE(spyPwr.count(), 1);
-    QCOMPARE(spyPwr.at(0).at(1).toInt(), 195);
-    QCOMPARE(spyHr.count(), 1);
-    QCOMPARE(spyHr.at(0).at(1).toInt(), 152);
-}
-
-/**
- * The Expended Energy field (bit 8, 5 bytes) precedes Heart Rate (bit 9). Verify
- * the parser skips it correctly so the HR byte is read at the right offset.
- */
-void TstBtleHub::testFtms_heartRateAfterEnergy()
-{
-    QSignalSpy spyHr(hub, &BtleHub::signal_hr);
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
-        BtlePacketBuilder::ftmsIndoorBikeData(0.0, 0.0, 0,
-            /*includeSpeed=*/false, /*includeCadence=*/false, /*includePower=*/false,
-            /*heartRateBpm=*/171, /*includeEnergy=*/true));
-
-    QCOMPARE(spyHr.count(), 1);
-    QCOMPARE(spyHr.at(0).at(1).toInt(), 171);
-}
-
-/**
- * Average Power (bit 7, 2 bytes) sits between Instantaneous Power and the energy/
- * HR fields. Verify the parser skips it so the HR byte lands at the right offset.
- * Built raw because the convenience builder doesn't expose an average-power field.
- */
-void TstBtleHub::testFtms_heartRateAfterAvgPower()
-{
-    QSignalSpy spyPwr(hub, &BtleHub::signal_power);
-    QSignalSpy spyHr(hub,  &BtleHub::signal_hr);
-
-    // bits: 0 speed-absent, 2 cadence-absent, 6 instant-power-absent,
-    //       7 avg-power present, 9 HR present  → 0x0001|0x0004|0x0040|0x0080|0x0200
-    QByteArray pkt;
-    quint16 flags = 0x02C5;
-    pkt.append(char( flags       & 0xFF));
-    pkt.append(char((flags >> 8) & 0xFF));
-    pkt.append(char(0x00)); pkt.append(char(0x00)); // average power = 0 W
-    pkt.append(char(168));                          // heart rate = 168 bpm
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, pkt);
-
-    QCOMPARE(spyPwr.count(), 0); // instantaneous power absent → no power signal
-    QCOMPARE(spyHr.count(), 1);
-    QCOMPARE(spyHr.at(0).at(1).toInt(), 168);
-}
-
-/**
- * HR flag set but the bpm byte is missing (truncated packet). The parser must not
- * read past the buffer or emit a bogus reading.
- */
-void TstBtleHub::testFtms_heartRateFlagButTruncated_ignored()
-{
-    QSignalSpy spyHr(hub, &BtleHub::signal_hr);
-
-    // Everything before HR absent, HR flagged present, but no HR byte appended.
-    QByteArray pkt;
-    quint16 flags = 0x0001 | 0x0004 | 0x0040 | 0x0200;
-    pkt.append(char( flags       & 0xFF));
-    pkt.append(char((flags >> 8) & 0xFF));
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, pkt);
-
-    QCOMPARE(spyHr.count(), 0);
-}
-
-/**
- * When the trainer bridges HR over FTMS, signal_trainerProvidesHr fires once per
- * connection (latched) so the UI can mark the HR slot "provided by trainer"
- * without re-firing on every packet.
- */
-void TstBtleHub::testFtms_trainerProvidesHrSignal_firesOnce()
-{
-    QSignalSpy spy(hub, &BtleHub::signal_trainerProvidesHr);
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
-        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180,
-            true, true, true, /*heartRateBpm=*/140));
-    QCOMPARE(spy.count(), 1);
-
-    // A second HR-bearing packet must not re-emit.
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
-        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180,
-            true, true, true, /*heartRateBpm=*/142));
-    QCOMPARE(spy.count(), 1);
-}
-
-/**
- * HR reaching us via a bridged 0x180D Heart Rate service (not the FTMS field)
- * must also flag the capability — the JetBlack Victory delivers HR this way.
+ * The trainer bridges its HR strap over a standard 0x180D Heart Rate service
+ * (the JetBlack Victory does this). The first such reading latches
+ * signal_trainerProvidesHr — once per connection — so the UI can mark the Heart
+ * Rate slot "provided by trainer".
  */
 void TstBtleHub::testHrService_firesTrainerProvidesHr()
 {
@@ -904,17 +796,6 @@ void TstBtleHub::testHrService_firesTrainerProvidesHr()
 
     hub->simulateNotification(0x2A37, BtlePacketBuilder::heartRate(141));
     QCOMPARE(spy.count(), 1); // latched: once per connection
-}
-
-/** No HR field in the FTMS stream → the capability signal never fires. */
-void TstBtleHub::testFtms_noHr_noTrainerProvidesHrSignal()
-{
-    QSignalSpy spy(hub, &BtleHub::signal_trainerProvidesHr);
-
-    hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA,
-        BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180));
-
-    QCOMPARE(spy.count(), 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -96,6 +96,7 @@ private slots:
     void testFtms_heartRateAfterAvgPower();
     void testFtms_heartRateFlagButTruncated_ignored();
     void testFtms_trainerProvidesHrSignal_firesOnce();
+    void testHrService_firesTrainerProvidesHr();
     void testFtms_noHr_noTrainerProvidesHrSignal();
 
     // ── SimulatorHub no-op slot verification ─────────────────────────────────
@@ -888,6 +889,21 @@ void TstBtleHub::testFtms_trainerProvidesHrSignal_firesOnce()
         BtlePacketBuilder::ftmsIndoorBikeData(30.0, 85.0, 180,
             true, true, true, /*heartRateBpm=*/142));
     QCOMPARE(spy.count(), 1);
+}
+
+/**
+ * HR reaching us via a bridged 0x180D Heart Rate service (not the FTMS field)
+ * must also flag the capability — the JetBlack Victory delivers HR this way.
+ */
+void TstBtleHub::testHrService_firesTrainerProvidesHr()
+{
+    QSignalSpy spy(hub, &BtleHub::signal_trainerProvidesHr);
+
+    hub->simulateNotification(0x2A37, BtlePacketBuilder::heartRate(138));
+    QCOMPARE(spy.count(), 1);
+
+    hub->simulateNotification(0x2A37, BtlePacketBuilder::heartRate(141));
+    QCOMPARE(spy.count(), 1); // latched: once per connection
 }
 
 /** No HR field in the FTMS stream → the capability signal never fires. */


### PR DESCRIPTION
## What

Make heart rate from a **trainer that bridges an HR strap** flow into workouts, and label it in the UI — plus a small scanner usability fix.

## Why

The **JetBlack Victory** (and similar trainers) pair an ANT+/BLE HR strap and re-expose it as a standard **`0x180D` Heart Rate service on the trainer connection**. The app already parsed `0x180D`, but only wired HR to the workout when a *separate* HR sensor was saved — so trainer-bridged HR was parsed and silently dropped. Validated on hardware.

## Changes

- **Wire trainer HR to the workout** (`mainwindow.cpp`): a dedicated strap still takes precedence (more reliable); otherwise HR from the trainer connection is used. Covers solo and Studio.
- **"Provided by trainer" for Heart Rate** (`sensorswidget` / `studiowidget`): `BtleHub` emits `signal_trainerProvidesHr` the first time the connection yields HR; `MainWindow` persists it per rider (`BtleSensorStore`). The Sensors page then annotates the HR slot. Unlike Power/Cadence (always on FTMS), the HR slot **stays scannable** (bridging can stop) and a saved strap takes precedence over the label.
- **Double-click to connect** (`btle_scanner_dialog.cpp`): double-clicking a scanned device now connects, like the Connect button.

## Validation

On a JetBlack Victory: HR shows live during the workout; after a workout the Sensors page shows Heart Rate "Provided by trainer"; double-click connects.

## Notes

An earlier revision also parsed HR from the FTMS Indoor Bike Data field (bit 9); hardware testing showed the JetBlack uses `0x180D` instead, so that speculative path was removed to avoid dead code. 54 btle tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
