### PR TITLE
feat: virtual shifting for single-cog / Zwift Cog trainers (#293)

### DIFF
--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -812,6 +812,23 @@
           <strong>Increase / Decrease Difficulty</strong> buttons to temporarily override ERG.
         </div>
 
+        <h3>Virtual shifting (Zwift Cog / single-gear setups)</h3>
+        <p>
+          If your trainer uses a <strong>single cog</strong> (e.g. a Zwift Cog) instead of a normal
+          cassette, free rides and FTP tests would otherwise leave you with no usable resistance.
+          Enable <strong>Virtual shifting</strong> on the <em>Bluetooth / Smart Trainer</em> settings
+          page (it is <strong>off by default</strong>, so normal-cassette setups are unaffected) and
+          the app gives you on-screen gears.
+        </p>
+        <ul>
+          <li>A <strong>gear indicator (▼ N / 24 ▲)</strong> appears on the workout top bar.</li>
+          <li>Shift with the <strong>Up / Down arrow keys</strong> or by clicking the on-screen
+              <strong>▲ / ▼</strong> arrows — a harder gear instantly raises resistance, like a real
+              drivetrain.</li>
+          <li>During an ERG power interval the indicator dims to <strong>ERG</strong> (the target power
+              is in control); it becomes active again on free / test intervals.</li>
+        </ul>
+
         <h3>ERG tips</h3>
         <ul>
           <li>Maintain a <strong>smooth, consistent cadence</strong> (85–95 rpm is typical). Abrupt cadence changes
@@ -1198,6 +1215,7 @@
               <tr><td><kbd>→</kbd></td><td>Skip to next interval</td></tr>
               <tr><td><kbd>+</kbd> / <kbd>=</kbd></td><td>Increase difficulty +5 %</td></tr>
               <tr><td><kbd>-</kbd></td><td>Decrease difficulty −5 %</td></tr>
+              <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Virtual shift gear up / down (when Virtual shifting is on; otherwise adjusts difficulty)</td></tr>
               <tr><td><kbd>L</kbd></td><td>Mark interval (lap)</td></tr>
               <tr><td><kbd>F11</kbd></td><td>Toggle fullscreen</td></tr>
               <tr><td><kbd>F6</kbd></td><td>Radio — previous track</td></tr>

--- a/notes/zwift-cog-protocol-findings.md
+++ b/notes/zwift-cog-protocol-findings.md
@@ -1,0 +1,101 @@
+# Zwift Cog / virtual shifting — protocol findings & Click roadmap
+
+Consolidated reference so the next person (or the Zwift Click work) doesn't start
+from scratch. Companion to `zwift-virtual-shifting-plan.md` (the journey log).
+Hardware used: **JetBlack Victory** trainer (fw 4.29) + **Zwift Click v2** (fw 1.2.0).
+
+---
+
+## TL;DR / what shipped
+
+Virtual shifting (#293) ships over **standard FTMS Set Target Resistance Level
+(`0x04`)**, NOT Zwift's proprietary protocol. Each virtual gear → a fixed
+resistance level → instant, real-gear feel. Opt-in setting (default off) so
+normal-cassette trainers are unaffected. Up/Down keys + on-screen ▲/▼ shift.
+
+The Zwift proprietary protocol was explored and **abandoned** (see below): the
+trainer ACKs its commands but never actuates resistance for us.
+
+---
+
+## Zwift proprietary *trainer* protocol (the Victory) — UNENCRYPTED
+
+Discovered via `--zwift-probe`. The trainer exposes a Zwift service **advertised
+as 16-bit `0x FC82`** (`0000fc82-0000-1000-8000-00805f9b34fb`), containing:
+
+| Characteristic | UUID | Props | Role |
+|---|---|---|---|
+| Measurement | `00000002-19ca-4651-86e5-fa29dcdd09d1` | Notify | riding data (0x03 frames) |
+| Control point | `00000003-19ca-4651-86e5-fa29dcdd09d1` | Wr/WrNR | commands (0x04) |
+| Response | `00000004-19ca-4651-86e5-fa29dcdd09d1` | Rd/Ind | handshake/cmd responses |
+
+- **Handshake:** write ASCII `"RideOn"` to the control point → trainer echoes
+  `"RideOn"` (`526964654f6e`) on the response char. **No encryption**, no trailing
+  bytes.
+- **Command `0x04` (HubCommand, protobuf):** field 3 `PowerTarget` (uint32),
+  field 4 `SimulationParam { f1 wind sint32, f2 inclineX100 sint32, f3 CWa uint32
+  =CW·a·10000, f4 Crr uint32 =Crr·100000 }`, field 5 `PhysicalParam { f2
+  GearRatioX10000 uint32, f4 BikeWeightx100, f5 RiderWeightx100 }`.
+  Zwift fixes **CWa=0.51 (5100), Crr=0.004 (400)**.
+- **Incoming `0x03` (HubRidingData):** f1 power, f2 cadence, f3 speedX100, f4 hr.
+- Codec implemented + unit-tested: `src/btle/zwift/zwift_protocol.h`.
+
+**Why abandoned:** on the Victory, the trainer **acknowledges** every `0x04`
+(SIM gear ratio *and* ERG power — its `RfCommsZcs`/`ResCtrl` debug log even prints
+"Set simulated virtual gear ratio received: 5490" and "Target power set to: 250W")
+**but applies zero resistance** — power stays ~20 W in saddle, blue LED flashing
+(= not in a controlled session). FTMS, by contrast, actuates fine (solid LED).
+Likely needs a control-grant the real (encrypted) Zwift app performs, or actuation
+simply isn't wired to this service on this firmware. Not worth fighting — FTMS works.
+
+JetBlack diagnostic char `c4632b08-003f-4cec-8994-e489b04d857f` streams ASCII logs
+(incl. `ResCtrl:` resistance lines and the `ANT HR` bridge) — invaluable as a bench
+instrument.
+
+---
+
+## Zwift Click v2 (fw 1.2.0) — ENCRYPTED (the Phase 3 blocker)
+
+Discovered via `--zwift-probe` (`CC:0A:DF:72:3D:4C`, mfr "Zwift Inc", hw "B.0"):
+
+- Advertises the **same `0x FC82`** service, with chars `00000002/3/4-19ca-…`
+  **plus three more: `00000100/101/102-19ca-…`** (the secure channel).
+- After `RideOn` it emits an `ff03…` handshake carrying **33 bytes of high-entropy
+  data = an X25519 public key** → **the Click v2 encrypts its button data**
+  (ECDH key exchange + AES). The *trainer* link is plaintext; the *Click* is not.
+
+**Implication for Click support (future):** must implement the Zwift encrypted
+handshake (X25519 → shared secret → AES-GCM decrypt of button events). Real effort
++ a **DMCA §1201** circumvention angle (the trainer path had none — it's plaintext).
+The Click is only an INPUT device (it tells the app to shift; it never talks to the
+trainer), so it's fully decoupled from actuation: **keyboard/on-screen shifting
+already delivers the feature; the Click is an optional, separable add-on.**
+
+Decoupled architecture to keep:
+```
+Zwift Click button → app virtual-gear index ±1 → app computes resistance → FTMS 0x04
+   (encrypted input)          (app logic)                                  (actuation, done)
+```
+
+---
+
+## Exploration tools left in the tree (dev/debug, behind CLI flags)
+
+- `--zwift-probe [name]` — read-only BLE GATT dump + RideOn + frame decode
+  (`zwift_probe.*`). How the above was found; rerun for the Click crypto work.
+- `--zwift-control [name]` / `--zwift-gearsweep` — drive 0x04 on the Zwift service
+  (proved acks-but-no-actuation).
+- `--ftms-erg [name]` / `--trainer-gear-test [name]` — drive FTMS via BtleHub (the
+  working path; `--trainer-gear-test` auto-cycles gears for an input-free feel test).
+
+(These are dormant in normal use; strip or keep before any public PR.)
+
+---
+
+## References
+- Makinolo, "Zwift Trainer protocol" (2024-10-20) and "Virtual gear shifting"
+  (2023-11-06) — the protocol/protobuf field map.
+- qdomyos-zwift (GPLv3) — working Zwift-protocol + Click crypto implementation.
+- Zwift Insider, "All About Virtual Shifting" — gear range (~0.75–5.49, 24 gears).
+- Patent to check before public distribution: **US 11,986,700**, "Virtual shifting
+  for exercise devices" (covers the *method*, independent of protocol).

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -2,7 +2,8 @@
 
 **Branch:** `zwift-virtual-shifting` (local only — do **not** push until the
 distribution/patent question below is resolved).
-**Status:** Phase 0 in progress.
+**Status:** Phases 0 & 1 done (codec + probe, validated on real hardware).
+Next: Phase 2 (control-point writes — first time we change resistance).
 **Origin:** issue [#293](https://github.com/MaximumTrainer/MaximumTrainer_Redux/issues/293)
 — JetBlack Victory + Zwift Cog: trainer "resistance was 0" during an FTP/MAP
 test interval and the rider could not pedal.
@@ -39,10 +40,13 @@ Virtual shifting on the Victory does **NOT** run over FTMS. It uses Zwift's own
 **proprietary trainer protocol**, and the gear→resistance math lives in the
 **trainer firmware** — we send a gear ratio, the trainer computes resistance.
 
-- **Zwift trainer service:** `00000001-19ca-4651-86e5-fa29dcdd09d1`
-  - Notifications (riding data): `00000002-19ca-4651-86e5-fa29dcdd09d1`
-  - Control point (commands):    `00000003-19ca-4651-86e5-fa29dcdd09d1`
-  - Response/indicate (assumed): `00000004-19ca-4651-86e5-fa29dcdd09d1`
+- **Zwift trainer service:** advertised as **`0000fc82-0000-1000-8000-00805f9b34fb`**
+  (16-bit Zwift UUID 0xFC82 — *confirmed via Phase 1 probe on the JetBlack
+  Victory fw 4.29*; the earlier `00000001-19ca-…` guess was WRONG). The three
+  characteristics inside it do use the 19ca base:
+  - Notifications (riding data): `00000002-19ca-4651-86e5-fa29dcdd09d1` [Ntf]
+  - Control point (commands):    `00000003-19ca-4651-86e5-fa29dcdd09d1` [Wr|WrNR]
+  - Response/indicate:           `00000004-19ca-4651-86e5-fa29dcdd09d1` [Rd|Ind]
 - **Framing:** `[command_code][protobuf_data]`
 - **Incoming 0x03 — HubRidingData:** f1 Power, f2 Cadence, f3 SpeedX100,
   f4 HR, f5/f6 unknown (all uint32 varints).
@@ -86,11 +90,21 @@ qdomyos-zwift (GPLv3), SHIFTR.
   protocol constants + protobuf codec for HubCommand (0x04) and HubRidingData
   (0x03), the gear table, handshake constant. Unit-tested against byte fixtures.
   ← *current*
-- [ ] **Phase 1 — Read-only probe harness (device).** CLI flag (extend the
-  `--sensor-check` pattern) that connects to the Victory + Click, dumps
-  services/characteristics, runs the RideOn handshake, logs raw + decoded
-  frames. Confirms layout, handshake trailing bytes, encryption assumption,
-  Click button format. Read-only = safe.
+- [x] **Phase 1 — Read-only probe harness (device).** DONE. `--zwift-probe
+  [nameFilter]` (`src/btle/zwift/zwift_probe.*`). Run against the live Victory
+  (name "Victory MaJet", C4:67:D8:7A:AC:35, JetBlack fw 4.29):
+  `./build/release/MaximumTrainer --zwift-probe Victory` (offscreen ok).
+  **Confirmed on hardware:**
+  - Zwift service lives under **`0000fc82`** (not `00000001-19ca-…`); chars
+    `00000002/3/4-19ca-…` exactly as documented.
+  - Handshake: write `"RideOn"` to `…03` → trainer echoes `"RideOn"`
+    (`526964654f6e`) on `…04`. **No trailing bytes, NOT encrypted.**
+  - `…02` streams `0x03`-framed HubRidingData; the Phase 0 decoder parses it
+    cleanly (idle → all-zero fields; needs a pedaling test for non-zero).
+  - FTMS (`1826`/`2ad2`) streams in parallel; JetBlack debug char
+    `c4632b08` logs ASCII incl. `ResCtrl: Resistance control timer …` and the
+    `ANT HR` bridge (the #292 HR path).
+  - Zwift Click was not present/paired this session → defer to Phase 3.
 - [ ] **Phase 2 — Trainer control path (device).** `ZwiftTrainerController`
   sibling to `setLoad`/`setSlope`; `setVirtualGear(riderId, gearIndex)` →
   encode 0x04 with gear ratio + sim params + rider/bike weight → write control
@@ -110,6 +124,12 @@ qdomyos-zwift (GPLv3), SHIFTR.
 ## Resume checklist
 
 1. `git checkout zwift-virtual-shifting`
-2. Phase 0 code lives in `src/btle/zwift/`; tests in `tests/zwift/`.
-3. Build the unit tests: `cd tests/zwift && qmake6 zwift_tests.pro && make && ./zwift_tests -v2`
-4. Next up = Phase 1 probe harness against real hardware.
+2. Code: codec `src/btle/zwift/zwift_protocol.*`, probe `…/zwift_probe.*`; unit
+   tests `tests/zwift/`.
+3. Unit tests: `cd tests/zwift && qmake6 zwift_tests.pro && make && ./zwift_tests -v2`
+4. Probe a live trainer: `qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6 && make -j$(nproc)`
+   then `LD_LIBRARY_PATH=/tmp/qwt6/lib QT_QPA_PLATFORM=offscreen ./build/release/MaximumTrainer --zwift-probe Victory`
+5. **Next = Phase 2:** send a 0x04 HubCommand with a gear ratio to control point
+   `…03` and watch resistance change (the `c4632b08` ResCtrl debug log + a
+   pedaling test confirm it). First writes that actually change the trainer —
+   gate behind an explicit flag, start from a known gear, test incrementally.

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -1,0 +1,115 @@
+# Zwift virtual shifting — implementation plan & working notes
+
+**Branch:** `zwift-virtual-shifting` (local only — do **not** push until the
+distribution/patent question below is resolved).
+**Status:** Phase 0 in progress.
+**Origin:** issue [#293](https://github.com/MaximumTrainer/MaximumTrainer_Redux/issues/293)
+— JetBlack Victory + Zwift Cog: trainer "resistance was 0" during an FTP/MAP
+test interval and the rider could not pedal.
+
+---
+
+## Why this is needed (root cause of #293)
+
+The FTP/MAP **test interval** is deliberately driven in **slope/SIM mode at 0 %
+grade**, not ERG:
+
+`src/ui/workoutdialog.cpp:2529`
+```cpp
+if (interval.isTestInterval() || interval.getPowerStepType() == Interval::NONE
+    || workout.getWorkoutNameEnum() == Workout::OPEN_RIDE)
+    isUsingSlopeMode = true;     // → sendSlopes(0) → FTMS 0x11, grade = 0%
+```
+
+On a normal trainer with a real cassette, 0 % grade is fine — you shift to a hard
+gear and push. The **Zwift Cog is a single sprocket** (one gear ratio), so at 0 %
+simulated grade there is almost nothing to push against → spin-out → "resistance
+was 0." Single-cog trainers *require* virtual shifting (or ERG) to have usable
+resistance in SIM mode.
+
+We chose to implement **real virtual shifting** (option 3) rather than change the
+test (option 1) or a manual FTMS-resistance approximation (option 2), because
+Maxime owns the Zwift Cog + Click hardware to test with.
+
+---
+
+## Key protocol facts (from public reverse-engineering)
+
+Virtual shifting on the Victory does **NOT** run over FTMS. It uses Zwift's own
+**proprietary trainer protocol**, and the gear→resistance math lives in the
+**trainer firmware** — we send a gear ratio, the trainer computes resistance.
+
+- **Zwift trainer service:** `00000001-19ca-4651-86e5-fa29dcdd09d1`
+  - Notifications (riding data): `00000002-19ca-4651-86e5-fa29dcdd09d1`
+  - Control point (commands):    `00000003-19ca-4651-86e5-fa29dcdd09d1`
+  - Response/indicate (assumed): `00000004-19ca-4651-86e5-fa29dcdd09d1`
+- **Framing:** `[command_code][protobuf_data]`
+- **Incoming 0x03 — HubRidingData:** f1 Power, f2 Cadence, f3 SpeedX100,
+  f4 HR, f5/f6 unknown (all uint32 varints).
+- **Outgoing 0x04 — HubCommand:**
+  - f3 PowerTarget (uint32) — ERG
+  - f4 SimulationParam { f1 Wind sint32 (m/s·100), f2 InclineX100 sint32,
+    f3 CWa uint32 (CW·a·10000), f4 Crr uint32 (·100000) }
+  - f5 PhysicalParam { f2 **GearRatioX10000** uint32, f4 BikeWeightX100 uint32,
+    f5 RiderWeightX100 uint32 }
+- **Encryption:** the trainer link is **NOT encrypted** (same as Zwift Ride).
+  Handshake begins with `"RideOn"` — trailing bytes TBD, confirm in Phase 1.
+- **Virtual gear range:** ~0.75 → 5.49, 24 gears (Zwift Insider).
+- The **Zwift Click** is a *separate* BLE input device — it tells the *app* to
+  shift up/down; it never talks to the trainer. Its button protocol is decoded
+  in Phase 3; keyboard/on-screen shifting covers Phases 0–2.
+
+Sources: Makinolo "Zwift Trainer protocol" (2024-10-20) and "Virtual gear
+shifting" (2023-11-06); Zwift Insider "All About Virtual Shifting";
+qdomyos-zwift (GPLv3), SHIFTR.
+
+---
+
+## Legal / distribution notes (resolve before pushing)
+
+- **License:** project is GPL-3.0; qdomyos-zwift reference is GPLv3 → reuse is
+  fine if GPL terms respected. Verify any snippet's license before copying.
+- **Patent:** Zwift holds **US 11,986,700 "Virtual shifting for exercise
+  devices."** Patents cover the *method*, not the code — clean-room does not
+  help. **Read claim 1 before any public distribution.** Local experimentation
+  is low-risk; *public release* is the exposure point.
+- **DMCA §1201:** only a concern if firmware required circumventing encryption —
+  it does **not** (link is unencrypted), so this risk is low here.
+- Keep the Zwift-proprietary path in a **separable module** (`src/btle/zwift/`)
+  so it can stay on an experimental branch if the patent question blocks a merge.
+
+---
+
+## Phased plan
+
+- [ ] **Phase 0 — Protocol scaffolding (no device).** `src/btle/zwift/`
+  protocol constants + protobuf codec for HubCommand (0x04) and HubRidingData
+  (0x03), the gear table, handshake constant. Unit-tested against byte fixtures.
+  ← *current*
+- [ ] **Phase 1 — Read-only probe harness (device).** CLI flag (extend the
+  `--sensor-check` pattern) that connects to the Victory + Click, dumps
+  services/characteristics, runs the RideOn handshake, logs raw + decoded
+  frames. Confirms layout, handshake trailing bytes, encryption assumption,
+  Click button format. Read-only = safe.
+- [ ] **Phase 2 — Trainer control path (device).** `ZwiftTrainerController`
+  sibling to `setLoad`/`setSlope`; `setVirtualGear(riderId, gearIndex)` →
+  encode 0x04 with gear ratio + sim params + rider/bike weight → write control
+  point. Drive with keyboard / on-screen ▲▼ first (no Click dependency). Wire
+  into workout SIM mode.
+  - NOTE: the app is **BLE-only** — ANT+ was removed in #240. The existing
+    `setLoad(int antID, …)` / `setSlope(int antID, …)` params are named `antID`
+    purely as legacy leftover; the value is really the BLE trainer/rider id
+    (`trainerControlUserId` / `getFecID()`). New API uses `riderId`, not `antID`.
+- [ ] **Phase 3 — Zwift Click input (device).** Decode Click button frames →
+  call the same shift function. Pure add-on.
+- [ ] **Phase 4 — Polish + distribution call.** Gear indicator UI, gear-range
+  persistence; revisit patent/distribution before any merge to public master.
+
+---
+
+## Resume checklist
+
+1. `git checkout zwift-virtual-shifting`
+2. Phase 0 code lives in `src/btle/zwift/`; tests in `tests/zwift/`.
+3. Build the unit tests: `cd tests/zwift && qmake6 zwift_tests.pro && make && ./zwift_tests -v2`
+4. Next up = Phase 1 probe harness against real hardware.

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -2,8 +2,10 @@
 
 **Branch:** `zwift-virtual-shifting` (local only — do **not** push until the
 distribution/patent question below is resolved).
-**Status:** Phases 0 & 1 done (codec + probe, validated on real hardware).
-Next: Phase 2 (control-point writes — first time we change resistance).
+**Status:** Phases 0, 1, 2a done — codec, probe, and **trainer control all
+validated on real hardware** (Victory ACKs our ERG commands). Next: Phase 2b
+(in-app ZwiftTrainerController + keyboard shifting = the #293 fix), plus an
+in-saddle pedaling test to confirm gear feel.
 **Origin:** issue [#293](https://github.com/MaximumTrainer/MaximumTrainer_Redux/issues/293)
 — JetBlack Victory + Zwift Cog: trainer "resistance was 0" during an FTP/MAP
 test interval and the rider could not pedal.
@@ -105,15 +107,25 @@ qdomyos-zwift (GPLv3), SHIFTR.
     `c4632b08` logs ASCII incl. `ResCtrl: Resistance control timer …` and the
     `ANT HR` bridge (the #292 HR path).
   - Zwift Click was not present/paired this session → defer to Phase 3.
-- [ ] **Phase 2 — Trainer control path (device).** `ZwiftTrainerController`
-  sibling to `setLoad`/`setSlope`; `setVirtualGear(riderId, gearIndex)` →
-  encode 0x04 with gear ratio + sim params + rider/bike weight → write control
-  point. Drive with keyboard / on-screen ▲▼ first (no Click dependency). Wire
-  into workout SIM mode.
-  - NOTE: the app is **BLE-only** — ANT+ was removed in #240. The existing
-    `setLoad(int antID, …)` / `setSlope(int antID, …)` params are named `antID`
-    purely as legacy leftover; the value is really the BLE trainer/rider id
-    (`trainerControlUserId` / `getFecID()`). New API uses `riderId`, not `antID`.
+- [x] **Phase 2a — Control path validated on hardware (harness).** DONE.
+  `--zwift-control [name]` runs a scripted 0x04 sequence after the handshake.
+  Live on the Victory: **trainer ACKs our commands** — its ResCtrl debug log
+  printed `Target power set to: 250W` / `150W` / `0W` for our ERG writes, and
+  resistance ticks reacted. RESET (ERG 0 W) releases cleanly. ERG control over
+  the Zwift trainer protocol is proven. (Encoders: ERG `0418fa01`=250W; SIM+gear
+  e.g. `04220310b0092a0a10c5a50120a00628cc3a`.)
+  - SIM/gear writes are accepted but, with **no one pedaling**, gear effect on
+    felt resistance can't be seen (speed≈0 → low SIM resistance — the #293
+    effect itself). Needs an **in-saddle pedaling test** to confirm gears change
+    feel. ← do with Maxime on the bike.
+- [ ] **Phase 2b — In-app integration (no device dep for the code).**
+  `ZwiftTrainerController` sibling to `setLoad`/`setSlope`;
+  `setVirtualGear(riderId, gearIndex)` + keyboard / on-screen ▲▼. Detect the
+  Zwift `fc82` service on connect and prefer it for single-cog trainers; wire
+  into workout SIM mode; this is the actual #293 fix.
+  - NOTE: app is **BLE-only** (ANT+ removed #240). Existing `setLoad(int antID,…)`
+    param is legacy-named; value is really the trainer/rider id
+    (`trainerControlUserId`/`getFecID()`). New API uses `riderId`, not `antID`.
 - [ ] **Phase 3 — Zwift Click input (device).** Decode Click button frames →
   call the same shift function. Pure add-on.
   - **Phase 1 recon (Click v2, fw 1.2.0, CC:0A:DF:72:3D:4C) DONE:** advertises

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -116,6 +116,18 @@ qdomyos-zwift (GPLv3), SHIFTR.
     (`trainerControlUserId` / `getFecID()`). New API uses `riderId`, not `antID`.
 - [ ] **Phase 3 — Zwift Click input (device).** Decode Click button frames →
   call the same shift function. Pure add-on.
+  - **Phase 1 recon (Click v2, fw 1.2.0, CC:0A:DF:72:3D:4C) DONE:** advertises
+    the **same `0000fc82`** service; chars `00000002/3/4-19ca-…` PLUS three
+    extra `00000100/101/102-19ca-…`. mfr "Zwift Inc", hw "B.0", battery 80%.
+    After RideOn it streams a handshake incl. `ff03…` + 33 bytes of
+    high-entropy data = an **X25519 public key** → **the Click v2 ENCRYPTS its
+    button data** (ECDH + AES; the `010x` chars are the secure channel). Unlike
+    the trainer, which is plaintext.
+  - **Implication:** Click support requires implementing the Zwift crypto
+    handshake — real effort AND the **DMCA §1201** circumvention angle. NOT on
+    the critical path: keyboard/on-screen shifting (Phase 2) gives full virtual
+    shifting with no crypto. Defer Click; decide separately. Public RE exists
+    (qdomyos-zwift, makinolo "Zwift Play" posts).
 - [ ] **Phase 4 — Polish + distribution call.** Gear indicator UI, gear-range
   persistence; revisit patent/distribution before any merge to public master.
 

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -2,10 +2,11 @@
 
 **Branch:** `zwift-virtual-shifting` (local only — do **not** push until the
 distribution/patent question below is resolved).
-**Status:** Phases 0, 1, 2a done — codec, probe, and **trainer control all
-validated on real hardware** (Victory ACKs our ERG commands). Next: Phase 2b
-(in-app ZwiftTrainerController + keyboard shifting = the #293 fix), plus an
-in-saddle pedaling test to confirm gear feel.
+**Status:** PIVOTED OFF the Zwift protocol — it acks but never actuates
+resistance (proven in-saddle for SIM *and* ERG). Virtual shifting is now built
+over **standard FTMS** (the channel the app already drives). In-app feature +
+a BtleHub-based headless feel test are written; **the next session is to FEEL
+it on the trainer** via `--trainer-gear-test`. See "Where we are / resume" below.
 **Origin:** issue [#293](https://github.com/MaximumTrainer/MaximumTrainer_Redux/issues/293)
 — JetBlack Victory + Zwift Cog: trainer "resistance was 0" during an FTP/MAP
 test interval and the rider could not pedal.
@@ -121,16 +122,39 @@ qdomyos-zwift (GPLv3), SHIFTR.
     aero drag (CWa) on the gear-driven virtual speed; with CWa=Crr=0 and grade
     not biting, the gear scales nothing. FIX: send Zwift's fixed
     **CWa=0.51 (5100), Crr=0.004 (400)** (now `ZwiftSim::` constants) in every
-    SimulationParam. Gear-sweep grades flattened to 0% so aero isolates gear
-    feel. ← retest in saddle.
-- [ ] **Phase 2b — In-app integration (no device dep for the code).**
-  `ZwiftTrainerController` sibling to `setLoad`/`setSlope`;
-  `setVirtualGear(riderId, gearIndex)` + keyboard / on-screen ▲▼. Detect the
-  Zwift `fc82` service on connect and prefer it for single-cog trainers; wire
-  into workout SIM mode; this is the actual #293 fix.
-  - NOTE: app is **BLE-only** (ANT+ removed #240). Existing `setLoad(int antID,…)`
-    param is legacy-named; value is really the trainer/rider id
-    (`trainerControlUserId`/`getFecID()`). New API uses `riderId`, not `antID`.
+    SimulationParam. Gear-sweep grades flattened to 0% so aero isolates gear feel.
+  - **In-saddle test #2 (CWa/Crr fix): STILL flat.** Firmware confirmed receipt
+    of gear ratios again, but power stayed ~22 W.
+  - **In-saddle test #3 (ERG over the Zwift channel): STILL flat.** Power pinned
+    ~20 W (independently confirmed via Cycling Power 2A63) through ERG 100/170/
+    230 W, all ACKed. **The blue LED was flashing = trainer NOT in a controlled
+    session.** ⇒ **The Zwift `fc82` channel acks but never actuates for us.**
+    DEAD END. (Likely needs a control-grant the encrypted Zwift app does, or
+    actuation just isn't wired to that service on this firmware.)
+- [x] **PIVOT → FTMS actuation.** The owner confirmed normal ERG works in the app
+  (FTMS), and the app's LED goes **solid**. So drive resistance over standard
+  FTMS (`1826`/`2AD9`), the channel `BtleHub` already controls. `--ftms-erg`
+  harness gets a real FTMS **control grant** (op00 res01) — but standalone-harness
+  FTMS still didn't actuate in saddle (flashing LED) and a dozen rapid
+  connect/control cycles left the trainer stuck at free-roll until a power-cycle.
+  Conclusion: **don't use the standalone harness — use `BtleHub`** (it gets a
+  solid LED + real resistance in the app).
+- [x] **Phase 2b — In-app virtual shifting (BUILT; needs in-saddle feel test).**
+  Commit `9452aac`+. In `WorkoutDialog`: Up/Down arrows shift a virtual gear
+  (`m_virtualGear`, 1..15); on test/slope/free-ride intervals — where the code
+  used to send `sendSlopes(0)` (resistance 0, the #293 bug) — it now calls
+  `sendGearLoad()` → `setLoad` (FTMS `0x05`) with cadence-aware watts from the
+  shared `VirtualGear::targetWatts` model. Re-sent each second so cadence changes
+  feel like a gear. Guards: never fights an ERG target, resets mid-gear on start,
+  releases on end. Gear shown in the window title (proper on-screen indicator =
+  follow-up, do WITH owner). Unit-tested (`tests/zwift`, 20/20).
+  - **Headless feel test:** `--trainer-gear-test [name]` drives `BtleHub` (the
+    PROVEN path) and auto-cycles gears (warmup → easy↔hard) so the rider just
+    pedals and feels them — no source/keyboard needed on the trainer-side PC.
+    Smoke test: `FTMS control granted by trainer` + `0x05` acked. THIS is what
+    to run in saddle next.
+  - NOTE: app is **BLE-only** (ANT+ removed #240). `setLoad(int antID,…)`'s param
+    is legacy-named; value is really `trainerControlUserId`/`getFecID()`.
 - [ ] **Phase 3 — Zwift Click input (device).** Decode Click button frames →
   call the same shift function. Pure add-on.
   - **Phase 1 recon (Click v2, fw 1.2.0, CC:0A:DF:72:3D:4C) DONE:** advertises
@@ -150,15 +174,43 @@ qdomyos-zwift (GPLv3), SHIFTR.
 
 ---
 
-## Resume checklist
+## Where we are / how to resume
 
-1. `git checkout zwift-virtual-shifting`
-2. Code: codec `src/btle/zwift/zwift_protocol.*`, probe `…/zwift_probe.*`; unit
-   tests `tests/zwift/`.
-3. Unit tests: `cd tests/zwift && qmake6 zwift_tests.pro && make && ./zwift_tests -v2`
-4. Probe a live trainer: `qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6 && make -j$(nproc)`
-   then `LD_LIBRARY_PATH=/tmp/qwt6/lib QT_QPA_PLATFORM=offscreen ./build/release/MaximumTrainer --zwift-probe Victory`
-5. **Next = Phase 2:** send a 0x04 HubCommand with a gear ratio to control point
-   `…03` and watch resistance change (the `c4632b08` ResCtrl debug log + a
-   pedaling test confirm it). First writes that actually change the trainer —
-   gate behind an explicit flag, start from a known gear, test incrementally.
+**The Zwift-protocol path is abandoned** (acks, never actuates). Virtual shifting
+is built over **FTMS via `BtleHub`** and is the real #293 fix. Code is on local
+branch `zwift-virtual-shifting` (do NOT push — patent question still open).
+
+Key code:
+- In-app feature: `src/ui/workoutdialog.{h,cpp}` — `virtualShiftingActive()`,
+  `gearTargetWatts()`, `sendGearLoad()`, `shiftGear()`; Up/Down in
+  `keyPressEvent`; the two `sendSlopes(0)`→gear swaps (free-ride ~line 1147,
+  test/slope ~line 2472); per-second re-send in `sendLastSecondData`.
+- Shared model: `src/btle/zwift/virtual_gear.h` (unit-tested, `tests/zwift`).
+- Headless feel test: `src/btle/zwift/trainer_gear_test.*` (`--trainer-gear-test`).
+- Dormant Zwift harness (kept for reference): `zwift_probe.*`,
+  `zwift_protocol.*`, flags `--zwift-probe/-control/-gearsweep`, `--ftms-erg`.
+
+Build & tests (no hardware):
+```
+qmake6 MaximumTrainer.pro QWT_INSTALL=/tmp/qwt6 && make -j$(nproc)
+cd tests/zwift && qmake6 zwift_tests.pro && make && ../../build/tests/zwift_tests   # 20/20
+```
+
+**THE NEXT STEP (with owner at the trainer):** feel the gears.
+1. Owner: phone Bluetooth OFF (so nothing else holds the trainer); be ready to
+   pedal at the trainer.
+2. Run from this machine (reaches the trainer over BLE):
+   `LD_LIBRARY_PATH=/tmp/qwt6/lib QT_QPA_PLATFORM=offscreen ./build/release/MaximumTrainer --trainer-gear-test Victory`
+   (add `--debug` to see `BtleHub` FTMS grant logs). It connects via `BtleHub`,
+   warms up ~25 s (mount + pedal), then auto-cycles easy↔hard gears ~90 s and
+   releases. Owner reports whether resistance clearly changes per gear; the log
+   prints cadence + target watts per gear.
+3. If gears are felt → success. Then: tune the gear curve, add an on-screen gear
+   indicator + on-screen ▲▼ buttons, decide ratios/persistence, and clean up the
+   dormant Zwift harness before any PR.
+   If still flat with `BtleHub` (solid LED + real FTMS control) → it's a
+   trainer-setup issue (calibration/Cog), not our code.
+
+Gotcha learned: rapid connect→control→disconnect cycles can leave the trainer
+stuck at free-roll (LED flashing) — power-cycle the trainer to clear it. Don't
+hammer it with the standalone harness.

--- a/notes/zwift-virtual-shifting-plan.md
+++ b/notes/zwift-virtual-shifting-plan.md
@@ -114,10 +114,15 @@ qdomyos-zwift (GPLv3), SHIFTR.
   resistance ticks reacted. RESET (ERG 0 W) releases cleanly. ERG control over
   the Zwift trainer protocol is proven. (Encoders: ERG `0418fa01`=250W; SIM+gear
   e.g. `04220310b0092a0a10c5a50120a00628cc3a`.)
-  - SIM/gear writes are accepted but, with **no one pedaling**, gear effect on
-    felt resistance can't be seen (speed≈0 → low SIM resistance — the #293
-    effect itself). Needs an **in-saddle pedaling test** to confirm gears change
-    feel. ← do with Maxime on the bike.
+  - **In-saddle pedaling test #1 (felt nothing, ~22 W flat across all gears).**
+    Firmware log (`RfCommsZcs`) proved it RECEIVED our exact gear ratios
+    (0.817 / 2.118 / 5.49) + masses — encoding perfect — but resistance never
+    changed. ROOT CAUSE: we sent **CWa=0 and Crr=0**. Virtual shifting's feel is
+    aero drag (CWa) on the gear-driven virtual speed; with CWa=Crr=0 and grade
+    not biting, the gear scales nothing. FIX: send Zwift's fixed
+    **CWa=0.51 (5100), Crr=0.004 (400)** (now `ZwiftSim::` constants) in every
+    SimulationParam. Gear-sweep grades flattened to 0% so aero isolates gear
+    feel. ← retest in saddle.
 - [ ] **Phase 2b — In-app integration (no device dep for the code).**
   `ZwiftTrainerController` sibling to `setLoad`/`setSlope`;
   `setVirtualGear(riderId, gearIndex)` + keyboard / on-screen ▲▼. Detect the

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -28,6 +28,7 @@
 #include "retroracecontroller.h"
 #ifndef Q_OS_WASM
 #include "zwift_probe.h"
+#include "trainer_gear_test.h"
 #endif
 #endif
 
@@ -264,6 +265,21 @@ int main(int argc, char *argv[]) {
         QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
         probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/110,
                      ZwiftProbe::Script::ErgHold);
+        return app.exec();
+    }
+
+    // --trainer-gear-test [nameFilter]: headless auto gear-shift over BtleHub
+    // (the app's working FTMS path) so a rider can feel virtual gears change.
+    if (cliArgs.contains(QLatin1String("--trainer-gear-test"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--trainer-gear-test"));
+        QString nameFilter = QStringLiteral("Victory");
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+        auto *t = new TrainerGearTest(&app);
+        QObject::connect(t, &TrainerGearTest::finished, &app, &QCoreApplication::quit);
+        t->start(nameFilter);
         return app.exec();
     }
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -247,7 +247,25 @@ int main(int argc, char *argv[]) {
         auto *probe = new ZwiftProbe(&app);
         QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
         probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/50,
-                     /*controlTest=*/true);
+                     ZwiftProbe::Script::ErgDemo);
+        return app.exec();
+    }
+
+    // --zwift-gearsweep [nameFilter]: Phase 2 gear validation. Holds a grade and
+    // auto-steps the virtual gear up/down every few seconds so a rider can FEEL
+    // each gear without touching any input. CHANGES RESISTANCE; releases at end.
+    if (cliArgs.contains(QLatin1String("--zwift-gearsweep"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--zwift-gearsweep"));
+        QString nameFilter = QStringLiteral("Victory");
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+
+        auto *probe = new ZwiftProbe(&app);
+        QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
+        probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/95,
+                     ZwiftProbe::Script::GearSweep);
         return app.exec();
     }
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -233,6 +233,24 @@ int main(int argc, char *argv[]) {
         return app.exec();
     }
 
+    // --zwift-control [nameFilter]: Phase 2. Connects to the trainer, runs the
+    // RideOn handshake, then sends a scripted sequence of 0x04 control commands
+    // (ERG + SIM/gear). THIS CHANGES TRAINER RESISTANCE; ends by releasing it.
+    if (cliArgs.contains(QLatin1String("--zwift-control"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--zwift-control"));
+        QString nameFilter = QStringLiteral("Victory");
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+
+        auto *probe = new ZwiftProbe(&app);
+        QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
+        probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/50,
+                     /*controlTest=*/true);
+        return app.exec();
+    }
+
     // --retrorace [file.fit] [--shot out.png]: standalone spike of the retro
     // ghost-race view. Skips login/MainWindow entirely. With --shot it grabs one
     // frame to a PNG and quits (headless validation); otherwise it stays open.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -26,6 +26,9 @@
 #include <QPainter>
 #include <QImage>
 #include "retroracecontroller.h"
+#ifndef Q_OS_WASM
+#include "zwift_probe.h"
+#endif
 #endif
 
 
@@ -213,6 +216,23 @@ int main(int argc, char *argv[]) {
                              || cliArgs.contains(QLatin1String("/screenshots"),  Qt::CaseInsensitive);
 
 #ifndef Q_OS_WASM
+    // --zwift-probe [nameFilter]: headless, read-only BLE exploration of the
+    // Zwift trainer/Click protocol (issue #293, Phase 1). Dumps GATT + frames,
+    // writes only the RideOn handshake (never a control command), then quits.
+    if (cliArgs.contains(QLatin1String("--zwift-probe"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--zwift-probe"));
+        QString nameFilter;
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+
+        auto *probe = new ZwiftProbe(&app);
+        QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
+        probe->start(nameFilter);
+        return app.exec();
+    }
+
     // --retrorace [file.fit] [--shot out.png]: standalone spike of the retro
     // ghost-race view. Skips login/MainWindow entirely. With --shot it grabs one
     // frame to a PNG and quits (headless validation); otherwise it stays open.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -251,6 +251,22 @@ int main(int argc, char *argv[]) {
         return app.exec();
     }
 
+    // --zwift-erghold [nameFilter]: decisive test of whether ERG actuates
+    // resistance while pedaling. Holds 100/160/230/120 W, then releases.
+    if (cliArgs.contains(QLatin1String("--zwift-erghold"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--zwift-erghold"));
+        QString nameFilter = QStringLiteral("Victory");
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+        auto *probe = new ZwiftProbe(&app);
+        QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
+        probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/110,
+                     ZwiftProbe::Script::ErgHold);
+        return app.exec();
+    }
+
     // --zwift-gearsweep [nameFilter]: Phase 2 gear validation. Holds a grade and
     // auto-steps the virtual gear up/down every few seconds so a rider can FEEL
     // each gear without touching any input. CHANGES RESISTANCE; releases at end.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -267,6 +267,22 @@ int main(int argc, char *argv[]) {
         return app.exec();
     }
 
+    // --ftms-erg [nameFilter]: drive standard FTMS Set Target Power (the channel
+    // that actually actuates this trainer) to confirm resistance while pedaling.
+    if (cliArgs.contains(QLatin1String("--ftms-erg"), Qt::CaseInsensitive)) {
+        splash.hide();
+        const int idx = cliArgs.indexOf(QLatin1String("--ftms-erg"));
+        QString nameFilter = QStringLiteral("Victory");
+        if (idx >= 0 && idx + 1 < cliArgs.size()
+            && !cliArgs.at(idx + 1).startsWith(QLatin1Char('-')))
+            nameFilter = cliArgs.at(idx + 1);
+        auto *probe = new ZwiftProbe(&app);
+        QObject::connect(probe, &ZwiftProbe::finished, &app, &QCoreApplication::quit);
+        probe->start(nameFilter, /*scanSeconds=*/8, /*listenSeconds=*/110,
+                     ZwiftProbe::Script::FtmsErg);
+        return app.exec();
+    }
+
     // --zwift-gearsweep [nameFilter]: Phase 2 gear validation. Holds a grade and
     // auto-steps the virtual gear up/down every few seconds so a rider can FEEL
     // each gear without touching any input. CHANGES RESISTANCE; releases at end.

--- a/src/btle/btle.pri
+++ b/src/btle/btle.pri
@@ -32,8 +32,10 @@ contains(QMAKE_PLATFORM, wasm) {
         $$PWD/simulator_hub.h
 
     # Read-only Zwift exploration harness (Phase 1) needs native QtBluetooth.
-    SOURCES += $$PWD/zwift/zwift_probe.cpp
-    HEADERS += $$PWD/zwift/zwift_probe.h
+    SOURCES += $$PWD/zwift/zwift_probe.cpp \
+               $$PWD/zwift/trainer_gear_test.cpp
+    HEADERS += $$PWD/zwift/zwift_probe.h \
+               $$PWD/zwift/trainer_gear_test.h
 }
 
 # Zwift virtual-shifting protocol codec — pure bytes, platform-independent.

--- a/src/btle/btle.pri
+++ b/src/btle/btle.pri
@@ -32,5 +32,9 @@ contains(QMAKE_PLATFORM, wasm) {
         $$PWD/simulator_hub.h
 }
 
+# Zwift virtual-shifting protocol codec — pure bytes, platform-independent.
+SOURCES += $$PWD/zwift/zwift_protocol.cpp
+HEADERS += $$PWD/zwift/zwift_protocol.h
+
 FORMS += \
     $$PWD/btle_scanner_dialog.ui

--- a/src/btle/btle.pri
+++ b/src/btle/btle.pri
@@ -1,4 +1,4 @@
-INCLUDEPATH += $$PWD
+INCLUDEPATH += $$PWD $$PWD/zwift
 
 # On Wasm use the WebBluetooth bridge; on all other platforms use native Qt BLE
 contains(QMAKE_PLATFORM, wasm) {
@@ -30,6 +30,10 @@ contains(QMAKE_PLATFORM, wasm) {
         $$PWD/sensor_connect_dialog.h \
         $$PWD/btle_uuids.h \
         $$PWD/simulator_hub.h
+
+    # Read-only Zwift exploration harness (Phase 1) needs native QtBluetooth.
+    SOURCES += $$PWD/zwift/zwift_probe.cpp
+    HEADERS += $$PWD/zwift/zwift_probe.h
 }
 
 # Zwift virtual-shifting protocol codec — pure bytes, platform-independent.

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -35,6 +35,7 @@ static const QBluetoothUuid CyclingPowerMeasurement (QBluetoothUuid::CyclingPowe
 #endif
 static const QBluetoothUuid FtmsIndoorBikeData      (quint16(0x2AD2));
 static const QBluetoothUuid FtmsControlPoint        (quint16(0x2AD9));
+static const QBluetoothUuid FtmsFeature             (quint16(0x2ACC));
 static const QBluetoothUuid BatteryLevel            (quint16(0x2A19));
 // Moxy Muscle Oxygen Monitor (proprietary UUIDs - not in BT SIG enum)
 static const QBluetoothUuid MoxyService             (quint16(0xAAB0));
@@ -272,6 +273,7 @@ void BtleHub::simulateNotification(quint16 characteristicUuid, const QByteArray 
     case BTLE_UUID_CSC_MEASUREMENT:   parseCscMeasurement(data);     break;
     case BTLE_UUID_POWER_MEASUREMENT: parsePowerMeasurement(data);   break;
     case BTLE_UUID_FTMS_BIKE_DATA:    parseFtmsIndoorBikeData(data); break;
+    case BTLE_UUID_FTMS_FEATURE:      parseFtmsFeature(data);        break;
     case BTLE_UUID_MOXY_MEASUREMENT:  parseMoxyMeasurement(data);    break;
     case BTLE_UUID_BATTERY_LEVEL:     parseBatteryLevel(data);       break;
     default: break;
@@ -335,8 +337,13 @@ void BtleHub::onServiceDiscovered(const QBluetoothUuid &serviceUuid)
     }
     else if (serviceUuid == BtleUuid::FitnessMachine) {
         m_ftmsService = m_controller->createServiceObject(serviceUuid, this);
-        if (m_ftmsService)
+        if (m_ftmsService) {
+            // Handle the one-shot read of the Fitness Machine Feature (0x2ACC)
+            // so we learn whether Set Target Resistance Level (0x04) is supported.
+            connect(m_ftmsService, &QLowEnergyService::characteristicRead,
+                    this, &BtleHub::onCharacteristicChanged);
             setupService(m_ftmsService);
+        }
     }
     else if (serviceUuid == BtleUuid::MoxyService) {
         m_moxyService = m_controller->createServiceObject(serviceUuid, this);
@@ -507,6 +514,25 @@ void BtleHub::handleFtmsControlPointResponse(const QByteArray &value)
     }
 }
 
+void BtleHub::parseFtmsFeature(const QByteArray &value)
+{
+    // 0x2ACC: [Fitness Machine Features (uint32 LE)][Target Setting Features (uint32 LE)]
+    if (value.size() < 8)
+        return;
+    const quint32 targetFeatures =
+          static_cast<quint32>(quint8(value[4]))
+        | (static_cast<quint32>(quint8(value[5])) << 8)
+        | (static_cast<quint32>(quint8(value[6])) << 16)
+        | (static_cast<quint32>(quint8(value[7])) << 24);
+    // Bit 2 = Resistance Target Setting Supported (i.e. Set Target Resistance
+    // Level, opcode 0x04 — the channel that gives instant, gear-like feel).
+    m_resistanceLevelSupported = (targetFeatures & (1u << 2)) != 0;
+    LOG_INFO("BtleHub", QStringLiteral("FTMS resistance-level (0x04) control %1")
+                            .arg(m_resistanceLevelSupported ? QStringLiteral("supported")
+                                                            : QStringLiteral("not supported")));
+    emit signal_resistanceLevelSupported(m_resistanceLevelSupported);
+}
+
 void BtleHub::onServiceStateChanged(QLowEnergyService::ServiceState state)
 {
     QLowEnergyService *service = qobject_cast<QLowEnergyService*>(sender());
@@ -542,6 +568,11 @@ void BtleHub::onServiceStateChanged(QLowEnergyService::ServiceState state)
         // point, which left ERG mode stuck at the trainer's default load.
         enableIndication(service,
             service->characteristic(BtleUuid::FtmsControlPoint));
+        // One-shot read of the feature char to learn if Set Target Resistance
+        // Level (0x04) is supported (drives virtual-shifting mode selection).
+        QLowEnergyCharacteristic feat = service->characteristic(BtleUuid::FtmsFeature);
+        if (feat.isValid())
+            service->readCharacteristic(feat);
     }
     else if (service == m_moxyService) {
         enableNotification(service,
@@ -577,6 +608,8 @@ void BtleHub::onCharacteristicChanged(const QLowEnergyCharacteristic &characteri
         parseFtmsIndoorBikeData(value);
     else if (uuid == BtleUuid::FtmsControlPoint)
         handleFtmsControlPointResponse(value);
+    else if (uuid == BtleUuid::FtmsFeature)
+        parseFtmsFeature(value);
     else if (uuid == BtleUuid::MoxyMeasurement)
         parseMoxyMeasurement(value);
     else if (uuid == BtleUuid::BatteryLevel)

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -201,6 +201,24 @@ void BtleHub::setSlope(int antID, double grade)
     sendFtmsCommand(cmd);
 }
 
+void BtleHub::setResistanceLevel(int antID, int levelTenths)
+{
+    if (m_filterControlByUserID && antID != m_userID)
+        return;
+
+    if (!m_ftmsService)
+        return;
+
+    // FTMS: Set Target Resistance Level (opcode 0x04), value = int16 in 0.1 units
+    // (same representation as the Supported Resistance Level Range, 0x2AD6).
+    qint16 lvl = static_cast<qint16>(qBound(-32768, levelTenths, 32767));
+    QByteArray cmd(3, '\0');
+    cmd[0] = 0x04;                          // Set Target Resistance Level opcode
+    cmd[1] = static_cast<char>(lvl & 0xFF);
+    cmd[2] = static_cast<char>((lvl >> 8) & 0xFF);
+    sendFtmsCommand(cmd);
+}
+
 // One control-point op in flight at a time: real trainers reject overlapping
 // writes with ATT error 0x80, and every op completes only when its response
 // indication ([0x80, opcode, result]) arrives.  Commands issued while waiting

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -80,12 +80,18 @@ signals:
     void deviceDisconnected();
     void connectionError(const QString &errorString);
     void serviceDiscoveryFinished();
+    /// Emitted once the FTMS Feature char is read: whether the trainer supports
+    /// Set Target Resistance Level (0x04). Drives ERG-vs-resistance gear mode.
+    void signal_resistanceLevelSupported(bool supported);
 
 public slots:
     // Slots with same signatures as Hub::setLoad / Hub::setSlope so they can
     // be wired up identically from WorkoutDialog signals.
     void setLoad(int antID, double watts);
     void setSlope(int antID, double grade);
+    /// Whether the connected trainer advertised Set Target Resistance Level
+    /// (0x04) support in its FTMS feature char. Valid after discovery.
+    bool resistanceLevelSupported() const { return m_resistanceLevelSupported; }
     // FTMS Set Target Resistance Level (opcode 0x04). levelTenths is the raw
     // resistance level in 0.1 units (the 2AD6 "Supported Resistance Level Range"
     // representation). Unlike ERG, this sets a fixed brake — resistance changes
@@ -134,6 +140,7 @@ private:
     void parseCscMeasurement(const QByteArray &data);
     void parsePowerMeasurement(const QByteArray &data);
     void parseFtmsIndoorBikeData(const QByteArray &data);
+    void parseFtmsFeature(const QByteArray &data);
     void parseMoxyMeasurement(const QByteArray &data);
     void parseBatteryLevel(const QByteArray &data);
     QString determineSensorType() const; ///< Infer sensor type from connected services
@@ -149,6 +156,7 @@ private:
 
     bool m_ftmsControlRequested = false;
     bool m_ftmsControlGranted   = false;
+    bool m_resistanceLevelSupported = false;   // FTMS 0x04 (from 0x2ACC feature)
 
     // Control-point serialization: one op in flight until the trainer's
     // response indication arrives; the newest deferred command waits in

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -86,6 +86,11 @@ public slots:
     // be wired up identically from WorkoutDialog signals.
     void setLoad(int antID, double watts);
     void setSlope(int antID, double grade);
+    // FTMS Set Target Resistance Level (opcode 0x04). levelTenths is the raw
+    // resistance level in 0.1 units (the 2AD6 "Supported Resistance Level Range"
+    // representation). Unlike ERG, this sets a fixed brake — resistance changes
+    // instantly and power follows effort, so virtual gears feel like real gears.
+    void setResistanceLevel(int antID, int levelTenths);
     void stopDecodingMsg();
 
     // Test hook: inject raw BLE notification bytes as if received from hardware.

--- a/src/btle/btle_hub_wasm.cpp
+++ b/src/btle/btle_hub_wasm.cpp
@@ -87,6 +87,11 @@ void BtleHubWasm::setSlope(int /*antID*/, double grade)
     WebBluetoothBridge::sendFtmsSetIndoorBikeSimulation(static_cast<int>(grade * 100.0));
 }
 
+void BtleHubWasm::setResistanceLevel(int /*antID*/, int levelTenths)
+{
+    WebBluetoothBridge::sendFtmsSetResistanceLevel(levelTenths);
+}
+
 void BtleHubWasm::stopDecodingMsg()
 {
     disconnectFromDevice();

--- a/src/btle/btle_hub_wasm.h
+++ b/src/btle/btle_hub_wasm.h
@@ -54,10 +54,20 @@ signals:
     void deviceDisconnected();
     void connectionError(const QString &errorString);
     void serviceDiscoveryFinished();
+    /// Mirrors BtleHub: whether the trainer supports Set Target Resistance Level
+    /// (0x04). The Wasm hub doesn't read the feature char, so we assume support —
+    /// virtual shifting is opt-in and targets FTMS 0x04-capable single-cog trainers.
+    void signal_resistanceLevelSupported(bool supported);
+
+public:
+    bool resistanceLevelSupported() const { return true; }
 
 public slots:
     void setLoad(int antID, double watts);
     void setSlope(int antID, double grade);
+    /// FTMS Set Target Resistance Level (0x04), 0.1 units. Same signature as
+    /// BtleHub so WorkoutDialog wiring compiles on Wasm.
+    void setResistanceLevel(int antID, int levelTenths);
     void stopDecodingMsg();
 
     // Test hook – same as BtleHub::simulateNotification

--- a/src/btle/btle_uuids.h
+++ b/src/btle/btle_uuids.h
@@ -11,6 +11,7 @@ static constexpr quint16 BTLE_UUID_HR_MEASUREMENT    = 0x2A37;
 static constexpr quint16 BTLE_UUID_CSC_MEASUREMENT   = 0x2A5B;
 static constexpr quint16 BTLE_UUID_POWER_MEASUREMENT = 0x2A63;
 static constexpr quint16 BTLE_UUID_FTMS_BIKE_DATA    = 0x2AD2;
+static constexpr quint16 BTLE_UUID_FTMS_FEATURE      = 0x2ACC;
 static constexpr quint16 BTLE_UUID_BATTERY_LEVEL     = 0x2A19;
 
 // Moxy Muscle Oxygen Monitor (proprietary, not BT SIG)

--- a/src/btle/webbluetooth_bridge.cpp
+++ b/src/btle/webbluetooth_bridge.cpp
@@ -351,6 +351,15 @@ void sendFtmsSetTargetPower(int watts)
     js_sendFtmsCommand(cmd, sizeof(cmd));
 }
 
+void sendFtmsSetResistanceLevel(int levelTenths)
+{
+    // FTMS Set Target Resistance Level (opcode 0x04), int16 in 0.1 units.
+    uint8_t cmd[3] = { 0x04 };
+    int16_t level = static_cast<int16_t>(levelTenths);
+    std::memcpy(&cmd[1], &level, 2);
+    js_sendFtmsCommand(cmd, sizeof(cmd));
+}
+
 void requestFtmsControl()
 {
     js_requestFtmsControl();

--- a/src/btle/webbluetooth_bridge.h
+++ b/src/btle/webbluetooth_bridge.h
@@ -89,6 +89,10 @@ void sendFtmsSetIndoorBikeSimulation(int grade100);
 // watts is the target power in whole watts.
 void sendFtmsSetTargetPower(int watts);
 
+// Send FTMS Set Target Resistance Level (opcode 0x04) on 0x2AD9.
+// levelTenths is the resistance level in 0.1 units (virtual-shifting gears).
+void sendFtmsSetResistanceLevel(int levelTenths);
+
 // Send FTMS opcode 0x00 (Request Control) to characteristic 0x2AD9.
 // Must be called once after GATT connection is established, before any
 // Set Target Power (0x05) or Indoor Bike Simulation (0x11) commands.

--- a/src/btle/zwift/trainer_gear_test.cpp
+++ b/src/btle/zwift/trainer_gear_test.cpp
@@ -64,12 +64,12 @@ void TrainerGearTest::onGearTick()
 
     int gear;
     QString label;
-    if      (t < 25) { gear = 5;  label = QStringLiteral("WARMUP — get on & pedal steady (easy)"); }
-    else if (t < 37) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → should feel light"); }
-    else if (t < 49) { gear = 13; label = QStringLiteral("HARD  (gear 13) → should feel heavy"); }
-    else if (t < 61) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → light again"); }
-    else if (t < 73) { gear = 13; label = QStringLiteral("HARD  (gear 13) → heavy again"); }
-    else if (t < 85) { gear = 8;  label = QStringLiteral("MID   (gear 8)"); }
+    if      (t < 25) { gear = 8;  label = QStringLiteral("WARMUP — get on & pedal steady (easy)"); }
+    else if (t < 37) { gear = 5;  label = QStringLiteral("EASY  (gear 5/24)  → should feel light"); }
+    else if (t < 49) { gear = 20; label = QStringLiteral("HARD  (gear 20/24) → should feel heavy"); }
+    else if (t < 61) { gear = 5;  label = QStringLiteral("EASY  (gear 5/24)  → light again"); }
+    else if (t < 73) { gear = 20; label = QStringLiteral("HARD  (gear 20/24) → heavy again"); }
+    else if (t < 85) { gear = 12; label = QStringLiteral("MID   (gear 12/24)"); }
     else {
         line(QStringLiteral("  releasing resistance — done"));
         if (m_hub) m_hub->setLoad(1, 0);

--- a/src/btle/zwift/trainer_gear_test.cpp
+++ b/src/btle/zwift/trainer_gear_test.cpp
@@ -1,7 +1,7 @@
 #include "trainer_gear_test.h"
 #include "btle_hub.h"
+#include "virtual_gear.h"
 
-#include <QtMath>
 #include <cstdio>
 
 namespace {
@@ -57,17 +57,11 @@ void TrainerGearTest::start(const QString &nameFilter, int scanSeconds)
     m_agent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
 }
 
-// Cadence-aware gear → watts (mirrors WorkoutDialog::gearTargetWatts so the feel
-// matches the in-app feature). Fixed FTP-agnostic base for a standalone test.
+// Cadence-aware gear → watts via the shared model (same feel as the in-app
+// feature). FTP unknown in this standalone test → a sensible default is used.
 int TrainerGearTest::gearWatts(int gear, double cadence) const
 {
-    const int N = 15;
-    const int g = qBound(1, gear, N);
-    const double coeff = 0.5 + (g - 1) / double(N - 1) * 1.5;   // 0.5 → 2.0
-    double cad = (cadence > 0) ? cadence : 85.0;
-    cad = qBound(40.0, cad, 120.0);
-    const double cadFactor = (cad / 85.0) * (cad / 85.0);
-    return qBound(20, int(qRound(110.0 * coeff * cadFactor)), 450);
+    return VirtualGear::targetWatts(gear, cadence, /*ftp=*/220.0);
 }
 
 void TrainerGearTest::onGearTick()

--- a/src/btle/zwift/trainer_gear_test.cpp
+++ b/src/btle/zwift/trainer_gear_test.cpp
@@ -1,0 +1,101 @@
+#include "trainer_gear_test.h"
+#include "btle_hub.h"
+
+#include <QtMath>
+#include <cstdio>
+
+namespace {
+void line(const QString &s)
+{
+    const QByteArray u = s.toUtf8();
+    fprintf(stdout, "%s\n", u.constData());
+    fflush(stdout);
+}
+} // namespace
+
+TrainerGearTest::TrainerGearTest(QObject *parent) : QObject(parent) {}
+
+void TrainerGearTest::start(const QString &nameFilter, int scanSeconds)
+{
+    line(QStringLiteral("── Trainer gear test (via BtleHub = real FTMS actuation) ──"));
+    line(QStringLiteral("  looking for: %1   (auto-shifts; just pedal — no input needed)")
+             .arg(nameFilter));
+
+    m_hub = new BtleHub(this);
+    connect(m_hub, &BtleHub::signal_cadence, this,
+            [this](int, int c) { m_cadence = c; });
+    connect(m_hub, &BtleHub::connectionError, this,
+            [](const QString &e) { line(QStringLiteral("  [error] %1").arg(e)); });
+    connect(m_hub, &BtleHub::serviceDiscoveryFinished, this, [this]() {
+        if (m_started)
+            return;
+        m_started = true;
+        line(QStringLiteral("  trainer connected — FTMS control will engage; auto gears starting"));
+        m_tick = new QTimer(this);
+        connect(m_tick, &QTimer::timeout, this, &TrainerGearTest::onGearTick);
+        m_tick->start(1000);
+    });
+
+    m_agent = new QBluetoothDeviceDiscoveryAgent(this);
+    m_agent->setLowEnergyDiscoveryTimeout(scanSeconds * 1000);
+    connect(m_agent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered, this,
+            [this, nameFilter](const QBluetoothDeviceInfo &info) {
+                if (m_connecting || !info.name().contains(nameFilter, Qt::CaseInsensitive))
+                    return;
+                m_connecting = true;
+                line(QStringLiteral("  found %1 [%2] — connecting")
+                         .arg(info.name(), info.address().toString()));
+                m_agent->stop();
+                m_hub->connectToDevice(info);
+            });
+    connect(m_agent, &QBluetoothDeviceDiscoveryAgent::finished, this, [this]() {
+        if (!m_connecting) {
+            line(QStringLiteral("  trainer not found — awake & in range?"));
+            emit finished();
+        }
+    });
+    m_agent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
+// Cadence-aware gear → watts (mirrors WorkoutDialog::gearTargetWatts so the feel
+// matches the in-app feature). Fixed FTP-agnostic base for a standalone test.
+int TrainerGearTest::gearWatts(int gear, double cadence) const
+{
+    const int N = 15;
+    const int g = qBound(1, gear, N);
+    const double coeff = 0.5 + (g - 1) / double(N - 1) * 1.5;   // 0.5 → 2.0
+    double cad = (cadence > 0) ? cadence : 85.0;
+    cad = qBound(40.0, cad, 120.0);
+    const double cadFactor = (cad / 85.0) * (cad / 85.0);
+    return qBound(20, int(qRound(110.0 * coeff * cadFactor)), 450);
+}
+
+void TrainerGearTest::onGearTick()
+{
+    ++m_elapsed;
+    const int t = m_elapsed;
+
+    int gear;
+    QString label;
+    if      (t < 25) { gear = 7;  label = QStringLiteral("WARMUP — get on & pedal steady"); }
+    else if (t < 37) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → should feel light"); }
+    else if (t < 49) { gear = 13; label = QStringLiteral("HARD  (gear 13) → should feel heavy"); }
+    else if (t < 61) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → light again"); }
+    else if (t < 73) { gear = 13; label = QStringLiteral("HARD  (gear 13) → heavy again"); }
+    else if (t < 85) { gear = 8;  label = QStringLiteral("MID   (gear 8)"); }
+    else {
+        line(QStringLiteral("  releasing resistance — done"));
+        if (m_hub) m_hub->setLoad(1, 0);
+        if (m_tick) m_tick->stop();
+        QTimer::singleShot(800, this, [this]() { emit finished(); });
+        return;
+    }
+
+    if (gear != m_lastGear) {
+        m_lastGear = gear;
+        line(QStringLiteral("  ▶ %1   (cad=%2, target=%3W)")
+                 .arg(label).arg(int(m_cadence)).arg(gearWatts(gear, m_cadence)));
+    }
+    if (m_hub)
+        m_hub->setLoad(1, gearWatts(gear, m_cadence));
+}

--- a/src/btle/zwift/trainer_gear_test.cpp
+++ b/src/btle/zwift/trainer_gear_test.cpp
@@ -71,7 +71,7 @@ void TrainerGearTest::onGearTick()
 
     int gear;
     QString label;
-    if      (t < 25) { gear = 7;  label = QStringLiteral("WARMUP — get on & pedal steady"); }
+    if      (t < 25) { gear = 5;  label = QStringLiteral("WARMUP — get on & pedal steady (easy)"); }
     else if (t < 37) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → should feel light"); }
     else if (t < 49) { gear = 13; label = QStringLiteral("HARD  (gear 13) → should feel heavy"); }
     else if (t < 61) { gear = 3;  label = QStringLiteral("EASY  (gear 3)  → light again"); }

--- a/src/btle/zwift/trainer_gear_test.cpp
+++ b/src/btle/zwift/trainer_gear_test.cpp
@@ -57,13 +57,6 @@ void TrainerGearTest::start(const QString &nameFilter, int scanSeconds)
     m_agent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
 }
 
-// Cadence-aware gear → watts via the shared model (same feel as the in-app
-// feature). FTP unknown in this standalone test → a sensible default is used.
-int TrainerGearTest::gearWatts(int gear, double cadence) const
-{
-    return VirtualGear::targetWatts(gear, cadence, /*ftp=*/220.0);
-}
-
 void TrainerGearTest::onGearTick()
 {
     ++m_elapsed;
@@ -85,11 +78,14 @@ void TrainerGearTest::onGearTick()
         return;
     }
 
+    // Resistance-level mode (FTMS 0x04): instant, real-gear feel. Sent only on
+    // change — a fixed brake doesn't need re-sending every second like ERG did.
     if (gear != m_lastGear) {
         m_lastGear = gear;
-        line(QStringLiteral("  ▶ %1   (cad=%2, target=%3W)")
-                 .arg(label).arg(int(m_cadence)).arg(gearWatts(gear, m_cadence)));
+        const int level = VirtualGear::resistanceLevel(gear);
+        line(QStringLiteral("  ▶ %1   (resistance level %2 = %3)")
+                 .arg(label).arg(level).arg(level / 10.0, 0, 'f', 1));
+        if (m_hub)
+            m_hub->setResistanceLevel(1, level);
     }
-    if (m_hub)
-        m_hub->setLoad(1, gearWatts(gear, m_cadence));
 }

--- a/src/btle/zwift/trainer_gear_test.h
+++ b/src/btle/zwift/trainer_gear_test.h
@@ -29,7 +29,6 @@ signals:
 
 private:
     void onGearTick();
-    int  gearWatts(int gear, double cadence) const;
 
     QBluetoothDeviceDiscoveryAgent *m_agent = nullptr;
     BtleHub *m_hub      = nullptr;

--- a/src/btle/zwift/trainer_gear_test.h
+++ b/src/btle/zwift/trainer_gear_test.h
@@ -1,0 +1,44 @@
+#ifndef TRAINER_GEAR_TEST_H
+#define TRAINER_GEAR_TEST_H
+
+#include <QObject>
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QBluetoothDeviceInfo>
+#include <QTimer>
+
+class BtleHub;
+
+/*
+ * Headless virtual-shifting feel test, driven through BtleHub — the app's
+ * PROVEN FTMS control path (solid LED, real resistance), NOT the standalone
+ * Zwift harness (which never actuated). It auto-cycles a virtual gear so a
+ * rider can FEEL the gears change while pedaling, with no source code or
+ * keyboard needed on the trainer-side machine (issue #293).
+ *
+ * Launched via `--trainer-gear-test [name]`.
+ */
+class TrainerGearTest : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TrainerGearTest(QObject *parent = nullptr);
+    void start(const QString &nameFilter, int scanSeconds = 8);
+
+signals:
+    void finished();
+
+private:
+    void onGearTick();
+    int  gearWatts(int gear, double cadence) const;
+
+    QBluetoothDeviceDiscoveryAgent *m_agent = nullptr;
+    BtleHub *m_hub      = nullptr;
+    QTimer  *m_tick     = nullptr;
+    double   m_cadence  = -1.0;
+    int      m_elapsed  = 0;
+    int      m_lastGear = -1;
+    bool     m_connecting = false;
+    bool     m_started  = false;
+};
+
+#endif // TRAINER_GEAR_TEST_H

--- a/src/btle/zwift/virtual_gear.h
+++ b/src/btle/zwift/virtual_gear.h
@@ -1,0 +1,49 @@
+#ifndef VIRTUAL_GEAR_H
+#define VIRTUAL_GEAR_H
+
+#include <QtGlobal>
+#include <QtMath>
+
+/*
+ * Virtual shifting gear model (#293). Single source of truth shared by the
+ * in-app feature (WorkoutDialog) and the headless feel test (TrainerGearTest).
+ *
+ * The trainer is driven in ERG (FTMS Set Target Power), but the *target* is
+ * recomputed from gear + live cadence so it feels like a real gear rather than
+ * a flat power clamp: a harder gear and/or faster pedaling demand more watts.
+ *
+ * Header-only + pure so it is trivially unit-testable (tests/zwift).
+ */
+namespace VirtualGear {
+
+constexpr int    Count        = 15;     // number of virtual gears
+constexpr double RefCadence   = 85.0;   // cadence at which the base watts apply
+constexpr double EasiestCoeff = 0.5;    // gear 1 multiplier
+constexpr double HardestCoeff = 2.0;    // gear Count multiplier
+constexpr double BaseFtpFrac  = 0.48;   // mid gear @ RefCadence ≈ 0.6×FTP
+constexpr double DefaultFtp   = 200.0;  // used when the rider FTP is unknown
+
+// Resistance coefficient for a gear, linear from EasiestCoeff..HardestCoeff.
+inline double coeffForGear(int gear)
+{
+    const int g = qBound(1, gear, Count);
+    return EasiestCoeff
+         + (g - 1) / double(Count - 1) * (HardestCoeff - EasiestCoeff);
+}
+
+// Target watts for a gear at a given cadence and rider FTP. cadence<=0 (no
+// reading yet) falls back to RefCadence. ftp<=0 falls back to DefaultFtp.
+inline int targetWatts(int gear, double cadence, double ftp)
+{
+    const double effFtp = (ftp > 0.0) ? ftp : DefaultFtp;
+    double cad = (cadence > 0.0) ? cadence : RefCadence;
+    cad = qBound(40.0, cad, 120.0);
+    // Aero-like: power ∝ cadence² so spinning faster in a gear costs more.
+    const double cadFactor = (cad / RefCadence) * (cad / RefCadence);
+    const double watts = BaseFtpFrac * effFtp * coeffForGear(gear) * cadFactor;
+    return qBound(20, int(qRound(watts)), int(qRound(1.6 * effFtp)));
+}
+
+} // namespace VirtualGear
+
+#endif // VIRTUAL_GEAR_H

--- a/src/btle/zwift/virtual_gear.h
+++ b/src/btle/zwift/virtual_gear.h
@@ -44,6 +44,23 @@ inline int targetWatts(int gear, double cadence, double ftp)
     return qBound(20, int(qRound(watts)), int(qRound(1.6 * effFtp)));
 }
 
+// ── Resistance-level shifting (FTMS 0x04) ────────────────────────────────────
+// The authentic, Zwift-like feel: each gear is a fixed brake resistance that
+// changes instantly (no ERG convergence) and lets power follow effort. The
+// value is in the trainer's 0.1-unit resistance representation (2AD6 range).
+// Mapped linearly across a usable middle band of a 0..100 range so the extremes
+// aren't unrideable; clamped to the trainer's actual [min,max].
+constexpr int EasiestResistance = 15;   // gear 1   (1.5)
+constexpr int HardestResistance = 85;   // gear Count (8.5)
+
+inline int resistanceLevel(int gear, int minLevel = 0, int maxLevel = 100)
+{
+    const int g = qBound(1, gear, Count);
+    const double t = (g - 1) / double(Count - 1);
+    const int raw = int(qRound(EasiestResistance + t * (HardestResistance - EasiestResistance)));
+    return qBound(minLevel, raw, maxLevel);
+}
+
 } // namespace VirtualGear
 
 #endif // VIRTUAL_GEAR_H

--- a/src/btle/zwift/virtual_gear.h
+++ b/src/btle/zwift/virtual_gear.h
@@ -16,7 +16,7 @@
  */
 namespace VirtualGear {
 
-constexpr int    Count        = 15;     // number of virtual gears
+constexpr int    Count        = 24;     // virtual gears (matches Zwift)
 constexpr double RefCadence   = 85.0;   // cadence at which the base watts apply
 constexpr double EasiestCoeff = 0.5;    // gear 1 multiplier
 constexpr double HardestCoeff = 2.0;    // gear Count multiplier

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -19,6 +19,13 @@ QBluetoothUuid zwiftControlPointUuid()
     return QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::ControlPoint));
 }
 
+// JetBlack's diagnostic log characteristic — streams ASCII text (incl. the
+// "ResCtrl: Resistance control timer …" lines that reveal resistance changes).
+QBluetoothUuid jetBlackDebugLogUuid()
+{
+    return QBluetoothUuid(QStringLiteral("c4632b08-003f-4cec-8994-e489b04d857f"));
+}
+
 // Console logging — write straight to stdout so output survives the app's
 // installed Qt message handler (which filters qInfo unless --debug).
 void line(const QString &s)
@@ -31,12 +38,16 @@ void line(const QString &s)
 
 ZwiftProbe::ZwiftProbe(QObject *parent) : QObject(parent) {}
 
-void ZwiftProbe::start(const QString &nameFilter, int scanSeconds, int listenSeconds)
+void ZwiftProbe::start(const QString &nameFilter, int scanSeconds,
+                       int listenSeconds, bool controlTest)
 {
     m_nameFilter    = nameFilter.trimmed();
     m_listenSeconds = listenSeconds;
+    m_controlTest   = controlTest;
 
-    line(QStringLiteral("── Zwift probe (read-only) ──────────────────────────"));
+    line(controlTest
+             ? QStringLiteral("── Zwift CONTROL TEST (writes change resistance!) ───")
+             : QStringLiteral("── Zwift probe (read-only) ──────────────────────────"));
     line(QStringLiteral("  name filter : %1")
              .arg(m_nameFilter.isEmpty() ? QStringLiteral("(auto)") : m_nameFilter));
     line(QStringLiteral("  scan        : %1 s   listen/device : %2 s")
@@ -215,7 +226,11 @@ void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
             [this](const QLowEnergyCharacteristic &c, const QByteArray &value) {
                 const QString hex = QString::fromLatin1(value.toHex());
                 ZwiftProtocol::RidingData rd;
-                if (ZwiftProtocol::decodeRidingData(value, rd)) {
+                if (c.uuid() == jetBlackDebugLogUuid()) {
+                    // ASCII diagnostic log — show the text (ResCtrl lines etc.).
+                    line(QStringLiteral("    ◀ dbg  %1")
+                             .arg(QString::fromLatin1(value).trimmed()));
+                } else if (ZwiftProtocol::decodeRidingData(value, rd)) {
                     line(QStringLiteral("    ◀ %1  RIDING pwr=%2 cad=%3 spd=%4 hr=%5")
                              .arg(c.uuid().toString(QUuid::WithoutBraces))
                              .arg(rd.power).arg(rd.cadence).arg(rd.speedX100).arg(rd.hr));
@@ -248,7 +263,77 @@ void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
                                   : QLowEnergyService::WriteWithResponse;
             service->writeCharacteristic(cp, ZwiftProtocol::rideOnHandshake(), mode);
             line(QStringLiteral("    ▶ wrote RideOn handshake to control point"));
+
+            if (m_controlTest && !m_controlStarted)
+                beginControlScript(service);
         }
+    }
+}
+
+// Phase 2: after the handshake, send a scripted sequence of 0x04 control
+// commands and watch the trainer react (ResCtrl debug log + FTMS data). Steps
+// are spaced so each reaction is visible; the final step releases resistance.
+void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
+{
+    using namespace ZwiftProtocol;
+    m_controlStarted = true;
+    m_ctrlService    = zwiftService;
+    m_ctrlIndex      = 0;
+
+    auto erg = [](quint32 watts) {
+        HubCommand c; c.powerTargetW = watts; return encodeControlCommand(c);
+    };
+    auto simGear = [](qint32 inclineX100, int gear) {
+        HubCommand c;
+        c.sim.inclineX100          = inclineX100;
+        c.physical.gearRatioX10000 = ZwiftGears::ratioX10000ForGear(gear);
+        c.physical.riderWeightX100 = 7500;   // 75.0 kg
+        c.physical.bikeWeightX100  = 800;    //  8.0 kg
+        return encodeControlCommand(c);
+    };
+
+    m_ctrlSteps = {
+        { QStringLiteral("ERG 100 W"),                 erg(100) },
+        { QStringLiteral("ERG 250 W"),                 erg(250) },
+        { QStringLiteral("ERG 150 W"),                 erg(150) },
+        { QStringLiteral("SIM +6% gear 12 (mid)"),    simGear(600, 12) },
+        { QStringLiteral("SIM +6% gear 2 (low/easy)"),simGear(600, 2)  },
+        { QStringLiteral("SIM +6% gear 22 (high)"),   simGear(600, 22) },
+        { QStringLiteral("RESET — ERG 0 W (release)"), erg(0)  },
+    };
+
+    line(QString());
+    line(QStringLiteral("  ▶▶ control script: %1 steps — watch the dbg ResCtrl lines")
+             .arg(m_ctrlSteps.size()));
+
+    if (!m_ctrlTimer) {
+        m_ctrlTimer = new QTimer(this);
+        connect(m_ctrlTimer, &QTimer::timeout, this, &ZwiftProbe::onControlStep);
+    }
+    onControlStep();                 // first step immediately
+    m_ctrlTimer->start(4500);        // then one every 4.5 s
+}
+
+void ZwiftProbe::onControlStep()
+{
+    if (!m_ctrlService || m_ctrlIndex >= m_ctrlSteps.size()) {
+        if (m_ctrlTimer) m_ctrlTimer->stop();
+        line(QStringLiteral("  ▶▶ control script complete (resistance released)"));
+        finishCurrentDevice();
+        return;
+    }
+
+    const auto &step = m_ctrlSteps.at(m_ctrlIndex++);
+    const QLowEnergyCharacteristic cp =
+        m_ctrlService->characteristic(zwiftControlPointUuid());
+    if (cp.isValid()) {
+        const auto mode = (cp.properties() & QLowEnergyCharacteristic::WriteNoResponse)
+                              ? QLowEnergyService::WriteWithoutResponse
+                              : QLowEnergyService::WriteWithResponse;
+        m_ctrlService->writeCharacteristic(cp, step.second, mode);
+        line(QStringLiteral("  ▶ step %1/%2: %3   (%4)")
+                 .arg(m_ctrlIndex).arg(m_ctrlSteps.size())
+                 .arg(step.first, QString::fromLatin1(step.second.toHex())));
     }
 }
 

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -328,6 +328,20 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
             { QStringLiteral("Gear 11 @ +5% → grade sanity: HARDER"),  simGear(500, 11) },
             { QStringLiteral("RESET — release resistance"),            erg(0)           },
         };
+    } else if (m_script == Script::ErgHold) {
+        // Decisive test: does ERG actuate resistance while pedaling? Hold each
+        // target long enough for the loop to settle; the rider's power should
+        // track the target at whatever cadence they pedal. The warmup itself
+        // holds 100 W, so a working ERG shows up immediately.
+        m_ctrlIntervalMs = 15000;
+        m_ctrlPrerollMs  = 30000;
+        m_ctrlSteps = {
+            { QStringLiteral("CONNECTED — get on & pedal; holding ERG 100W (30s warmup)"), erg(100) },
+            { QStringLiteral("ERG 160W → your power should rise to ~160"), erg(160) },
+            { QStringLiteral("ERG 230W → your power should rise to ~230"), erg(230) },
+            { QStringLiteral("ERG 120W → your power should drop to ~120"), erg(120) },
+            { QStringLiteral("RESET — ERG 0 W (release)"),                 erg(0)   },
+        };
     } else { // Script::ErgDemo
         m_ctrlIntervalMs = 4500;
         m_ctrlSteps = {

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -39,13 +39,13 @@ void line(const QString &s)
 ZwiftProbe::ZwiftProbe(QObject *parent) : QObject(parent) {}
 
 void ZwiftProbe::start(const QString &nameFilter, int scanSeconds,
-                       int listenSeconds, bool controlTest)
+                       int listenSeconds, Script script)
 {
     m_nameFilter    = nameFilter.trimmed();
     m_listenSeconds = listenSeconds;
-    m_controlTest   = controlTest;
+    m_script        = script;
 
-    line(controlTest
+    line(script != Script::None
              ? QStringLiteral("── Zwift CONTROL TEST (writes change resistance!) ───")
              : QStringLiteral("── Zwift probe (read-only) ──────────────────────────"));
     line(QStringLiteral("  name filter : %1")
@@ -264,7 +264,7 @@ void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
             service->writeCharacteristic(cp, ZwiftProtocol::rideOnHandshake(), mode);
             line(QStringLiteral("    ▶ wrote RideOn handshake to control point"));
 
-            if (m_controlTest && !m_controlStarted)
+            if (m_script != Script::None && !m_controlStarted)
                 beginControlScript(service);
         }
     }
@@ -292,26 +292,43 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
         return encodeControlCommand(c);
     };
 
-    m_ctrlSteps = {
-        { QStringLiteral("ERG 100 W"),                 erg(100) },
-        { QStringLiteral("ERG 250 W"),                 erg(250) },
-        { QStringLiteral("ERG 150 W"),                 erg(150) },
-        { QStringLiteral("SIM +6% gear 12 (mid)"),    simGear(600, 12) },
-        { QStringLiteral("SIM +6% gear 2 (low/easy)"),simGear(600, 2)  },
-        { QStringLiteral("SIM +6% gear 22 (high)"),   simGear(600, 22) },
-        { QStringLiteral("RESET — ERG 0 W (release)"), erg(0)  },
-    };
+    if (m_script == Script::GearSweep) {
+        // Rider pedals steadily; we step the gear so they FEEL each change with
+        // no input. Hold +3% so SIM resistance is non-trivial at speed.
+        m_ctrlIntervalMs = 8000;   // hold each long enough to feel
+        m_ctrlSteps = {
+            { QStringLiteral("PEDAL STEADY ~80rpm. Gear 12/24 @ +3% (baseline)"), simGear(300, 12) },
+            { QStringLiteral("Gear 1/24  → should feel EASIEST"), simGear(300, 1)  },
+            { QStringLiteral("Gear 24/24 → should feel HARDEST"), simGear(300, 24) },
+            { QStringLiteral("Gear 1/24  → EASIEST again"),       simGear(300, 1)  },
+            { QStringLiteral("Gear 24/24 → HARDEST again"),       simGear(300, 24) },
+            { QStringLiteral("Gear 12 @ 0% → sanity: flat/easy"),simGear(0,   12) },
+            { QStringLiteral("Gear 12 @ +6% → sanity: HARDER"),  simGear(600, 12) },
+            { QStringLiteral("RESET — release resistance"),       erg(0)           },
+        };
+    } else { // Script::ErgDemo
+        m_ctrlIntervalMs = 4500;
+        m_ctrlSteps = {
+            { QStringLiteral("ERG 100 W"),                 erg(100) },
+            { QStringLiteral("ERG 250 W"),                 erg(250) },
+            { QStringLiteral("ERG 150 W"),                 erg(150) },
+            { QStringLiteral("SIM +6% gear 12 (mid)"),    simGear(600, 12) },
+            { QStringLiteral("SIM +6% gear 2 (low/easy)"),simGear(600, 2)  },
+            { QStringLiteral("SIM +6% gear 22 (high)"),   simGear(600, 22) },
+            { QStringLiteral("RESET — ERG 0 W (release)"), erg(0)  },
+        };
+    }
 
     line(QString());
-    line(QStringLiteral("  ▶▶ control script: %1 steps — watch the dbg ResCtrl lines")
-             .arg(m_ctrlSteps.size()));
+    line(QStringLiteral("  ▶▶ control script: %1 steps, %2 s each — watch the dbg ResCtrl lines")
+             .arg(m_ctrlSteps.size()).arg(m_ctrlIntervalMs / 1000));
 
     if (!m_ctrlTimer) {
         m_ctrlTimer = new QTimer(this);
         connect(m_ctrlTimer, &QTimer::timeout, this, &ZwiftProbe::onControlStep);
     }
-    onControlStep();                 // first step immediately
-    m_ctrlTimer->start(4500);        // then one every 4.5 s
+    onControlStep();                       // first step immediately
+    m_ctrlTimer->start(m_ctrlIntervalMs);  // then one per interval
 }
 
 void ZwiftProbe::onControlStep()

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -136,6 +136,7 @@ void ZwiftProbe::connectNextCandidate()
 
     m_current          = m_candidates.dequeue();
     m_zwiftServiceSeen = false;
+    m_retriesLeft      = 3;   // weak links (distant trainer) drop mid-discovery
     line(QString());
     line(QStringLiteral("== Connecting to %1 [%2] ==")
              .arg(m_current.name(), m_current.address().toString()));
@@ -146,6 +147,18 @@ void ZwiftProbe::connectNextCandidate()
         m_controller->discoverServices();
     });
     connect(m_controller, &QLowEnergyController::disconnected, this, [this]() {
+        // A weak link can drop before per-service detail discovery completes,
+        // so we never see the Zwift service. Retry the same device a few times.
+        if (!m_zwiftServiceSeen && m_retriesLeft > 0 && m_controller) {
+            --m_retriesLeft;
+            if (m_listenTimer) m_listenTimer->stop();
+            qDeleteAll(m_services);
+            m_services.clear();
+            line(QStringLiteral("  link dropped before discovery — retrying (%1 left)")
+                     .arg(m_retriesLeft));
+            m_controller->connectToDevice();
+            return;
+        }
         line(QStringLiteral("  disconnected"));
     });
     connect(m_controller,

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -26,6 +26,21 @@ QBluetoothUuid jetBlackDebugLogUuid()
     return QBluetoothUuid(QStringLiteral("c4632b08-003f-4cec-8994-e489b04d857f"));
 }
 
+// Standard FTMS (the channel that actually actuates resistance on this trainer).
+QBluetoothUuid ftmsServiceUuid()      { return QBluetoothUuid(quint16(0x1826)); }
+QBluetoothUuid ftmsControlPointUuid() { return QBluetoothUuid(quint16(0x2AD9)); }
+
+// FTMS Set Target Power (opcode 0x05), value = int16 watts, little-endian.
+QByteArray ftmsSetTargetPower(int watts)
+{
+    const qint16 w = static_cast<qint16>(watts);
+    QByteArray cmd(3, '\0');
+    cmd[0] = 0x05;
+    cmd[1] = static_cast<char>(w & 0xFF);
+    cmd[2] = static_cast<char>((w >> 8) & 0xFF);
+    return cmd;
+}
+
 // Console logging — write straight to stdout so output survives the app's
 // installed Qt message handler (which filters qInfo unless --debug).
 void line(const QString &s)
@@ -239,9 +254,22 @@ void ZwiftProbe::dumpService(QLowEnergyService *service)
 void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
 {
     connect(service, &QLowEnergyService::characteristicChanged, this,
-            [this](const QLowEnergyCharacteristic &c, const QByteArray &value) {
+            [this, service](const QLowEnergyCharacteristic &c, const QByteArray &value) {
                 const QString hex = QString::fromLatin1(value.toHex());
                 ZwiftProtocol::RidingData rd;
+                // FTMS control-point response: [0x80, opcode, result(0x01=ok)].
+                if (c.uuid() == ftmsControlPointUuid() && value.size() >= 3
+                        && quint8(value[0]) == 0x80) {
+                    const quint8 op = quint8(value[1]);
+                    const quint8 res = quint8(value[2]);
+                    line(QStringLiteral("    ◀ FTMS resp op=0x%1 result=0x%2")
+                             .arg(op, 2, 16, QLatin1Char('0')).arg(res, 2, 16, QLatin1Char('0')));
+                    if (op == 0x00 && res == 0x01 && !m_controlStarted) {
+                        line(QStringLiteral("    ✓ FTMS control GRANTED — starting script"));
+                        beginControlScript(service, ftmsControlPointUuid());
+                    }
+                    return;
+                }
                 if (c.uuid() == jetBlackDebugLogUuid()) {
                     // ASCII diagnostic log — show the text (ResCtrl lines etc.).
                     line(QStringLiteral("    ◀ dbg  %1")
@@ -280,20 +308,54 @@ void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
             service->writeCharacteristic(cp, ZwiftProtocol::rideOnHandshake(), mode);
             line(QStringLiteral("    ▶ wrote RideOn handshake to control point"));
 
-            if (m_script != Script::None && !m_controlStarted)
-                beginControlScript(service);
+            // Zwift-protocol scripts drive the Zwift control point directly. The
+            // FTMS script keeps this handshake only for reading power/cadence and
+            // is started later, once FTMS control is granted.
+            const bool zwiftScript = (m_script == Script::ErgDemo
+                                   || m_script == Script::GearSweep
+                                   || m_script == Script::ErgHold);
+            if (zwiftScript && !m_controlStarted)
+                beginControlScript(service, zwiftControlPointUuid());
         }
     }
+
+    // FTMS mode: set up the standard request-control handshake on this trainer's
+    // FTMS service — that is the channel that actually actuates resistance.
+    if (m_script == Script::FtmsErg && service->serviceUuid() == ftmsServiceUuid())
+        setupFtmsControl(service);
+}
+
+// Enable indications on the FTMS control point and, once confirmed, send
+// Request Control (0x00). Mirrors BtleHub's working sequence.
+void ZwiftProbe::setupFtmsControl(QLowEnergyService *service)
+{
+    line(QStringLiteral("  FTMS service found — enabling control"));
+    connect(service, &QLowEnergyService::descriptorWritten, this,
+            [this, service](const QLowEnergyDescriptor &, const QByteArray &v) {
+                // The 0x0200 (indications) write is the FTMS control point's CCCD.
+                if (v != kIndicateOn || m_ftmsRequested)
+                    return;
+                const QLowEnergyCharacteristic cp =
+                    service->characteristic(ftmsControlPointUuid());
+                if (!cp.isValid())
+                    return;
+                m_ftmsRequested = true;
+                service->writeCharacteristic(cp, QByteArray::fromHex("00"),
+                                             QLowEnergyService::WriteWithResponse);
+                line(QStringLiteral("    ▶ FTMS Request Control (0x00) sent"));
+            });
 }
 
 // Phase 2: after the handshake, send a scripted sequence of 0x04 control
 // commands and watch the trainer react (ResCtrl debug log + FTMS data). Steps
 // are spaced so each reaction is visible; the final step releases resistance.
-void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
+void ZwiftProbe::beginControlScript(QLowEnergyService *service,
+                                    const QBluetoothUuid &controlPoint)
 {
     using namespace ZwiftProtocol;
     m_controlStarted = true;
-    m_ctrlService    = zwiftService;
+    m_ctrlService    = service;
+    m_ctrlPointUuid  = controlPoint;
     m_ctrlIndex      = 0;
 
     auto erg = [](quint32 watts) {
@@ -311,7 +373,20 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
         return encodeControlCommand(c);
     };
 
-    if (m_script == Script::GearSweep) {
+    if (m_script == Script::FtmsErg) {
+        // Decisive test on the PROVEN channel: drive standard FTMS Set Target
+        // Power (0x05). If the rider's power tracks these, FTMS is our actuation
+        // path for virtual shifting. Warmup holds 100 W so it shows immediately.
+        m_ctrlIntervalMs = 15000;
+        m_ctrlPrerollMs  = 30000;
+        m_ctrlSteps = {
+            { QStringLiteral("CONNECTED — get on & pedal; FTMS ERG 100W (30s warmup)"), ftmsSetTargetPower(100) },
+            { QStringLiteral("FTMS ERG 170W → power should rise to ~170"), ftmsSetTargetPower(170) },
+            { QStringLiteral("FTMS ERG 240W → power should rise to ~240"), ftmsSetTargetPower(240) },
+            { QStringLiteral("FTMS ERG 120W → power should drop to ~120"), ftmsSetTargetPower(120) },
+            { QStringLiteral("RESET — FTMS ERG 0 W (release)"),            ftmsSetTargetPower(0)   },
+        };
+    } else if (m_script == Script::GearSweep) {
         // Rider pedals steadily; we step the gear so they FEEL each change with
         // no input. Hold +3% so SIM resistance is non-trivial at speed. The
         // baseline holds for a warmup so the rider can mount + start pedaling
@@ -382,7 +457,7 @@ void ZwiftProbe::onControlStep()
     const int sent = m_ctrlIndex;
     const auto &step = m_ctrlSteps.at(m_ctrlIndex++);
     const QLowEnergyCharacteristic cp =
-        m_ctrlService->characteristic(zwiftControlPointUuid());
+        m_ctrlService->characteristic(m_ctrlPointUuid);
     if (cp.isValid()) {
         const auto mode = (cp.properties() & QLowEnergyCharacteristic::WriteNoResponse)
                               ? QLowEnergyService::WriteWithoutResponse

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -1,0 +1,279 @@
+#include "zwift_probe.h"
+#include "zwift_protocol.h"
+
+#include <QLowEnergyDescriptor>
+#include <QMetaEnum>
+
+#include <cstdio>
+
+namespace {
+const QByteArray kNotifyOn   = QByteArray::fromHex("0100");
+const QByteArray kIndicateOn = QByteArray::fromHex("0200");
+
+QBluetoothUuid zwiftServiceUuid()
+{
+    return QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::Service));
+}
+QBluetoothUuid zwiftControlPointUuid()
+{
+    return QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::ControlPoint));
+}
+
+// Console logging — write straight to stdout so output survives the app's
+// installed Qt message handler (which filters qInfo unless --debug).
+void line(const QString &s)
+{
+    const QByteArray utf8 = s.toUtf8();
+    fprintf(stdout, "%s\n", utf8.constData());
+    fflush(stdout);
+}
+} // namespace
+
+ZwiftProbe::ZwiftProbe(QObject *parent) : QObject(parent) {}
+
+void ZwiftProbe::start(const QString &nameFilter, int scanSeconds, int listenSeconds)
+{
+    m_nameFilter    = nameFilter.trimmed();
+    m_listenSeconds = listenSeconds;
+
+    line(QStringLiteral("── Zwift probe (read-only) ──────────────────────────"));
+    line(QStringLiteral("  name filter : %1")
+             .arg(m_nameFilter.isEmpty() ? QStringLiteral("(auto)") : m_nameFilter));
+    line(QStringLiteral("  scan        : %1 s   listen/device : %2 s")
+             .arg(scanSeconds).arg(listenSeconds));
+    line(QStringLiteral("  zwift svc   : %1").arg(QString::fromLatin1(ZwiftProtocol::Uuid::Service)));
+    line(QString());
+
+    m_agent = new QBluetoothDeviceDiscoveryAgent(this);
+    m_agent->setLowEnergyDiscoveryTimeout(scanSeconds * 1000);
+    connect(m_agent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered,
+            this, &ZwiftProbe::onDeviceDiscovered);
+    connect(m_agent, &QBluetoothDeviceDiscoveryAgent::finished,
+            this, &ZwiftProbe::onScanFinished);
+    connect(m_agent,
+            static_cast<void (QBluetoothDeviceDiscoveryAgent::*)(QBluetoothDeviceDiscoveryAgent::Error)>(
+                &QBluetoothDeviceDiscoveryAgent::errorOccurred),
+            this, [this](QBluetoothDeviceDiscoveryAgent::Error) {
+                line(QStringLiteral("  [scan error] %1").arg(m_agent->errorString()));
+                // No adapter / failed scan won't emit finished() — proceed anyway
+                // so the probe still quits instead of hanging.
+                onScanFinished();
+            });
+
+    m_listenTimer = new QTimer(this);
+    m_listenTimer->setSingleShot(true);
+    connect(m_listenTimer, &QTimer::timeout, this, &ZwiftProbe::finishCurrentDevice);
+
+    m_agent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
+bool ZwiftProbe::looksInteresting(const QBluetoothDeviceInfo &info, const QString &nameFilter)
+{
+    if (!nameFilter.isEmpty())
+        return info.name().contains(nameFilter, Qt::CaseInsensitive);
+
+    if (info.serviceUuids().contains(zwiftServiceUuid()))
+        return true;
+
+    // No filter and no advertised Zwift service: fall back to name hints so we
+    // still catch the Click and trainers that don't advertise the full service.
+    static const QStringList hints = {
+        QStringLiteral("zwift"), QStringLiteral("click"), QStringLiteral("play"),
+        QStringLiteral("victory"), QStringLiteral("jetblack"), QStringLiteral("jet black"),
+    };
+    const QString name = info.name();
+    for (const QString &h : hints)
+        if (name.contains(h, Qt::CaseInsensitive))
+            return true;
+    return false;
+}
+
+void ZwiftProbe::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
+{
+    QStringList svc;
+    for (const QBluetoothUuid &u : info.serviceUuids())
+        svc << u.toString(QUuid::WithoutBraces);
+
+    const bool interesting = looksInteresting(info, m_nameFilter);
+
+    // Cut the scan-log flood: skip uninteresting devices that expose no
+    // services (TVs, phones, beacons). Count them for the summary instead.
+    if (!interesting && info.serviceUuids().isEmpty()) {
+        ++m_suppressedCount;
+        return;
+    }
+
+    line(QStringLiteral("  %1 %2  [%3]  rssi=%4  svcs={%5}")
+             .arg(interesting ? QStringLiteral("►") : QStringLiteral(" "))
+             .arg(info.name().isEmpty() ? QStringLiteral("(unnamed)") : info.name(), -22)
+             .arg(info.address().toString())
+             .arg(info.rssi())
+             .arg(svc.join(QStringLiteral(", "))));
+
+    if (interesting && !m_candidates.contains(info))
+        m_candidates.enqueue(info);
+}
+
+void ZwiftProbe::onScanFinished()
+{
+    if (m_scanHandled)   // finished() and errorOccurred() can both fire
+        return;
+    m_scanHandled = true;
+    line(QString());
+    line(QStringLiteral("Scan finished — %1 candidate(s); %2 service-less device(s) hidden.")
+             .arg(m_candidates.size()).arg(m_suppressedCount));
+    connectNextCandidate();
+}
+
+void ZwiftProbe::connectNextCandidate()
+{
+    teardownController();
+    if (m_candidates.isEmpty()) {
+        line(QStringLiteral("── probe complete ──"));
+        emit finished();
+        return;
+    }
+
+    m_current          = m_candidates.dequeue();
+    m_zwiftServiceSeen = false;
+    line(QString());
+    line(QStringLiteral("== Connecting to %1 [%2] ==")
+             .arg(m_current.name(), m_current.address().toString()));
+
+    m_controller = QLowEnergyController::createCentral(m_current, this);
+    connect(m_controller, &QLowEnergyController::connected, this, [this]() {
+        line(QStringLiteral("  connected — discovering services"));
+        m_controller->discoverServices();
+    });
+    connect(m_controller, &QLowEnergyController::disconnected, this, [this]() {
+        line(QStringLiteral("  disconnected"));
+    });
+    connect(m_controller,
+            static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
+                &QLowEnergyController::errorOccurred),
+            this, [this](QLowEnergyController::Error) {
+                line(QStringLiteral("  [controller error] %1").arg(m_controller->errorString()));
+                finishCurrentDevice();
+            });
+    connect(m_controller, &QLowEnergyController::discoveryFinished, this, [this]() {
+        const auto uuids = m_controller->services();
+        line(QStringLiteral("  %1 service(s) discovered").arg(uuids.size()));
+        for (const QBluetoothUuid &u : uuids) {
+            QLowEnergyService *svc = m_controller->createServiceObject(u, this);
+            if (!svc)
+                continue;
+            m_services << svc;
+            connect(svc, &QLowEnergyService::stateChanged, this,
+                    [this, svc](QLowEnergyService::ServiceState st) {
+                        if (st == QLowEnergyService::RemoteServiceDiscovered)
+                            dumpService(svc);
+                    });
+            svc->discoverDetails();
+        }
+        // Hold the connection open to capture streaming frames, then move on.
+        m_listenTimer->start(m_listenSeconds * 1000);
+    });
+
+    m_controller->connectToDevice();
+}
+
+void ZwiftProbe::dumpService(QLowEnergyService *service)
+{
+    const bool isZwift = service->serviceUuid() == zwiftServiceUuid();
+    if (isZwift)
+        m_zwiftServiceSeen = true;
+
+    line(QStringLiteral("  service %1%2")
+             .arg(service->serviceUuid().toString(QUuid::WithoutBraces))
+             .arg(isZwift ? QStringLiteral("   ◄ ZWIFT TRAINER SERVICE") : QString()));
+
+    for (const QLowEnergyCharacteristic &c : service->characteristics()) {
+        line(QStringLiteral("      char %1  props=[%2]  val=%3")
+                 .arg(c.uuid().toString(QUuid::WithoutBraces))
+                 .arg(propsToString(c.properties()))
+                 .arg(QString::fromLatin1(c.value().toHex())));
+    }
+    subscribeAndProbe(service);
+}
+
+void ZwiftProbe::subscribeAndProbe(QLowEnergyService *service)
+{
+    connect(service, &QLowEnergyService::characteristicChanged, this,
+            [this](const QLowEnergyCharacteristic &c, const QByteArray &value) {
+                const QString hex = QString::fromLatin1(value.toHex());
+                ZwiftProtocol::RidingData rd;
+                if (ZwiftProtocol::decodeRidingData(value, rd)) {
+                    line(QStringLiteral("    ◀ %1  RIDING pwr=%2 cad=%3 spd=%4 hr=%5")
+                             .arg(c.uuid().toString(QUuid::WithoutBraces))
+                             .arg(rd.power).arg(rd.cadence).arg(rd.speedX100).arg(rd.hr));
+                } else {
+                    line(QStringLiteral("    ◀ %1  %2")
+                             .arg(c.uuid().toString(QUuid::WithoutBraces), hex));
+                }
+            });   // one connection per service object (dumpService runs once each)
+
+    // Subscribe to every notify/indicate characteristic so we also capture the
+    // Zwift Click's button frames, not just trainer riding data.
+    for (const QLowEnergyCharacteristic &c : service->characteristics()) {
+        const auto props = c.properties();
+        QLowEnergyDescriptor cccd = c.descriptor(QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
+        if (!cccd.isValid())
+            continue;
+        if (props & QLowEnergyCharacteristic::Notify)
+            service->writeDescriptor(cccd, kNotifyOn);
+        else if (props & QLowEnergyCharacteristic::Indicate)
+            service->writeDescriptor(cccd, kIndicateOn);
+    }
+
+    // The only write we ever make: the documented handshake that makes the
+    // trainer start streaming. No 0x04 control command → resistance untouched.
+    if (service->serviceUuid() == zwiftServiceUuid()) {
+        const QLowEnergyCharacteristic cp = service->characteristic(zwiftControlPointUuid());
+        if (cp.isValid()) {
+            const auto mode = (cp.properties() & QLowEnergyCharacteristic::WriteNoResponse)
+                                  ? QLowEnergyService::WriteWithoutResponse
+                                  : QLowEnergyService::WriteWithResponse;
+            service->writeCharacteristic(cp, ZwiftProtocol::rideOnHandshake(), mode);
+            line(QStringLiteral("    ▶ wrote RideOn handshake to control point"));
+        }
+    }
+}
+
+void ZwiftProbe::finishCurrentDevice()
+{
+    if (m_listenTimer)
+        m_listenTimer->stop();
+    line(QStringLiteral("  -- done with %1 (zwift service %2) --")
+             .arg(m_current.name(),
+                  m_zwiftServiceSeen ? QStringLiteral("FOUND") : QStringLiteral("not found")));
+    connectNextCandidate();
+}
+
+void ZwiftProbe::teardownController()
+{
+    qDeleteAll(m_services);
+    m_services.clear();
+    if (!m_controller)
+        return;
+
+    // Disconnect is async — delete only once it has settled, else Qt warns
+    // "Controller is not Unconnected when deleted".
+    QLowEnergyController *c = m_controller;
+    m_controller = nullptr;
+    connect(c, &QLowEnergyController::disconnected, c, &QObject::deleteLater);
+    if (c->state() != QLowEnergyController::UnconnectedState)
+        c->disconnectFromDevice();
+    else
+        c->deleteLater();
+}
+
+QString ZwiftProbe::propsToString(QLowEnergyCharacteristic::PropertyTypes p)
+{
+    QStringList out;
+    if (p & QLowEnergyCharacteristic::Read)            out << QStringLiteral("Rd");
+    if (p & QLowEnergyCharacteristic::Write)           out << QStringLiteral("Wr");
+    if (p & QLowEnergyCharacteristic::WriteNoResponse) out << QStringLiteral("WrNR");
+    if (p & QLowEnergyCharacteristic::Notify)          out << QStringLiteral("Ntf");
+    if (p & QLowEnergyCharacteristic::Indicate)        out << QStringLiteral("Ind");
+    return out.join(QLatin1Char('|'));
+}

--- a/src/btle/zwift/zwift_probe.cpp
+++ b/src/btle/zwift/zwift_probe.cpp
@@ -147,7 +147,7 @@ void ZwiftProbe::connectNextCandidate()
 
     m_current          = m_candidates.dequeue();
     m_zwiftServiceSeen = false;
-    m_retriesLeft      = 3;   // weak links (distant trainer) drop mid-discovery
+    m_retriesLeft      = 5;   // weak links (distant trainer) fail/drop transiently
     line(QString());
     line(QStringLiteral("== Connecting to %1 [%2] ==")
              .arg(m_current.name(), m_current.address().toString()));
@@ -158,26 +158,16 @@ void ZwiftProbe::connectNextCandidate()
         m_controller->discoverServices();
     });
     connect(m_controller, &QLowEnergyController::disconnected, this, [this]() {
-        // A weak link can drop before per-service detail discovery completes,
-        // so we never see the Zwift service. Retry the same device a few times.
-        if (!m_zwiftServiceSeen && m_retriesLeft > 0 && m_controller) {
-            --m_retriesLeft;
-            if (m_listenTimer) m_listenTimer->stop();
-            qDeleteAll(m_services);
-            m_services.clear();
-            line(QStringLiteral("  link dropped before discovery — retrying (%1 left)")
-                     .arg(m_retriesLeft));
-            m_controller->connectToDevice();
-            return;
-        }
+        if (!m_zwiftServiceSeen) { retryOrAdvance(QStringLiteral("link dropped")); return; }
         line(QStringLiteral("  disconnected"));
     });
     connect(m_controller,
             static_cast<void (QLowEnergyController::*)(QLowEnergyController::Error)>(
                 &QLowEnergyController::errorOccurred),
             this, [this](QLowEnergyController::Error) {
-                line(QStringLiteral("  [controller error] %1").arg(m_controller->errorString()));
-                finishCurrentDevice();
+                const QString es = m_controller ? m_controller->errorString()
+                                                : QStringLiteral("error");
+                retryOrAdvance(QStringLiteral("connect error: %1").arg(es));
             });
     connect(m_controller, &QLowEnergyController::discoveryFinished, this, [this]() {
         const auto uuids = m_controller->services();
@@ -199,6 +189,32 @@ void ZwiftProbe::connectNextCandidate()
     });
 
     m_controller->connectToDevice();
+}
+
+// A weak/transient BLE failure (connect "Unknown Error" or a mid-discovery
+// drop) before we see the Zwift service: wait a moment for the stack to settle,
+// then reconnect the same device. Bounded by m_retriesLeft. The success path
+// (m_zwiftServiceSeen) owns its own teardown, so do nothing there.
+void ZwiftProbe::retryOrAdvance(const QString &reason)
+{
+    if (m_zwiftServiceSeen || m_reconnectPending)
+        return;
+    if (m_retriesLeft <= 0 || !m_controller) {
+        line(QStringLiteral("  %1 — giving up on this device").arg(reason));
+        finishCurrentDevice();
+        return;
+    }
+    --m_retriesLeft;
+    m_reconnectPending = true;
+    if (m_listenTimer) m_listenTimer->stop();
+    qDeleteAll(m_services);
+    m_services.clear();
+    line(QStringLiteral("  %1 — retrying in 1.5 s (%2 left)").arg(reason).arg(m_retriesLeft));
+    QTimer::singleShot(1500, this, [this]() {
+        m_reconnectPending = false;
+        if (m_controller && !m_zwiftServiceSeen)
+            m_controller->connectToDevice();
+    });
 }
 
 void ZwiftProbe::dumpService(QLowEnergyService *service)
@@ -285,7 +301,10 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
     };
     auto simGear = [](qint32 inclineX100, int gear) {
         HubCommand c;
+        c.sim.windX100             = 0;
         c.sim.inclineX100          = inclineX100;
+        c.sim.cwaX10000            = ZwiftSim::CWaX10000;   // 0.51 — required for gears to bite
+        c.sim.crrX100000           = ZwiftSim::CrrX100000;  // 0.004
         c.physical.gearRatioX10000 = ZwiftGears::ratioX10000ForGear(gear);
         c.physical.riderWeightX100 = 7500;   // 75.0 kg
         c.physical.bikeWeightX100  = 800;    //  8.0 kg
@@ -294,17 +313,20 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
 
     if (m_script == Script::GearSweep) {
         // Rider pedals steadily; we step the gear so they FEEL each change with
-        // no input. Hold +3% so SIM resistance is non-trivial at speed.
+        // no input. Hold +3% so SIM resistance is non-trivial at speed. The
+        // baseline holds for a warmup so the rider can mount + start pedaling
+        // (and the connection settles) before gears begin changing.
         m_ctrlIntervalMs = 8000;   // hold each long enough to feel
+        m_ctrlPrerollMs  = 30000;  // warmup after baseline
         m_ctrlSteps = {
-            { QStringLiteral("PEDAL STEADY ~80rpm. Gear 12/24 @ +3% (baseline)"), simGear(300, 12) },
-            { QStringLiteral("Gear 1/24  → should feel EASIEST"), simGear(300, 1)  },
-            { QStringLiteral("Gear 24/24 → should feel HARDEST"), simGear(300, 24) },
-            { QStringLiteral("Gear 1/24  → EASIEST again"),       simGear(300, 1)  },
-            { QStringLiteral("Gear 24/24 → HARDEST again"),       simGear(300, 24) },
-            { QStringLiteral("Gear 12 @ 0% → sanity: flat/easy"),simGear(0,   12) },
-            { QStringLiteral("Gear 12 @ +6% → sanity: HARDER"),  simGear(600, 12) },
-            { QStringLiteral("RESET — release resistance"),       erg(0)           },
+            { QStringLiteral("CONNECTED — get on & pedal steady ~80rpm (30s warmup)"), simGear(0, 8) },
+            { QStringLiteral("Gear 2/24  @ 0% → should feel EASIEST"), simGear(0, 2)  },
+            { QStringLiteral("Gear 22/24 @ 0% → should feel HARDEST"), simGear(0, 22) },
+            { QStringLiteral("Gear 2/24  @ 0% → EASIEST again"),       simGear(0, 2)  },
+            { QStringLiteral("Gear 22/24 @ 0% → HARDEST again"),       simGear(0, 22) },
+            { QStringLiteral("Gear 11 @ 0%  → mid gear (flat)"),       simGear(0,   11) },
+            { QStringLiteral("Gear 11 @ +5% → grade sanity: HARDER"),  simGear(500, 11) },
+            { QStringLiteral("RESET — release resistance"),            erg(0)           },
         };
     } else { // Script::ErgDemo
         m_ctrlIntervalMs = 4500;
@@ -320,15 +342,18 @@ void ZwiftProbe::beginControlScript(QLowEnergyService *zwiftService)
     }
 
     line(QString());
-    line(QStringLiteral("  ▶▶ control script: %1 steps, %2 s each — watch the dbg ResCtrl lines")
-             .arg(m_ctrlSteps.size()).arg(m_ctrlIntervalMs / 1000));
+    line(QStringLiteral("  ▶▶ control script: %1 steps, %2 s each%3 — watch the dbg ResCtrl lines")
+             .arg(m_ctrlSteps.size()).arg(m_ctrlIntervalMs / 1000)
+             .arg(m_ctrlPrerollMs > 0
+                      ? QStringLiteral(" (after a %1s warmup)").arg(m_ctrlPrerollMs / 1000)
+                      : QString()));
 
     if (!m_ctrlTimer) {
         m_ctrlTimer = new QTimer(this);
+        m_ctrlTimer->setSingleShot(true);   // each step chains the next explicitly
         connect(m_ctrlTimer, &QTimer::timeout, this, &ZwiftProbe::onControlStep);
     }
-    onControlStep();                       // first step immediately
-    m_ctrlTimer->start(m_ctrlIntervalMs);  // then one per interval
+    onControlStep();   // sends baseline now, schedules the rest
 }
 
 void ZwiftProbe::onControlStep()
@@ -340,6 +365,7 @@ void ZwiftProbe::onControlStep()
         return;
     }
 
+    const int sent = m_ctrlIndex;
     const auto &step = m_ctrlSteps.at(m_ctrlIndex++);
     const QLowEnergyCharacteristic cp =
         m_ctrlService->characteristic(zwiftControlPointUuid());
@@ -352,6 +378,13 @@ void ZwiftProbe::onControlStep()
                  .arg(m_ctrlIndex).arg(m_ctrlSteps.size())
                  .arg(step.first, QString::fromLatin1(step.second.toHex())));
     }
+
+    // Chain the next step: the baseline (step 0) holds for the warmup, the rest
+    // for the normal interval.
+    const int delay = (sent == 0 && m_ctrlPrerollMs > 0) ? m_ctrlPrerollMs
+                                                         : m_ctrlIntervalMs;
+    if (m_ctrlTimer)
+        m_ctrlTimer->start(delay);
 }
 
 void ZwiftProbe::finishCurrentDevice()

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -7,8 +7,10 @@
 #include <QBluetoothUuid>
 #include <QLowEnergyController>
 #include <QLowEnergyService>
+#include <QLowEnergyCharacteristic>
 #include <QQueue>
 #include <QTimer>
+#include <QVector>
 
 /*
  * Phase 1 read-only BLE exploration harness for the Zwift virtual-shifting work
@@ -36,8 +38,11 @@ public:
 
     // nameFilter: case-insensitive substring; empty => auto (Zwift service or a
     // name hinting at a trainer/Click). listenSeconds: per-device capture window.
+    // controlTest: Phase 2 — after the handshake, drive a scripted sequence of
+    // 0x04 control commands and observe the trainer react (changes resistance).
     void start(const QString &nameFilter = QString(),
-               int scanSeconds = 8, int listenSeconds = 15);
+               int scanSeconds = 8, int listenSeconds = 15,
+               bool controlTest = false);
 
 signals:
     void finished();
@@ -45,11 +50,13 @@ signals:
 private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
+    void onControlStep();
 
 private:
     void connectNextCandidate();
     void dumpService(QLowEnergyService *service);
     void subscribeAndProbe(QLowEnergyService *service);
+    void beginControlScript(QLowEnergyService *zwiftService);
     void finishCurrentDevice();
     void teardownController();
 
@@ -70,6 +77,14 @@ private:
     bool                            m_scanHandled = false;
     int                             m_suppressedCount = 0;
     int                             m_retriesLeft = 0;
+
+    // Phase 2 control script (resistance-changing writes).
+    bool                            m_controlTest = false;
+    bool                            m_controlStarted = false;
+    QLowEnergyService              *m_ctrlService = nullptr;
+    QVector<QPair<QString, QByteArray>> m_ctrlSteps;
+    int                             m_ctrlIndex = 0;
+    QTimer                         *m_ctrlTimer = nullptr;
 };
 
 #endif // ZWIFT_PROBE_H

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -58,6 +58,7 @@ private slots:
 
 private:
     void connectNextCandidate();
+    void retryOrAdvance(const QString &reason);
     void dumpService(QLowEnergyService *service);
     void subscribeAndProbe(QLowEnergyService *service);
     void beginControlScript(QLowEnergyService *zwiftService);
@@ -81,6 +82,7 @@ private:
     bool                            m_scanHandled = false;
     int                             m_suppressedCount = 0;
     int                             m_retriesLeft = 0;
+    bool                            m_reconnectPending = false;
 
     // Phase 2 control script (resistance-changing writes).
     Script                          m_script = Script::None;
@@ -89,6 +91,7 @@ private:
     QVector<QPair<QString, QByteArray>> m_ctrlSteps;
     int                             m_ctrlIndex = 0;
     int                             m_ctrlIntervalMs = 4500;
+    int                             m_ctrlPrerollMs = 0;   // extra hold after the baseline step
     QTimer                         *m_ctrlTimer = nullptr;
 };
 

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -40,7 +40,7 @@ public:
     //   ErgDemo   — ERG power steps (proves control; no pedaling needed).
     //   GearSweep — hold a grade, auto-step the virtual gear up/down so a rider
     //               can FEEL each gear without touching any input.
-    enum class Script { None, ErgDemo, GearSweep };
+    enum class Script { None, ErgDemo, GearSweep, ErgHold };
 
     // nameFilter: case-insensitive substring; empty => auto (Zwift service or a
     // name hinting at a trainer/Click). listenSeconds: per-device capture window.

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -69,6 +69,7 @@ private:
     bool                            m_zwiftServiceSeen = false;
     bool                            m_scanHandled = false;
     int                             m_suppressedCount = 0;
+    int                             m_retriesLeft = 0;
 };
 
 #endif // ZWIFT_PROBE_H

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -36,13 +36,17 @@ class ZwiftProbe : public QObject
 public:
     explicit ZwiftProbe(QObject *parent = nullptr);
 
+    // Optional scripted write sequence run after the handshake (Phase 2).
+    //   ErgDemo   — ERG power steps (proves control; no pedaling needed).
+    //   GearSweep — hold a grade, auto-step the virtual gear up/down so a rider
+    //               can FEEL each gear without touching any input.
+    enum class Script { None, ErgDemo, GearSweep };
+
     // nameFilter: case-insensitive substring; empty => auto (Zwift service or a
     // name hinting at a trainer/Click). listenSeconds: per-device capture window.
-    // controlTest: Phase 2 — after the handshake, drive a scripted sequence of
-    // 0x04 control commands and observe the trainer react (changes resistance).
     void start(const QString &nameFilter = QString(),
                int scanSeconds = 8, int listenSeconds = 15,
-               bool controlTest = false);
+               Script script = Script::None);
 
 signals:
     void finished();
@@ -79,11 +83,12 @@ private:
     int                             m_retriesLeft = 0;
 
     // Phase 2 control script (resistance-changing writes).
-    bool                            m_controlTest = false;
+    Script                          m_script = Script::None;
     bool                            m_controlStarted = false;
     QLowEnergyService              *m_ctrlService = nullptr;
     QVector<QPair<QString, QByteArray>> m_ctrlSteps;
     int                             m_ctrlIndex = 0;
+    int                             m_ctrlIntervalMs = 4500;
     QTimer                         *m_ctrlTimer = nullptr;
 };
 

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -40,7 +40,7 @@ public:
     //   ErgDemo   — ERG power steps (proves control; no pedaling needed).
     //   GearSweep — hold a grade, auto-step the virtual gear up/down so a rider
     //               can FEEL each gear without touching any input.
-    enum class Script { None, ErgDemo, GearSweep, ErgHold };
+    enum class Script { None, ErgDemo, GearSweep, ErgHold, FtmsErg };
 
     // nameFilter: case-insensitive substring; empty => auto (Zwift service or a
     // name hinting at a trainer/Click). listenSeconds: per-device capture window.
@@ -61,7 +61,8 @@ private:
     void retryOrAdvance(const QString &reason);
     void dumpService(QLowEnergyService *service);
     void subscribeAndProbe(QLowEnergyService *service);
-    void beginControlScript(QLowEnergyService *zwiftService);
+    void setupFtmsControl(QLowEnergyService *ftmsService);
+    void beginControlScript(QLowEnergyService *service, const QBluetoothUuid &controlPoint);
     void finishCurrentDevice();
     void teardownController();
 
@@ -87,6 +88,8 @@ private:
     // Phase 2 control script (resistance-changing writes).
     Script                          m_script = Script::None;
     bool                            m_controlStarted = false;
+    bool                            m_ftmsRequested = false;
+    QBluetoothUuid                  m_ctrlPointUuid;   // where onControlStep writes
     QLowEnergyService              *m_ctrlService = nullptr;
     QVector<QPair<QString, QByteArray>> m_ctrlSteps;
     int                             m_ctrlIndex = 0;

--- a/src/btle/zwift/zwift_probe.h
+++ b/src/btle/zwift/zwift_probe.h
@@ -1,0 +1,74 @@
+#ifndef ZWIFT_PROBE_H
+#define ZWIFT_PROBE_H
+
+#include <QObject>
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QBluetoothDeviceInfo>
+#include <QBluetoothUuid>
+#include <QLowEnergyController>
+#include <QLowEnergyService>
+#include <QQueue>
+#include <QTimer>
+
+/*
+ * Phase 1 read-only BLE exploration harness for the Zwift virtual-shifting work
+ * (issue #293). Headless console tool, launched via `--zwift-probe`.
+ *
+ * What it does (and deliberately does NOT do):
+ *   - scans LE, logs every device (name / address / advertised services);
+ *   - connects to candidates (name filter, or anything advertising the Zwift
+ *     trainer service), dumps the full GATT table;
+ *   - subscribes to every notify/indicate characteristic and logs raw frames,
+ *     decoding 0x03 riding-data via the Phase 0 codec;
+ *   - writes ONLY the documented "RideOn" handshake to the Zwift control point
+ *     so the trainer starts streaming. It never sends a 0x04 control command,
+ *     so it cannot change resistance — purely observational.
+ *
+ * Goal: confirm the service/characteristic layout, the handshake's trailing
+ * bytes, the (assumed) lack of encryption, and the Zwift Click button frames,
+ * before any control code is written in Phase 2.
+ */
+class ZwiftProbe : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ZwiftProbe(QObject *parent = nullptr);
+
+    // nameFilter: case-insensitive substring; empty => auto (Zwift service or a
+    // name hinting at a trainer/Click). listenSeconds: per-device capture window.
+    void start(const QString &nameFilter = QString(),
+               int scanSeconds = 8, int listenSeconds = 15);
+
+signals:
+    void finished();
+
+private slots:
+    void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
+    void onScanFinished();
+
+private:
+    void connectNextCandidate();
+    void dumpService(QLowEnergyService *service);
+    void subscribeAndProbe(QLowEnergyService *service);
+    void finishCurrentDevice();
+    void teardownController();
+
+    static bool looksInteresting(const QBluetoothDeviceInfo &info,
+                                 const QString &nameFilter);
+    static QString propsToString(QLowEnergyCharacteristic::PropertyTypes p);
+
+    QBluetoothDeviceDiscoveryAgent *m_agent = nullptr;
+    QString                         m_nameFilter;
+    int                             m_listenSeconds = 15;
+
+    QQueue<QBluetoothDeviceInfo>    m_candidates;
+    QBluetoothDeviceInfo            m_current;
+    QLowEnergyController           *m_controller = nullptr;
+    QList<QLowEnergyService *>      m_services;
+    QTimer                         *m_listenTimer = nullptr;
+    bool                            m_zwiftServiceSeen = false;
+    bool                            m_scanHandled = false;
+    int                             m_suppressedCount = 0;
+};
+
+#endif // ZWIFT_PROBE_H

--- a/src/btle/zwift/zwift_protocol.cpp
+++ b/src/btle/zwift/zwift_protocol.cpp
@@ -1,0 +1,157 @@
+#include "zwift_protocol.h"
+
+#include <cmath>
+
+namespace {
+
+// ── Minimal protobuf wire helpers (only what the two messages need) ──────────
+void putVarint(QByteArray &out, quint64 value)
+{
+    do {
+        quint8 byte = value & 0x7F;
+        value >>= 7;
+        if (value)
+            byte |= 0x80;
+        out.append(static_cast<char>(byte));
+    } while (value);
+}
+
+quint64 zigzag32(qint32 value)
+{
+    return static_cast<quint32>((value << 1) ^ (value >> 31));
+}
+
+void putVarintField(QByteArray &out, int field, quint64 value)
+{
+    putVarint(out, (static_cast<quint64>(field) << 3) | 0);   // wire type 0
+    putVarint(out, value);
+}
+
+void putMessageField(QByteArray &out, int field, const QByteArray &msg)
+{
+    putVarint(out, (static_cast<quint64>(field) << 3) | 2);   // wire type 2
+    putVarint(out, static_cast<quint64>(msg.size()));
+    out.append(msg);
+}
+
+// Reads a base-128 varint; advances pos. Returns false past the end or on a
+// varint longer than 64 bits.
+bool getVarint(const QByteArray &data, int &pos, quint64 &out)
+{
+    out = 0;
+    int shift = 0;
+    while (pos < data.size()) {
+        const quint8 byte = static_cast<quint8>(data.at(pos++));
+        out |= (static_cast<quint64>(byte & 0x7F) << shift);
+        if (!(byte & 0x80))
+            return true;
+        shift += 7;
+        if (shift >= 64)
+            return false;
+    }
+    return false;
+}
+
+} // namespace
+
+namespace ZwiftProtocol {
+
+QByteArray rideOnHandshake()
+{
+    return QByteArrayLiteral("RideOn");
+}
+
+QByteArray encodeControlCommand(const HubCommand &cmd)
+{
+    QByteArray body;
+
+    if (cmd.powerTargetW)
+        putVarintField(body, 3, *cmd.powerTargetW);
+
+    if (cmd.sim.any()) {
+        QByteArray sim;
+        if (cmd.sim.windX100)    putVarintField(sim, 1, zigzag32(*cmd.sim.windX100));
+        if (cmd.sim.inclineX100) putVarintField(sim, 2, zigzag32(*cmd.sim.inclineX100));
+        if (cmd.sim.cwaX10000)   putVarintField(sim, 3, *cmd.sim.cwaX10000);
+        if (cmd.sim.crrX100000)  putVarintField(sim, 4, *cmd.sim.crrX100000);
+        putMessageField(body, 4, sim);
+    }
+
+    if (cmd.physical.any()) {
+        QByteArray phys;
+        if (cmd.physical.gearRatioX10000) putVarintField(phys, 2, *cmd.physical.gearRatioX10000);
+        if (cmd.physical.bikeWeightX100)  putVarintField(phys, 4, *cmd.physical.bikeWeightX100);
+        if (cmd.physical.riderWeightX100) putVarintField(phys, 5, *cmd.physical.riderWeightX100);
+        putMessageField(body, 5, phys);
+    }
+
+    QByteArray frame;
+    frame.append(static_cast<char>(Command::TrainerControl));
+    frame.append(body);
+    return frame;
+}
+
+bool decodeRidingData(const QByteArray &frame, RidingData &out)
+{
+    if (frame.isEmpty() ||
+        static_cast<quint8>(frame.at(0)) != static_cast<quint8>(Command::RidingData))
+        return false;
+
+    int pos = 1;
+    while (pos < frame.size()) {
+        quint64 tag;
+        if (!getVarint(frame, pos, tag))
+            return false;
+        const int field    = static_cast<int>(tag >> 3);
+        const int wireType = static_cast<int>(tag & 0x7);
+
+        switch (wireType) {
+        case 0: {                       // varint
+            quint64 value;
+            if (!getVarint(frame, pos, value))
+                return false;
+            switch (field) {
+            case 1: out.power     = static_cast<quint32>(value); break;
+            case 2: out.cadence   = static_cast<quint32>(value); break;
+            case 3: out.speedX100 = static_cast<quint32>(value); break;
+            case 4: out.hr        = static_cast<quint32>(value); break;
+            case 5: out.unknown1  = static_cast<quint32>(value); break;
+            case 6: out.unknown2  = static_cast<quint32>(value); break;
+            default: break;             // unknown field — ignore value
+            }
+            break;
+        }
+        case 2: {                       // length-delimited — skip
+            quint64 len;
+            if (!getVarint(frame, pos, len))
+                return false;
+            pos += static_cast<int>(len);
+            break;
+        }
+        case 5: pos += 4; break;        // 32-bit
+        case 1: pos += 8; break;        // 64-bit
+        default: return false;          // unsupported wire type
+        }
+        if (pos > frame.size())
+            return false;
+    }
+    return true;
+}
+
+} // namespace ZwiftProtocol
+
+namespace ZwiftGears {
+
+double ratioForGear(int gearIndex)
+{
+    const int g = qBound(0, gearIndex, Count - 1);
+    const double t = static_cast<double>(g) / static_cast<double>(Count - 1);
+    return MinRatio * std::pow(MaxRatio / MinRatio, t);
+}
+
+quint32 ratioX10000ForGear(int gearIndex)
+{
+    return static_cast<quint32>(std::lround(ratioForGear(gearIndex) * 10000.0));
+}
+
+} // namespace ZwiftGears

--- a/src/btle/zwift/zwift_protocol.h
+++ b/src/btle/zwift/zwift_protocol.h
@@ -92,6 +92,16 @@ bool decodeRidingData(const QByteArray &frame, RidingData &out);
 // Zwift exposes ~24 virtual gears spanning ratios ~0.75 → 5.49 (Zwift Insider).
 // Exact per-gear ratios are a product choice; default is a geometric spread so
 // each shift is a constant percentage step. Confirm/retune against the device.
+// Fixed environment coefficients Zwift sends in every SimulationParam. Without
+// these, virtual shifting produces no resistance on flat ground: the gear ratio
+// drives virtual speed, and the *feel* comes from aero drag (CWa) acting on that
+// speed. Confirmed on a JetBlack Victory — sending these is what makes gears
+// bite. (See notes/zwift-virtual-shifting-plan.md.)
+namespace ZwiftSim {
+constexpr quint32 CWaX10000  = 5100;   // CW·a·10000  → 0.51
+constexpr quint32 CrrX100000 = 400;    // Crr·100000  → 0.004
+} // namespace ZwiftSim
+
 namespace ZwiftGears {
 constexpr int    Count    = 24;
 constexpr double MinRatio = 0.75;

--- a/src/btle/zwift/zwift_protocol.h
+++ b/src/btle/zwift/zwift_protocol.h
@@ -1,0 +1,101 @@
+#ifndef ZWIFT_PROTOCOL_H
+#define ZWIFT_PROTOCOL_H
+
+#include <QByteArray>
+#include <QtGlobal>
+#include <optional>
+
+/*
+ * Zwift proprietary *trainer* protocol — virtual shifting (issue #293).
+ *
+ * This is NOT FTMS. Virtual-shifting trainers (e.g. JetBlack Victory + Zwift
+ * Cog) expose a Zwift-custom GATT service; we send a gear ratio and the trainer
+ * firmware turns it into resistance. Frame layout is [command_code][protobuf].
+ *
+ * Field numbers/types below are from public reverse-engineering (Makinolo,
+ * "Zwift Trainer protocol", 2024-10-20). The link is unencrypted, like the
+ * Zwift Ride. See notes/zwift-virtual-shifting-plan.md for provenance.
+ *
+ * Phase 0 is the pure codec only — no QtBluetooth, no device I/O — so it is
+ * unit-testable against byte fixtures with just Qt Core + Test.
+ */
+namespace ZwiftProtocol {
+
+// 128-bit UUIDs (full strings; the 32-bit prefix is the only part that varies).
+namespace Uuid {
+inline constexpr char Service[]      = "00000001-19ca-4651-86e5-fa29dcdd09d1";
+inline constexpr char Measurement[]  = "00000002-19ca-4651-86e5-fa29dcdd09d1"; // notify
+inline constexpr char ControlPoint[] = "00000003-19ca-4651-86e5-fa29dcdd09d1"; // write
+inline constexpr char Response[]     = "00000004-19ca-4651-86e5-fa29dcdd09d1"; // indicate
+} // namespace Uuid
+
+// Frame command codes (first byte of every message). Scoped to avoid colliding
+// with the RidingData struct below.
+enum class Command : quint8 {
+    RidingData     = 0x03,  // incoming notification (HubRidingData)
+    TrainerControl = 0x04,  // outgoing to control point (HubCommand)
+};
+
+// The handshake the app writes once subscribed. Trailing bytes (if any) are
+// confirmed against real hardware in Phase 1; "RideOn" is the documented prefix.
+QByteArray rideOnHandshake();
+
+// ── Outgoing: HubCommand (command 0x04) ──────────────────────────────────────
+struct SimulationParam {
+    std::optional<qint32>  windX100;      // f1 sint32 — wind speed, m/s * 100
+    std::optional<qint32>  inclineX100;   // f2 sint32 — road grade % * 100
+    std::optional<quint32> cwaX10000;     // f3        — CW * a * 10000
+    std::optional<quint32> crrX100000;    // f4        — Crr * 100000
+    bool any() const {
+        return windX100 || inclineX100 || cwaX10000 || crrX100000;
+    }
+};
+
+struct PhysicalParam {
+    std::optional<quint32> gearRatioX10000; // f2 — virtual gear ratio * 10000
+    std::optional<quint32> bikeWeightX100;  // f4 — kg * 100
+    std::optional<quint32> riderWeightX100; // f5 — kg * 100
+    bool any() const {
+        return gearRatioX10000 || bikeWeightX100 || riderWeightX100;
+    }
+};
+
+struct HubCommand {
+    std::optional<quint32> powerTargetW;  // f3 — ERG target watts
+    SimulationParam        sim;           // f4
+    PhysicalParam          physical;      // f5
+};
+
+// Encode a HubCommand to wire bytes, including the leading 0x04 command code.
+QByteArray encodeControlCommand(const HubCommand &cmd);
+
+// ── Incoming: HubRidingData (command 0x03) ───────────────────────────────────
+struct RidingData {
+    quint32 power      = 0;  // f1 watts
+    quint32 cadence    = 0;  // f2 rpm
+    quint32 speedX100  = 0;  // f3 km/h * 100 (assumed scale; confirm in Phase 1)
+    quint32 hr         = 0;  // f4 bpm
+    quint32 unknown1   = 0;  // f5
+    quint32 unknown2   = 0;  // f6
+};
+
+// Decode a 0x03 riding-data frame. Returns false if the command byte is not
+// 0x03 or the protobuf stream is malformed. Unknown fields are skipped.
+bool decodeRidingData(const QByteArray &frame, RidingData &out);
+
+} // namespace ZwiftProtocol
+
+// ── Virtual gear table ───────────────────────────────────────────────────────
+// Zwift exposes ~24 virtual gears spanning ratios ~0.75 → 5.49 (Zwift Insider).
+// Exact per-gear ratios are a product choice; default is a geometric spread so
+// each shift is a constant percentage step. Confirm/retune against the device.
+namespace ZwiftGears {
+constexpr int    Count    = 24;
+constexpr double MinRatio = 0.75;
+constexpr double MaxRatio = 5.49;
+
+double  ratioForGear(int gearIndex);        // clamped to [0, Count-1]
+quint32 ratioX10000ForGear(int gearIndex);  // ratio * 10000, rounded
+} // namespace ZwiftGears
+
+#endif // ZWIFT_PROTOCOL_H

--- a/src/btle/zwift/zwift_protocol.h
+++ b/src/btle/zwift/zwift_protocol.h
@@ -21,9 +21,12 @@
  */
 namespace ZwiftProtocol {
 
-// 128-bit UUIDs (full strings; the 32-bit prefix is the only part that varies).
+// UUIDs. The container service is advertised as the 16-bit Zwift UUID 0xFC82
+// (confirmed on a JetBlack Victory fw 4.29 via the Phase 1 probe); the three
+// characteristics use the 19ca-… base documented by Makinolo. Earlier drafts
+// wrongly assumed the service itself was 00000001-19ca-…; it is not.
 namespace Uuid {
-inline constexpr char Service[]      = "00000001-19ca-4651-86e5-fa29dcdd09d1";
+inline constexpr char Service[]      = "0000fc82-0000-1000-8000-00805f9b34fb";
 inline constexpr char Measurement[]  = "00000002-19ca-4651-86e5-fa29dcdd09d1"; // notify
 inline constexpr char ControlPoint[] = "00000003-19ca-4651-86e5-fa29dcdd09d1"; // write
 inline constexpr char Response[]     = "00000004-19ca-4651-86e5-fa29dcdd09d1"; // indicate

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -102,6 +102,7 @@ Account::Account(QObject *parent) : QObject(parent)  {
     strava_token_expires_at = 0;
     // intervals_icu_auto_upload is loaded from QSettings above; don't reset it here
     control_trainer_resistance = true;
+    virtual_shifting = false;   // opt-in; off keeps real-gear / free-ride behaviour
     // Clamp the loaded value to the valid range (0–30 s)
     erg_smoothing_duration_s = qBound(0, erg_smoothing_duration_s, 30);
     /* ----- */
@@ -309,6 +310,7 @@ void Account::loadDisplayPrefs() {
 
     // General / trainer / pairing / upload preferences.
     control_trainer_resistance   = settings.value("control_trainer_resistance",   control_trainer_resistance).toBool();
+    virtual_shifting             = settings.value("virtual_shifting",             virtual_shifting).toBool();
     enable_studio_mode           = settings.value("enable_studio_mode",           enable_studio_mode).toBool();
     distance_in_km               = settings.value("distance_in_km",               distance_in_km).toBool();
     force_workout_window_on_top  = settings.value("force_workout_window_on_top",  force_workout_window_on_top).toBool();
@@ -393,6 +395,7 @@ void Account::saveDisplayPrefs() {
     // General / trainer / pairing / upload preferences. Formerly server-saved;
     // persisted locally so they survive a restart.
     settings.setValue("control_trainer_resistance",  control_trainer_resistance);
+    settings.setValue("virtual_shifting",            virtual_shifting);
     settings.setValue("enable_studio_mode",          enable_studio_mode);
     settings.setValue("distance_in_km",              distance_in_km);
     settings.setValue("force_workout_window_on_top", force_workout_window_on_top);

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -106,6 +106,7 @@ public:
     QList<int> power_zones;            ///< Power zone upper-bounds retrieved from Intervals.icu
 
     bool control_trainer_resistance;
+    bool virtual_shifting;         ///< Opt-in (default off): drive resistance from a virtual gear (▲/▼) for single-cog / Zwift Cog setups. Off = real gears / free ride unchanged.
     int erg_smoothing_duration_s;  ///< Ramp duration (seconds) for ERG setpoint transitions; 0 = disabled.
 
     /// Battery warning threshold (issue #156): warn when a sensor's battery

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -214,7 +214,8 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     // .ui stylesheet doesn't reach these dynamically-created widgets).
     m_gearWidget->setStyleSheet(QStringLiteral("color: white;"));
     m_gearWidget->setVisible(false);
-    // Insert just after the timers so it sits in the middle of the bar.
+    // Centre of the bar: just after the timers/targets frame (renders cleanly
+    // there; the far-right radio area clips it).
     const int timerIdx = ui->horizontalLayout->indexOf(ui->frame_timer);
     if (timerIdx >= 0)
         ui->horizontalLayout->insertWidget(timerIdx + 1, m_gearWidget);

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -8,6 +8,7 @@
 #include <QKeyEvent>
 #include <QPainter>
 #include <QStyle>
+#include <QHBoxLayout>
 #include "util.h"
 
 namespace {
@@ -180,6 +181,66 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     connect (timeUpdateTime, SIGNAL(timeout()), this, SLOT(setCurrentTime()) );
     setCurrentTime();
 
+    // ── Virtual-shifting gear indicator (centre of the top bar, #293) ─────────
+    m_gearWidget = new QWidget(this);
+    auto *gearLayout = new QHBoxLayout(m_gearWidget);
+    gearLayout->setContentsMargins(0, 0, 0, 0);
+    gearLayout->setSpacing(4);
+
+    m_gearDownBtn = new QToolButton(m_gearWidget);
+    m_gearDownBtn->setText(QStringLiteral("▼"));
+    m_gearDownBtn->setAutoRaise(true);
+    m_gearDownBtn->setToolTip(tr("Easier gear (Down arrow)"));
+
+    m_gearLabel = new QLabel(QStringLiteral("⚙ –"), m_gearWidget);
+    m_gearLabel->setAlignment(Qt::AlignCenter);
+    m_gearLabel->setMinimumWidth(72);
+    m_gearLabel->setToolTip(tr("Virtual gear"));
+
+    m_gearUpBtn = new QToolButton(m_gearWidget);
+    m_gearUpBtn->setText(QStringLiteral("▲"));
+    m_gearUpBtn->setAutoRaise(true);
+    m_gearUpBtn->setToolTip(tr("Harder gear (Up arrow)"));
+
+    gearLayout->addWidget(m_gearDownBtn);
+    gearLayout->addWidget(m_gearLabel);
+    gearLayout->addWidget(m_gearUpBtn);
+
+    connect(m_gearDownBtn, &QToolButton::clicked, this, &TopMenuWorkout::gearDown);
+    connect(m_gearUpBtn,   &QToolButton::clicked, this, &TopMenuWorkout::gearUp);
+
+    m_gearWidget->setMinimumWidth(118);   // don't let the bar squeeze it to nothing
+    // The top bar is a fixed dark strip with white text; match it (the scoped
+    // .ui stylesheet doesn't reach these dynamically-created widgets).
+    m_gearWidget->setStyleSheet(QStringLiteral("color: white;"));
+    m_gearWidget->setVisible(false);
+    // Insert just after the timers so it sits in the middle of the bar.
+    const int timerIdx = ui->horizontalLayout->indexOf(ui->frame_timer);
+    if (timerIdx >= 0)
+        ui->horizontalLayout->insertWidget(timerIdx + 1, m_gearWidget);
+    else
+        ui->horizontalLayout->addWidget(m_gearWidget);
+}
+
+void TopMenuWorkout::setGearVisible(bool visible)
+{
+    if (m_gearWidget)
+        m_gearWidget->setVisible(visible);
+}
+
+void TopMenuWorkout::updateGear(int gear, int count, bool ergMode)
+{
+    if (!m_gearLabel)
+        return;
+    if (ergMode) {
+        m_gearLabel->setText(QStringLiteral("⚙ %1/%2  ERG").arg(gear).arg(count));
+        m_gearLabel->setStyleSheet(QStringLiteral("color: gray;"));   // dimmed in ERG
+    } else {
+        m_gearLabel->setText(QStringLiteral("⚙ %1/%2").arg(gear).arg(count));
+        m_gearLabel->setStyleSheet(QString());
+    }
+    if (m_gearDownBtn) m_gearDownBtn->setEnabled(!ergMode);
+    if (m_gearUpBtn)   m_gearUpBtn->setEnabled(!ergMode);
 }
 
 

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -214,13 +214,15 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     // .ui stylesheet doesn't reach these dynamically-created widgets).
     m_gearWidget->setStyleSheet(QStringLiteral("color: white;"));
     m_gearWidget->setVisible(false);
-    // Centre of the bar: just after the timers/targets frame (renders cleanly
-    // there; the far-right radio area clips it).
+    // Centre it: an expanding stretch before the gear balances the bar's right
+    // spacer (the left spacer is fixed), so the gear lands near the middle.
     const int timerIdx = ui->horizontalLayout->indexOf(ui->frame_timer);
-    if (timerIdx >= 0)
-        ui->horizontalLayout->insertWidget(timerIdx + 1, m_gearWidget);
-    else
+    if (timerIdx >= 0) {
+        ui->horizontalLayout->insertStretch(timerIdx + 1, 1);
+        ui->horizontalLayout->insertWidget(timerIdx + 2, m_gearWidget);
+    } else {
         ui->horizontalLayout->addWidget(m_gearWidget);
+    }
 }
 
 void TopMenuWorkout::setGearVisible(bool visible)

--- a/src/ui/components/topmenuworkout.h
+++ b/src/ui/components/topmenuworkout.h
@@ -3,6 +3,8 @@
 
 #include <QWidget>
 #include <QPushButton>
+#include <QLabel>
+#include <QToolButton>
 
 #include "calibration_types.h"
 
@@ -49,6 +51,12 @@ public:
     void setTargetCadence(int cadence, int range);
     void setTargetHeartRate(double percentageLTHR, int range);
 
+    // Virtual-shifting gear indicator (#293): ▼ gear N/24 ▲ in the middle of the
+    // top bar. Shown while shifting is available; during ERG intervals it shows
+    // dimmed with "ERG" and inactive arrows.
+    void setGearVisible(bool visible);
+    void updateGear(int gear, int count, bool ergMode);
+
 
 
 
@@ -68,6 +76,10 @@ signals :
     void prevRadio();
     void playPauseRadio();
     void nextRadio();
+
+    // Virtual-shifting: emitted when the on-screen ▲/▼ gear arrows are clicked.
+    void gearUp();
+    void gearDown();
 
 
 
@@ -115,6 +127,12 @@ private :
 
 private:
     Ui::TopMenuWorkout *ui;
+
+    // Virtual-shifting gear indicator widgets (built in the constructor).
+    QWidget     *m_gearWidget = nullptr;
+    QToolButton *m_gearDownBtn = nullptr;
+    QToolButton *m_gearUpBtn   = nullptr;
+    QLabel      *m_gearLabel   = nullptr;
 
     bool hasTargetPower;
     bool hasTargetCad;

--- a/src/ui/dialogkeyboardshortcuts.cpp
+++ b/src/ui/dialogkeyboardshortcuts.cpp
@@ -43,6 +43,7 @@ DialogKeyboardShortcuts::DialogKeyboardShortcuts(QWidget *parent)
         {tr("→  (Right)"),   tr("Skip to next interval")},
         {tr("+  /  ="),      tr("Increase difficulty +5 %")},
         {tr("-"),            tr("Decrease difficulty −5 %")},
+        {tr("↑  /  ↓"),      tr("Virtual shift up / down (or difficulty if shifting is off)")},
         {tr("L"),            tr("Manual lap")},
         {tr("?  /  F1"),     tr("Show keyboard shortcuts")},
         {tr("Escape"),       tr("Exit workout (with confirmation)")},

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1540,7 +1540,14 @@ void MainWindow::executeWorkout(Workout workout) {
 
     connect(w, SIGNAL(setLoad(int,double)),  btleHub, SLOT(setLoad(int,double)));
     connect(w, SIGNAL(setSlope(int,double)), btleHub, SLOT(setSlope(int,double)));
+    connect(w, SIGNAL(setResistance(int,int)), btleHub, SLOT(setResistanceLevel(int,int)));
     connect(w, SIGNAL(stopDecodingMsgHub()), btleHub, SLOT(stopDecodingMsg()));
+    // Virtual shifting prefers FTMS resistance level (0x04) for an instant,
+    // gear-like feel; tell the dialog whether this trainer supports it (the
+    // feature read may already have completed, so seed it now and also listen).
+    connect(btleHub, &BtleHub::signal_resistanceLevelSupported,
+            w, &WorkoutDialog::setResistanceLevelSupported);
+    w->setResistanceLevelSupported(btleHub->resistanceLevelSupported());
     // Harmless when the device is not a trainer: BtleHub::setLoad() no-ops
     // without an FTMS service.
     w->enableTrainerControl();
@@ -1669,6 +1676,10 @@ void MainWindow::wireHubsToDialog(WorkoutDialog *w,
                 [riderIndex]() { BtleSensorStore::setTrainerProvidesHr(true, riderIndex); });
         connect(w, SIGNAL(setLoad(int,double)),  hub, SLOT(setLoad(int,double)));
         connect(w, SIGNAL(setSlope(int,double)), hub, SLOT(setSlope(int,double)));
+        connect(w, SIGNAL(setResistance(int,int)), hub, SLOT(setResistanceLevel(int,int)));
+        connect(hub, &BtleHub::signal_resistanceLevelSupported,
+                w, &WorkoutDialog::setResistanceLevelSupported);
+        w->setResistanceLevelSupported(hub->resistanceLevelSupported());
         w->enableTrainerControl();
     }
     if (hubsByRole.contains(BtleSensorRole::Power))

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1993,6 +1993,7 @@ void MainWindow::launchDemoWorkout()
             m_ssWorkoutDlg, SLOT(OxygenValueChanged(int,double,double)));
 
     m_ssSimHub->start();
+    m_ssWorkoutDlg->enableTrainerControl();   // demo represents a trainer workout (shows the gear UI)
     m_ssWorkoutDlg->show();
     m_ssWorkoutDlg->raise();
     m_ssWorkoutDlg->activateWindow();

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -117,6 +117,20 @@ void SensorsWidget::buildUi()
     trainerHint->setStyleSheet(QStringLiteral("color: #777; font-size: 11px;"));
     trainerLayout->addWidget(trainerHint);
 
+    m_virtualShiftingCheck =
+        new QCheckBox(tr("Virtual shifting (Zwift Cog / single-gear setups)"), trainerGroup);
+    connect(m_virtualShiftingCheck, &QCheckBox::toggled,
+            this, &SensorsWidget::onVirtualShiftingToggled);
+    trainerLayout->addWidget(m_virtualShiftingCheck);
+
+    QLabel *vsHint = new QLabel(
+        tr("Adds ▲/▼ gear shifting (keyboard or the on-screen arrows) so a "
+           "single-cog trainer has usable resistance on free rides and tests. "
+           "Leave off if you shift with a real cassette."), trainerGroup);
+    vsHint->setWordWrap(true);
+    vsHint->setStyleSheet(QStringLiteral("color: #777; font-size: 11px;"));
+    trainerLayout->addWidget(vsHint);
+
     QHBoxLayout *ergRampRow = new QHBoxLayout();
     ergRampRow->addWidget(new QLabel(tr("ERG transition ramp duration:"), trainerGroup));
     m_ergRampSpin = new QSpinBox(trainerGroup);
@@ -218,6 +232,10 @@ void SensorsWidget::reload()
             QSignalBlocker b(m_controlResistanceCheck);
             m_controlResistanceCheck->setChecked(m_account->control_trainer_resistance);
         }
+        if (m_virtualShiftingCheck) {
+            QSignalBlocker b(m_virtualShiftingCheck);
+            m_virtualShiftingCheck->setChecked(m_account->virtual_shifting);
+        }
         if (m_ergRampSpin) {
             QSignalBlocker b(m_ergRampSpin);
             m_ergRampSpin->setValue(m_account->erg_smoothing_duration_s);
@@ -243,6 +261,14 @@ void SensorsWidget::onControlResistanceToggled(bool checked)
     if (!m_account)
         return;
     m_account->control_trainer_resistance = checked;
+    m_account->saveDisplayPrefs();
+}
+
+void SensorsWidget::onVirtualShiftingToggled(bool checked)
+{
+    if (!m_account)
+        return;
+    m_account->virtual_shifting = checked;
     m_account->saveDisplayPrefs();
 }
 

--- a/src/ui/sensorswidget.h
+++ b/src/ui/sensorswidget.h
@@ -36,6 +36,7 @@ private slots:
     void onScanClicked(int rowIndex);
     void onClearClicked(int rowIndex);
     void onControlResistanceToggled(bool checked);
+    void onVirtualShiftingToggled(bool checked);
     void onErgRampChanged(int seconds);
     void onSensorDropoutChanged();
     void onBatteryThresholdChanged(int percent);
@@ -56,6 +57,7 @@ private:
 
     QVector<SlotRow> m_rows;
     QCheckBox *m_controlResistanceCheck = nullptr;
+    QCheckBox *m_virtualShiftingCheck = nullptr;
     QSpinBox  *m_ergRampSpin            = nullptr;
     QCheckBox *m_dropoutEnabledCheck    = nullptr;
     QSpinBox  *m_dropoutTimeoutSpin     = nullptr;

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2387,7 +2387,9 @@ void WorkoutDialog::enableTrainerControl() {
 // here regardless of the ERG ("control trainer resistance") checkbox: with ERG
 // off the rider controls resistance *through* the gears.
 bool WorkoutDialog::virtualShiftingActive() const {
-    return trainerControlUserId != -1 && account && !account->enable_studio_mode;
+    return trainerControlUserId != -1 && account
+        && account->virtual_shifting          // opt-in; off => real gears / free ride
+        && !account->enable_studio_mode;
 }
 
 // ERG only owns an interval when the checkbox is on AND there's a positive power

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -495,6 +495,9 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
     connect(ui->widget_topMenu, SIGNAL(exit()), this, SLOT(closeWindow()));
     connect(ui->widget_topMenu, SIGNAL(startOrPause()), this, SLOT(start_or_pause_workout()));
     connect(ui->widget_topMenu, SIGNAL(lap()), this, SLOT(lapButtonPressed()) );
+    // On-screen virtual-shift arrows mirror the Up/Down keys.
+    connect(ui->widget_topMenu, &TopMenuWorkout::gearUp,   this, [this]{ shiftGear(+1); });
+    connect(ui->widget_topMenu, &TopMenuWorkout::gearDown, this, [this]{ shiftGear(-1); });
     connect(this, SIGNAL(insideConfig(bool)), ui->widget_topMenu, SLOT(changeConfigIcon(bool)));
 
     // Make the splitter gutters easy to grab — the 1px default was nearly
@@ -1544,6 +1547,7 @@ void WorkoutDialog::moveToNextInterval() {
 void WorkoutDialog::startWorkout() {
 
     m_virtualGear = (VirtualGear::Count + 1) / 2;   // every workout starts mid-gear
+    updateGearIndicator();
 
     emit startClock();
 
@@ -1799,8 +1803,9 @@ void WorkoutDialog::sendLastSecondData(int seconds) {
     }
 
     // Re-send the gear's load each second so faster/slower pedaling changes
-    // resistance like a real gear (only while we'd otherwise be at resistance 0).
-    if (isUsingSlopeMode && !isWorkoutOver && virtualShiftingActive())
+    // resistance like a real gear (ERG-fallback trainers); harmless dedup for
+    // resistance-level trainers.
+    if (gearsDriveNow())
         sendGearLoad();
 }
 
@@ -2373,10 +2378,29 @@ void WorkoutDialog::sendSlopes(double slope) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Virtual shifting (#293) — drive a single-cog trainer's resistance from a
 // rider-controlled gear instead of sending slope 0 (which spins out).
+void WorkoutDialog::enableTrainerControl() {
+    trainerControlUserId = 1;       // solo rider; hubs ignore the id
+    updateGearIndicator();          // a trainer is now wired → reveal the gear UI
+}
+
+// A trainer is under our control (solo, non-studio). Virtual shifting is offered
+// here regardless of the ERG ("control trainer resistance") checkbox: with ERG
+// off the rider controls resistance *through* the gears.
 bool WorkoutDialog::virtualShiftingActive() const {
-    return trainerControlUserId != -1
-        && account && account->control_trainer_resistance
-        && !account->enable_studio_mode;
+    return trainerControlUserId != -1 && account && !account->enable_studio_mode;
+}
+
+// ERG only owns an interval when the checkbox is on AND there's a positive power
+// target (a structured power interval). Then gears are inactive ("ERG").
+bool WorkoutDialog::ergOwnsThisInterval() const {
+    return account && account->control_trainer_resistance
+        && !isUsingSlopeMode && currentTargetPower > 0;
+}
+
+// Gears are the active resistance source whenever a trainer is controllable, the
+// workout isn't over, and ERG isn't currently owning the interval.
+bool WorkoutDialog::gearsDriveNow() const {
+    return virtualShiftingActive() && !isWorkoutOver && !ergOwnsThisInterval();
 }
 
 int WorkoutDialog::gearTargetWatts(int gear, double cadence) const {
@@ -2385,11 +2409,7 @@ int WorkoutDialog::gearTargetWatts(int gear, double cadence) const {
 }
 
 void WorkoutDialog::sendGearLoad() {
-    if (!virtualShiftingActive() || isWorkoutOver)
-        return;
-    // Never fight an active ERG power target — gears only drive the trainer when
-    // we'd otherwise send resistance 0 (slope / test / free ride / rest).
-    if (!isUsingSlopeMode && currentTargetPower > 0)
+    if (!gearsDriveNow())
         return;
 
     if (m_trainerSupportsResistanceLevel) {
@@ -2409,8 +2429,18 @@ void WorkoutDialog::shiftGear(int delta) {
     if (g == m_virtualGear)
         return;
     m_virtualGear = g;
-    setWindowTitle(QStringLiteral("Gear %1/%2").arg(m_virtualGear).arg(kVirtualGearCount));
     sendGearLoad();
+    updateGearIndicator();
+}
+
+// Refresh the top-bar gear indicator: visible whenever a trainer is controllable
+// (hidden in studio or with no trainer). During an ERG-owned interval it shows
+// dimmed with "ERG"; otherwise the gear is active and shiftable.
+void WorkoutDialog::updateGearIndicator() {
+    const bool show = virtualShiftingActive();
+    ui->widget_topMenu->setGearVisible(show);
+    if (show)
+        ui->widget_topMenu->updateGear(m_virtualGear, kVirtualGearCount, ergOwnsThisInterval());
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2552,6 +2582,9 @@ void WorkoutDialog::targetPowerChanged_f(double percentageTarget, int range) {
     ui->widget_time->setTargetPower(percentageTarget, range);
     ui->widget_topMenu->setTargetPower(percentageTarget, range);
     sendTargetsPower(percentageTarget, range);
+
+    // Reflect the new interval in the gear indicator (active vs dimmed "ERG").
+    updateGearIndicator();
 }
 
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1144,7 +1144,10 @@ void WorkoutDialog::update1sec(double totalTimeElapsed_sec) {
 
     // Early exit
     if (workout.getWorkoutNameEnum() == Workout::OPEN_RIDE) {
-        sendSlopes(0);
+        if (virtualShiftingActive())
+            sendGearLoad();
+        else
+            sendSlopes(0);
         return;
     }
 
@@ -1787,6 +1790,11 @@ void WorkoutDialog::sendLastSecondData(int seconds) {
                                       avgRightPedal1sec.at(0), avgLeftTorqueEff.at(0), avgRightTorqueEff.at(0), avgLeftPedalSmooth.at(0), avgRightPedalSmooth.at(0), avgCombinedPedalSmooth.at(0),
                                       avgSaturatedHemoglobinPercent1sec.at(0), avgTotalHemoglobinConc1sec.at(0));
     }
+
+    // Re-send the gear's load each second so faster/slower pedaling changes
+    // resistance like a real gear (only while we'd otherwise be at resistance 0).
+    if (isUsingSlopeMode && virtualShiftingActive())
+        sendGearLoad();
 }
 
 
@@ -2356,6 +2364,48 @@ void WorkoutDialog::sendSlopes(double slope) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Virtual shifting (#293) — drive a single-cog trainer's resistance from a
+// rider-controlled gear instead of sending slope 0 (which spins out).
+bool WorkoutDialog::virtualShiftingActive() const {
+    return trainerControlUserId != -1
+        && account && account->control_trainer_resistance
+        && !account->enable_studio_mode;
+}
+
+int WorkoutDialog::gearTargetWatts(int gear, double cadence) const {
+    const int g = qBound(1, gear, kVirtualGearCount);
+    // Per-gear resistance coefficient, easy (0.5) → hard (2.0).
+    const double coeff = 0.5 + (g - 1) / double(kVirtualGearCount - 1) * 1.5;
+    // Cadence factor (aero-like): faster pedaling demands more watts, like a
+    // real gear — distinguishes this from a flat ERG clamp.
+    double cad = (cadence > 0) ? cadence : 85.0;
+    cad = qBound(40.0, cad, 120.0);
+    const double cadFactor = (cad / 85.0) * (cad / 85.0);
+    const double ftp = (account && account->FTP > 0) ? account->FTP : 200.0;
+    const double watts = 0.48 * ftp * coeff * cadFactor;   // mid gear @85rpm ≈ 0.6×FTP
+    return qBound(20, int(qRound(watts)), int(qRound(1.6 * ftp)));
+}
+
+void WorkoutDialog::sendGearLoad() {
+    if (!virtualShiftingActive())
+        return;
+    const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
+    emit setLoad(trainerControlUserId, gearTargetWatts(m_virtualGear, cad));
+}
+
+void WorkoutDialog::shiftGear(int delta) {
+    const int g = qBound(1, m_virtualGear + delta, kVirtualGearCount);
+    if (g == m_virtualGear)
+        return;
+    m_virtualGear = g;
+    const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
+    setWindowTitle(QStringLiteral("Gear %1/%2  →  %3 W")
+                       .arg(m_virtualGear).arg(kVirtualGearCount)
+                       .arg(gearTargetWatts(m_virtualGear, cad)));
+    sendGearLoad();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutDialog::sendLoads(double percentageFTP) {
 
     // Studio mode: no smoothing — each rider has a different FTP, broadcast directly.
@@ -2466,7 +2516,12 @@ void WorkoutDialog::targetPowerChanged_f(double percentageTarget, int range) {
 
 
     if (percentageTarget <= 0 || isUsingSlopeMode || !account->control_trainer_resistance) {
-        sendSlopes(0);
+        // Single-cog trainers spin out at slope 0 (#293) — drive the virtual
+        // gear's resistance instead when trainer control is available.
+        if (virtualShiftingActive())
+            sendGearLoad();
+        else
+            sendSlopes(0);
     }
     else if(account->control_trainer_resistance) {
         sendLoads(percentageTarget);
@@ -3156,6 +3211,14 @@ void WorkoutDialog::keyPressEvent(QKeyEvent *event)
         return;
     case Qt::Key_Minus:
         adjustWorkoutDifficulty(currentWorkoutDifficultyPercentage - 5);
+        return;
+    case Qt::Key_Up:        // virtual shift up (harder gear)
+        if (virtualShiftingActive())
+            shiftGear(+1);
+        return;
+    case Qt::Key_Down:      // virtual shift down (easier gear)
+        if (virtualShiftingActive())
+            shiftGear(-1);
         return;
     case Qt::Key_L:
         if (!event->isAutoRepeat())

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1,4 +1,5 @@
 #include "workoutdialog.h"
+#include "virtual_gear.h"
 #include "ui_workoutdialog.h"
 
 #ifdef Q_OS_WIN32
@@ -2373,17 +2374,8 @@ bool WorkoutDialog::virtualShiftingActive() const {
 }
 
 int WorkoutDialog::gearTargetWatts(int gear, double cadence) const {
-    const int g = qBound(1, gear, kVirtualGearCount);
-    // Per-gear resistance coefficient, easy (0.5) → hard (2.0).
-    const double coeff = 0.5 + (g - 1) / double(kVirtualGearCount - 1) * 1.5;
-    // Cadence factor (aero-like): faster pedaling demands more watts, like a
-    // real gear — distinguishes this from a flat ERG clamp.
-    double cad = (cadence > 0) ? cadence : 85.0;
-    cad = qBound(40.0, cad, 120.0);
-    const double cadFactor = (cad / 85.0) * (cad / 85.0);
-    const double ftp = (account && account->FTP > 0) ? account->FTP : 200.0;
-    const double watts = 0.48 * ftp * coeff * cadFactor;   // mid gear @85rpm ≈ 0.6×FTP
-    return qBound(20, int(qRound(watts)), int(qRound(1.6 * ftp)));
+    return VirtualGear::targetWatts(gear, cadence,
+                                    (account && account->FTP > 0) ? account->FTP : 0.0);
 }
 
 void WorkoutDialog::sendGearLoad() {

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1543,6 +1543,7 @@ void WorkoutDialog::moveToNextInterval() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutDialog::startWorkout() {
 
+    m_virtualGear = (VirtualGear::Count + 1) / 2;   // every workout starts mid-gear
 
     emit startClock();
 
@@ -1575,6 +1576,11 @@ void WorkoutDialog::workoutOver() {
 
     isWorkoutOver = true;
     stopErgSmoothing();
+
+    // Release virtual-shifting resistance so the trainer doesn't hold a load
+    // after the workout ends (it would otherwise persist until disconnect).
+    if (virtualShiftingActive())
+        emit setLoad(trainerControlUserId, 0);
 
     if (raceController) raceController->finishRace();   // finish line + celebration
 
@@ -1794,7 +1800,7 @@ void WorkoutDialog::sendLastSecondData(int seconds) {
 
     // Re-send the gear's load each second so faster/slower pedaling changes
     // resistance like a real gear (only while we'd otherwise be at resistance 0).
-    if (isUsingSlopeMode && virtualShiftingActive())
+    if (isUsingSlopeMode && !isWorkoutOver && virtualShiftingActive())
         sendGearLoad();
 }
 
@@ -2379,13 +2385,19 @@ int WorkoutDialog::gearTargetWatts(int gear, double cadence) const {
 }
 
 void WorkoutDialog::sendGearLoad() {
-    if (!virtualShiftingActive())
+    if (!virtualShiftingActive() || isWorkoutOver)
+        return;
+    // Never fight an active ERG power target — gears only drive the trainer when
+    // we'd otherwise send resistance 0 (slope / test / free ride / rest).
+    if (!isUsingSlopeMode && currentTargetPower > 0)
         return;
     const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
     emit setLoad(trainerControlUserId, gearTargetWatts(m_virtualGear, cad));
 }
 
 void WorkoutDialog::shiftGear(int delta) {
+    if (isWorkoutOver)
+        return;
     const int g = qBound(1, m_virtualGear + delta, kVirtualGearCount);
     if (g == m_virtualGear)
         return;

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -486,7 +486,10 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
     flags = flags | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowMinimizeButtonHint;
 #endif
     this->setWindowFlags(flags);
-    installEventFilter(this); //For Hotkeys
+    // App-level filter so workout hotkeys (start/pause, gear ▲▼, lap, …) work
+    // regardless of which child widget holds focus — otherwise the arrow keys
+    // get eaten by button focus-navigation instead of reaching us.
+    qApp->installEventFilter(this);
     loadInterface();
 
 
@@ -3255,14 +3258,6 @@ void WorkoutDialog::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Minus:
         adjustWorkoutDifficulty(currentWorkoutDifficultyPercentage - 5);
         return;
-    case Qt::Key_Up:        // virtual shift up (harder gear)
-        if (virtualShiftingActive())
-            shiftGear(+1);
-        return;
-    case Qt::Key_Down:      // virtual shift down (easier gear)
-        if (virtualShiftingActive())
-            shiftGear(-1);
-        return;
     case Qt::Key_L:
         if (!event->isAutoRepeat())
             lapButtonPressed();
@@ -4199,7 +4194,10 @@ bool WorkoutDialog::eventFilter(QObject *watched, QEvent *event) {
 
     //    qDebug() << "EventFilter " << watched << "Event:" << event;
 
-    if(event->type() == QEvent::KeyPress) {
+    // Only act while this workout window is the active one (an app-level filter
+    // otherwise sees every key for every window). isActiveWindow() stays true
+    // even when a child button holds focus, but goes false for modal dialogs.
+    if(event->type() == QEvent::KeyPress && isActiveWindow()) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
         if(keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return ) {
             qDebug() << "ENTER PRESSED- STOP/START WORKOUT!" << watched;
@@ -4207,11 +4205,15 @@ bool WorkoutDialog::eventFilter(QObject *watched, QEvent *event) {
             return true; // mark the event as handled
         }
         else if (keyEvent->key() == Qt::Key_Up) {
-            emit increaseDifficulty();
+            // Virtual shifting takes the arrows when enabled; otherwise they keep
+            // their legacy role of nudging workout difficulty.
+            if (virtualShiftingActive()) shiftGear(+1);
+            else emit increaseDifficulty();
             return true;
         }
         else if (keyEvent->key() == Qt::Key_Down) {
-            emit decreaseDifficulty();
+            if (virtualShiftingActive()) shiftGear(-1);
+            else emit decreaseDifficulty();
             return true;
         }
         else if (keyEvent->key() == Qt::Key_Backspace) {

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2391,8 +2391,15 @@ void WorkoutDialog::sendGearLoad() {
     // we'd otherwise send resistance 0 (slope / test / free ride / rest).
     if (!isUsingSlopeMode && currentTargetPower > 0)
         return;
-    const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
-    emit setLoad(trainerControlUserId, gearTargetWatts(m_virtualGear, cad));
+
+    if (m_trainerSupportsResistanceLevel) {
+        // Instant, real-gear feel: a fixed brake the rider's power works against.
+        emit setResistance(trainerControlUserId, VirtualGear::resistanceLevel(m_virtualGear));
+    } else {
+        // Fallback for trainers without 0x04: cadence-aware ERG.
+        const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
+        emit setLoad(trainerControlUserId, gearTargetWatts(m_virtualGear, cad));
+    }
 }
 
 void WorkoutDialog::shiftGear(int delta) {
@@ -2402,10 +2409,7 @@ void WorkoutDialog::shiftGear(int delta) {
     if (g == m_virtualGear)
         return;
     m_virtualGear = g;
-    const double cad = averageCadence1sec.isEmpty() ? -1.0 : averageCadence1sec.at(0);
-    setWindowTitle(QStringLiteral("Gear %1/%2  →  %3 W")
-                       .arg(m_virtualGear).arg(kVirtualGearCount)
-                       .arg(gearTargetWatts(m_virtualGear, cad)));
+    setWindowTitle(QStringLiteral("Gear %1/%2").arg(m_virtualGear).arg(kVirtualGearCount));
     sendGearLoad();
 }
 

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -111,6 +111,8 @@ signals:
     // Commands to FE-C
     void setLoad(int antID, double load);
     void setSlope(int antID, double slope);
+    // Virtual-shifting resistance level (FTMS 0x04, 0.1 units) — instant gear feel.
+    void setResistance(int antID, int levelTenths);
 
     void increaseDifficulty();
     void decreaseDifficulty();
@@ -153,6 +155,11 @@ signals:
 public slots:
     // control list master of QThreads hub
     void addToControlList(int antID, int fromHubNumber);
+
+    /// Whether the connected trainer supports FTMS Set Target Resistance Level
+    /// (0x04). When true, virtual shifting uses resistance level (instant, gear-
+    /// like); otherwise it falls back to cadence-aware ERG.
+    void setResistanceLevelSupported(bool supported) { m_trainerSupportsResistanceLevel = supported; }
 
     ///Connected to Clock
     void update1sec(double totalTimeElapsed_sec);
@@ -305,7 +312,8 @@ private:
     // virtual gear that drives the trainer via the (working) FTMS ERG path,
     // cadence-aware so it feels like a gear rather than a flat ERG clamp.
     static constexpr int kVirtualGearCount = VirtualGear::Count;
-    int  m_virtualGear = (VirtualGear::Count + 1) / 2;   // start mid-gear (8)
+    int  m_virtualGear = (VirtualGear::Count + 1) / 2;   // start mid-gear
+    bool m_trainerSupportsResistanceLevel = false;       // FTMS 0x04 available?
     bool virtualShiftingActive() const;           // trainer connected + enabled
     int  gearTargetWatts(int gear, double cadence) const;
     void sendGearLoad();                          // emit setLoad for current gear

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -60,7 +60,7 @@ public:
     /// the FE-C id came from the removed maximumtrainer.com sensor list,
     /// which left trainerControlUserId at -1 and silently disabled trainer control
     /// for every BLE workout.  Solo hubs ignore the id (1 = solo rider).
-    void enableTrainerControl() { trainerControlUserId = 1; }
+    void enableTrainerControl();   // sets the solo id and reveals the gear indicator
 
     void showVideoPlayer(int choice);
 
@@ -314,10 +314,13 @@ private:
     static constexpr int kVirtualGearCount = VirtualGear::Count;
     int  m_virtualGear = (VirtualGear::Count + 1) / 2;   // start mid-gear
     bool m_trainerSupportsResistanceLevel = false;       // FTMS 0x04 available?
-    bool virtualShiftingActive() const;           // trainer connected + enabled
+    bool virtualShiftingActive() const;           // a trainer is under our control
+    bool ergOwnsThisInterval() const;             // ERG enabled + active power target
+    bool gearsDriveNow() const;                   // gears are the active resistance source
     int  gearTargetWatts(int gear, double cadence) const;
     void sendGearLoad();                          // emit setLoad for current gear
     void shiftGear(int delta);                    // +1 up / -1 down, re-sends
+    void updateGearIndicator();                   // refresh the top-bar gear UI
 
 
     //Internet radio player

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -298,6 +298,17 @@ private:
     bool isUsingSlopeMode;
     QTimer *timerAlertCalibrateCt;
 
+    // Virtual shifting (#293): on single-cog trainers, slope/test intervals
+    // otherwise send resistance 0 and the rider spins out. Up/Down shift a
+    // virtual gear that drives the trainer via the (working) FTMS ERG path,
+    // cadence-aware so it feels like a gear rather than a flat ERG clamp.
+    static constexpr int kVirtualGearCount = 15;
+    int  m_virtualGear = 8;                       // 1..kVirtualGearCount
+    bool virtualShiftingActive() const;           // trainer connected + enabled
+    int  gearTargetWatts(int gear, double cadence) const;
+    void sendGearLoad();                          // emit setLoad for current gear
+    void shiftGear(int delta);                    // +1 up / -1 down, re-sends
+
 
     //Internet radio player
 #ifdef GC_HAVE_QTMULTIMEDIA

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -4,6 +4,8 @@
 #include <QDialog>
 #include <QTime>
 #include <QTimer>
+
+#include "virtual_gear.h"
 #include <QHash>
 #include <QKeyEvent>
 #include <QNetworkReply>
@@ -302,8 +304,8 @@ private:
     // otherwise send resistance 0 and the rider spins out. Up/Down shift a
     // virtual gear that drives the trainer via the (working) FTMS ERG path,
     // cadence-aware so it feels like a gear rather than a flat ERG clamp.
-    static constexpr int kVirtualGearCount = 15;
-    int  m_virtualGear = 8;                       // 1..kVirtualGearCount
+    static constexpr int kVirtualGearCount = VirtualGear::Count;
+    int  m_virtualGear = (VirtualGear::Count + 1) / 2;   // start mid-gear (8)
     bool virtualShiftingActive() const;           // trainer connected + enabled
     int  gearTargetWatts(int gear, double cadence) const;
     void sendGearLoad();                          // emit setLoad for current gear

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -68,6 +68,8 @@ private slots:
     void testFtms_allThree();
     void testFtms_zeroValues();
     void testFtms_tooShort_ignored();
+    void testFtmsFeature_resistanceSupported();
+    void testFtmsFeature_resistanceNotSupported();
 
     // ── Brand-specific trainer simulations ───────────────────────────────────
     void testEliteTrainer_singlePacket();
@@ -435,6 +437,28 @@ void TstBtleHub::testFtms_tooShort_ignored()
     QSignalSpy spySpd(hub, &BtleHub::signal_speed);
     hub->simulateNotification(BTLE_UUID_FTMS_BIKE_DATA, QByteArray(1, '\x00'));
     QCOMPARE(spySpd.count(), 0);
+}
+
+void TstBtleHub::testFtmsFeature_resistanceSupported()
+{
+    // 0x2ACC = [Machine Features (4)][Target Setting Features (4)], LE. This is
+    // the JetBlack Victory's real value; Target Setting Features = 0x0000E00C,
+    // bit2 (Resistance Target Setting) set ⇒ supported = true.
+    QSignalSpy spy(hub, &BtleHub::signal_resistanceLevelSupported);
+    hub->simulateNotification(BTLE_UUID_FTMS_FEATURE, QByteArray::fromHex("874400000ce00000"));
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toBool(), true);
+    QVERIFY(hub->resistanceLevelSupported());
+}
+
+void TstBtleHub::testFtmsFeature_resistanceNotSupported()
+{
+    // Target Setting Features = 0x00000008 (bit3 Power only, bit2 clear).
+    QSignalSpy spy(hub, &BtleHub::signal_resistanceLevelSupported);
+    hub->simulateNotification(BTLE_UUID_FTMS_FEATURE, QByteArray::fromHex("0000000008000000"));
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(0).toBool(), false);
+    QVERIFY(!hub->resistanceLevelSupported());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/zwift/tst_zwift_protocol.cpp
+++ b/tests/zwift/tst_zwift_protocol.cpp
@@ -1,0 +1,147 @@
+/*
+ * tst_zwift_protocol.cpp
+ *
+ * Qt Test suite for the Zwift virtual-shifting protocol codec (Phase 0).
+ * Pure byte-level encode/decode — no hardware. Expected wire bytes are
+ * hand-computed from the protobuf field numbers documented in
+ * notes/zwift-virtual-shifting-plan.md.
+ */
+
+#include <QtTest/QtTest>
+
+#include "zwift_protocol.h"
+
+using namespace ZwiftProtocol;
+
+class TstZwiftProtocol : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ── encodeControlCommand (0x04) ──────────────────────────────────────────
+    void testEncode_gearRatioOnly();
+    void testEncode_powerTargetOnly();
+    void testEncode_negativeIncline_zigzag();
+    void testEncode_empty();
+    void testEncode_fieldOrdering();
+
+    // ── decodeRidingData (0x03) ──────────────────────────────────────────────
+    void testDecode_basicFields();
+    void testDecode_wrongCommandByte();
+    void testDecode_skipsUnknownLengthDelimited();
+    void testDecode_truncatedVarint();
+
+    // ── gear table ───────────────────────────────────────────────────────────
+    void testGears_endpoints();
+    void testGears_monotonic();
+    void testGears_clamped();
+
+    // ── misc ─────────────────────────────────────────────────────────────────
+    void testHandshakePrefix();
+};
+
+void TstZwiftProtocol::testEncode_gearRatioOnly()
+{
+    HubCommand cmd;
+    cmd.physical.gearRatioX10000 = 10000;   // ratio 1.0
+    // [04] [2A 03] field5(msg,len3){ [10] field2=varint(10000=90 4E) }
+    QCOMPARE(encodeControlCommand(cmd).toHex(), QByteArray("042a0310904e"));
+}
+
+void TstZwiftProtocol::testEncode_powerTargetOnly()
+{
+    HubCommand cmd;
+    cmd.powerTargetW = 250;
+    // [04] [18] field3=varint(250=FA 01)
+    QCOMPARE(encodeControlCommand(cmd).toHex(), QByteArray("0418fa01"));
+}
+
+void TstZwiftProtocol::testEncode_negativeIncline_zigzag()
+{
+    HubCommand cmd;
+    cmd.sim.inclineX100 = -150;             // -1.50 % grade; zigzag(-150) = 299
+    // [04] [22 03] field4(msg,len3){ [10] field2=varint(299=AB 02) }
+    QCOMPARE(encodeControlCommand(cmd).toHex(), QByteArray("04220310ab02"));
+}
+
+void TstZwiftProtocol::testEncode_empty()
+{
+    // No fields set — just the command byte, no protobuf body.
+    HubCommand cmd;
+    QCOMPARE(encodeControlCommand(cmd).toHex(), QByteArray("04"));
+}
+
+void TstZwiftProtocol::testEncode_fieldOrdering()
+{
+    // power (f3) then sim (f4) then physical (f5), in ascending field order.
+    HubCommand cmd;
+    cmd.powerTargetW             = 1;       // [18 01]
+    cmd.sim.inclineX100          = 0;        // f4 msg, len 2: [22 02 10 00]
+    cmd.physical.gearRatioX10000 = 1;        // f5 msg, len 2: [2A 02 10 01]
+    QCOMPARE(encodeControlCommand(cmd).toHex(),
+             QByteArray("04" "1801" "2202" "1000" "2a02" "1001"));
+}
+
+void TstZwiftProtocol::testDecode_basicFields()
+{
+    // 03 | f1=200 (C8 01) | f2=90 (5A) | f3=3050 (EA 17) | f4=145 (91 01)
+    const QByteArray frame = QByteArray::fromHex("0308c801105a18ea17209101");
+    RidingData d;
+    QVERIFY(decodeRidingData(frame, d));
+    QCOMPARE(d.power,     quint32(200));
+    QCOMPARE(d.cadence,   quint32(90));
+    QCOMPARE(d.speedX100, quint32(3050));
+    QCOMPARE(d.hr,        quint32(145));
+}
+
+void TstZwiftProtocol::testDecode_wrongCommandByte()
+{
+    // A 0x04 (control) frame must not parse as riding data.
+    const QByteArray frame = QByteArray::fromHex("0408c801");
+    RidingData d;
+    QVERIFY(!decodeRidingData(frame, d));
+    QVERIFY(!decodeRidingData(QByteArray(), d));
+}
+
+void TstZwiftProtocol::testDecode_skipsUnknownLengthDelimited()
+{
+    // 03 | f1=100 (64) | f7 len-delimited 2 bytes (3A 02 AA BB) — skipped.
+    const QByteArray frame = QByteArray::fromHex("03" "0864" "3a02aabb");
+    RidingData d;
+    QVERIFY(decodeRidingData(frame, d));
+    QCOMPARE(d.power, quint32(100));
+}
+
+void TstZwiftProtocol::testDecode_truncatedVarint()
+{
+    // Continuation bit set on the final byte → incomplete varint → reject.
+    const QByteArray frame = QByteArray::fromHex("0308ff");
+    RidingData d;
+    QVERIFY(!decodeRidingData(frame, d));
+}
+
+void TstZwiftProtocol::testGears_endpoints()
+{
+    QCOMPARE(ZwiftGears::ratioX10000ForGear(0), quint32(7500));
+    QCOMPARE(ZwiftGears::ratioX10000ForGear(ZwiftGears::Count - 1), quint32(54900));
+}
+
+void TstZwiftProtocol::testGears_monotonic()
+{
+    for (int g = 1; g < ZwiftGears::Count; ++g)
+        QVERIFY(ZwiftGears::ratioForGear(g) > ZwiftGears::ratioForGear(g - 1));
+}
+
+void TstZwiftProtocol::testGears_clamped()
+{
+    QCOMPARE(ZwiftGears::ratioForGear(-5),  ZwiftGears::ratioForGear(0));
+    QCOMPARE(ZwiftGears::ratioForGear(999), ZwiftGears::ratioForGear(ZwiftGears::Count - 1));
+}
+
+void TstZwiftProtocol::testHandshakePrefix()
+{
+    QVERIFY(rideOnHandshake().startsWith(QByteArrayLiteral("RideOn")));
+}
+
+QTEST_MAIN(TstZwiftProtocol)
+#include "tst_zwift_protocol.moc"

--- a/tests/zwift/tst_zwift_protocol.cpp
+++ b/tests/zwift/tst_zwift_protocol.cpp
@@ -46,6 +46,7 @@ private slots:
     void testGearWatts_cadenceFallbackAndClamp();
     void testGearWatts_ftpScaling();
     void testGearWatts_gearClamped();
+    void testResistanceLevel_monotonicEndpointsClamp();
 };
 
 void TstZwiftProtocol::testEncode_gearRatioOnly()
@@ -195,6 +196,22 @@ void TstZwiftProtocol::testGearWatts_gearClamped()
              VirtualGear::targetWatts(1,   85, 250));
     QCOMPARE(VirtualGear::targetWatts(999, 85, 250),
              VirtualGear::targetWatts(VirtualGear::Count, 85, 250));
+}
+
+void TstZwiftProtocol::testResistanceLevel_monotonicEndpointsClamp()
+{
+    // Endpoints map to the configured easiest/hardest levels.
+    QCOMPARE(VirtualGear::resistanceLevel(1), VirtualGear::EasiestResistance);
+    QCOMPARE(VirtualGear::resistanceLevel(VirtualGear::Count), VirtualGear::HardestResistance);
+    // Strictly increasing across gears.
+    for (int g = 2; g <= VirtualGear::Count; ++g)
+        QVERIFY(VirtualGear::resistanceLevel(g) > VirtualGear::resistanceLevel(g - 1));
+    // Clamped to the trainer's advertised [min,max].
+    QCOMPARE(VirtualGear::resistanceLevel(VirtualGear::Count, 0, 50), 50);
+    QCOMPARE(VirtualGear::resistanceLevel(1, 20, 100), 20);
+    // Out-of-range gears clamp to the ends.
+    QCOMPARE(VirtualGear::resistanceLevel(0),   VirtualGear::resistanceLevel(1));
+    QCOMPARE(VirtualGear::resistanceLevel(999), VirtualGear::resistanceLevel(VirtualGear::Count));
 }
 
 QTEST_MAIN(TstZwiftProtocol)

--- a/tests/zwift/tst_zwift_protocol.cpp
+++ b/tests/zwift/tst_zwift_protocol.cpp
@@ -10,6 +10,7 @@
 #include <QtTest/QtTest>
 
 #include "zwift_protocol.h"
+#include "virtual_gear.h"
 
 using namespace ZwiftProtocol;
 
@@ -38,6 +39,13 @@ private slots:
 
     // ── misc ─────────────────────────────────────────────────────────────────
     void testHandshakePrefix();
+
+    // ── virtual gear model (#293) ────────────────────────────────────────────
+    void testGearWatts_monotonicInGear();
+    void testGearWatts_risesWithCadence();
+    void testGearWatts_cadenceFallbackAndClamp();
+    void testGearWatts_ftpScaling();
+    void testGearWatts_gearClamped();
 };
 
 void TstZwiftProtocol::testEncode_gearRatioOnly()
@@ -141,6 +149,52 @@ void TstZwiftProtocol::testGears_clamped()
 void TstZwiftProtocol::testHandshakePrefix()
 {
     QVERIFY(rideOnHandshake().startsWith(QByteArrayLiteral("RideOn")));
+}
+
+void TstZwiftProtocol::testGearWatts_monotonicInGear()
+{
+    // Harder gear ⇒ strictly more watts at a fixed cadence/FTP.
+    for (int g = 2; g <= VirtualGear::Count; ++g)
+        QVERIFY(VirtualGear::targetWatts(g, 85, 250)
+                > VirtualGear::targetWatts(g - 1, 85, 250));
+}
+
+void TstZwiftProtocol::testGearWatts_risesWithCadence()
+{
+    // Same gear, faster pedaling ⇒ more watts (the "feels like a gear" property).
+    QVERIFY(VirtualGear::targetWatts(8, 100, 250)
+            > VirtualGear::targetWatts(8, 70, 250));
+}
+
+void TstZwiftProtocol::testGearWatts_cadenceFallbackAndClamp()
+{
+    // cadence<=0 falls back to the reference cadence (== explicit RefCadence).
+    QCOMPARE(VirtualGear::targetWatts(8, 0,   250),
+             VirtualGear::targetWatts(8, VirtualGear::RefCadence, 250));
+    QCOMPARE(VirtualGear::targetWatts(8, -1,  250),
+             VirtualGear::targetWatts(8, VirtualGear::RefCadence, 250));
+    // Cadence is clamped to [40,120], so extremes saturate rather than explode.
+    QCOMPARE(VirtualGear::targetWatts(8, 200, 250),
+             VirtualGear::targetWatts(8, 120, 250));
+    QCOMPARE(VirtualGear::targetWatts(8, 10,  250),
+             VirtualGear::targetWatts(8, 40,  250));
+}
+
+void TstZwiftProtocol::testGearWatts_ftpScaling()
+{
+    // Higher FTP ⇒ higher targets; ftp<=0 uses the default.
+    QVERIFY(VirtualGear::targetWatts(10, 85, 300)
+            > VirtualGear::targetWatts(10, 85, 150));
+    QCOMPARE(VirtualGear::targetWatts(10, 85, 0),
+             VirtualGear::targetWatts(10, 85, VirtualGear::DefaultFtp));
+}
+
+void TstZwiftProtocol::testGearWatts_gearClamped()
+{
+    QCOMPARE(VirtualGear::targetWatts(0,   85, 250),
+             VirtualGear::targetWatts(1,   85, 250));
+    QCOMPARE(VirtualGear::targetWatts(999, 85, 250),
+             VirtualGear::targetWatts(VirtualGear::Count, 85, 250));
 }
 
 QTEST_MAIN(TstZwiftProtocol)

--- a/tests/zwift/zwift_tests.pro
+++ b/tests/zwift/zwift_tests.pro
@@ -1,0 +1,31 @@
+###############################################################################
+# tests/zwift/zwift_tests.pro
+#
+# Standalone Qt Test project for the Zwift virtual-shifting protocol codec
+# (Phase 0). Pure byte-level encode/decode — no QtBluetooth, no GUI.
+#
+# Build:
+#   qmake6 zwift_tests.pro && make
+# Run:
+#   ./zwift_tests -v2
+###############################################################################
+
+QT       += core testlib
+QT       -= gui
+
+CONFIG   += qt c++17 console
+CONFIG   -= app_bundle
+
+TARGET   = zwift_tests
+TEMPLATE = app
+
+DESTDIR  = ../../build/tests
+
+INCLUDEPATH += ../../src/btle/zwift
+
+SOURCES += \
+    ../../src/btle/zwift/zwift_protocol.cpp \
+    tst_zwift_protocol.cpp
+
+HEADERS += \
+    ../../src/btle/zwift/zwift_protocol.h


### PR DESCRIPTION
## Virtual shifting for single-cog / Zwift Cog trainers (closes #293)

On a single-cog trainer (e.g. a Zwift Cog), free rides and FTP tests sent slope 0%
and left the rider with **no usable resistance** — they'd spin out and couldn't
complete the workout (#293). This adds **virtual shifting**: rider-controlled
gears that drive trainer resistance, so a single-cog setup feels like a real drivetrain.

### What it does
- **FTMS Set Target Resistance Level (`0x04`)** maps each virtual gear (1–24) to a
  fixed resistance level → instant, real-gear feel (fixed resistance, power follows
  effort). Falls back to **cadence-aware ERG** on trainers without `0x04`.
- **Opt-in**: a new **"Virtual shifting (Zwift Cog / single-gear setups)"** checkbox
  on the Bluetooth / Smart Trainer page, **default off** — normal-cassette setups are
  unaffected (they keep slope-0 free ride / their real gears).
- **Controls**: **Up/Down arrow keys** and on-screen **▲/▼**; a `▼ ⚙ N/24 ▲` top-bar
  indicator shows the gear, dimming to `ERG` during power intervals.

### Why FTMS, not the Zwift protocol
We explored Zwift's proprietary trainer protocol first (unencrypted on the trainer).
The JetBlack Victory **acknowledges** those commands but **never actuates resistance**
for us (flashing LED = no controlled session), whereas standard FTMS — the channel the
app already uses — works (solid LED, real resistance). Full protocol findings + the
Zwift Click roadmap are in `notes/zwift-cog-protocol-findings.md`.

### Validation
- Validated end-to-end on a **JetBlack Victory** (fw 4.29): per-gear resistance,
  instant shifts, hotkeys, opt-in gating.
- `tests/zwift` 21/21, `tests/btle` 56/56 (incl. FTMS feature-flag detection against
  the real trainer value). App builds; docs updated.

### Notes for review
- Dev-only BLE exploration tools sit behind CLI flags (`--zwift-probe`,
  `--trainer-gear-test`, …) — invisible in normal use; kept for the Click work, easy
  to strip if preferred.
- The Zwift **Click** (wireless shifter) is **not** included — its button channel is
  encrypted (X25519/AES); keyboard/on-screen shifting covers the feature today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
