### PR TITLE
fix: match workout search to saved filename for names with special chars (#294)

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -523,7 +523,11 @@ void MainWindow::onIntervalsIcuWorkoutDownloaded() {
     // Refresh the workout list and navigate to the imported workout
     ui->tab_workout1->refreshUserWorkout();
     ui->tabWidget_workout->setCurrentIndex(0);
-    ui->tab_workout1->setFilterWorkoutName(workout.getName());
+    // Filter on the SAVED filename stem, not the raw name: the workout list
+    // derives a workout's name from its filename, so a colon/slash/etc. removed
+    // for the filename (e.g. "A:B" → "A_B") must be mirrored in the search term
+    // or the just-imported workout can't be found (#294).
+    ui->tab_workout1->setFilterWorkoutName(uniqueSafeName);
     ftb->setCurrentIndex(0);
 
     ui->widget_bottomMenu->setGeneralMessage(
@@ -595,7 +599,9 @@ void MainWindow::goToWorkoutNameFilterFromIntervals(const QString &workoutName) 
             if (XmlUtil::createWorkoutXml(imported, destPath)) {
                 ui->tab_workout1->refreshUserWorkout();
                 ui->tabWidget_workout->setCurrentIndex(0);
-                ui->tab_workout1->setFilterWorkoutName(imported.getName());
+                // Filter on the saved filename stem so a sanitised name (e.g.
+                // colon → "_") still matches the listed workout (#294).
+                ui->tab_workout1->setFilterWorkoutName(uniqueName);
                 ftb->setCurrentIndex(0);
                 ui->widget_bottomMenu->setGeneralMessage(
                     tr("Workout '%1' imported from Intervals.icu.").arg(imported.getName()), 5000);


### PR DESCRIPTION
## Workout search fails after Intervals.icu download when the name has a colon (closes #294)

After downloading an Intervals.icu workout whose name contains a colon — or any of
`/ \ : * ? " < > |` — the workout couldn't be found in the list afterwards.

### Cause
- The workout list derives a workout's display name from its **filename**
  (`parseFileNameFromPath` → `baseName()`).
- On import, those characters are sanitized to `_` for the filename
  (`Test: VO2` → `Test_ VO2.workout`), so the listed name is `Test_ VO2`.
- But the search box was auto-filled with the **raw** name (`Test: VO2`), which
  never matches the sanitized listed name → the just-imported workout looks missing.

### Fix
Fill the search filter with the **same sanitized filename stem** used to save the
file (`uniqueSafeName` / `uniqueName`), in both Intervals.icu import paths
(`onIntervalsIcuWorkoutDownloaded` and `goToWorkoutNameFilterFromIntervals`).

### Platform behaviour
The sanitiser and the search-fill both run **unconditionally — no per-platform
branching** — so Windows / macOS / Linux / Wasm behave identically. (A colon is
only *illegal* as a filename on Windows, but we sanitize it everywhere, so the
bug reproduced on all platforms and is now fixed on all of them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
