### PR TITLE
fix: parse Intervals.icu power-range intervals instead of 0 W (#295)

### DIFF
--- a/src/persistence/file/importerworkoutzwo.cpp
+++ b/src/persistence/file/importerworkoutzwo.cpp
@@ -92,6 +92,17 @@ Workout ImporterWorkoutZwo::importFromByteArray(const QByteArray &data,
                 if (tag == QStringLiteral("SteadyState")) {
                     int    dur   = intAttr("Duration");
                     double power = dblAttr("Power");
+                    // Intervals.icu exports a power-range step as a SteadyState
+                    // with PowerLow/PowerHigh and no single Power — use the
+                    // midpoint so it matches the manual ERG/MRC import instead of
+                    // parsing as 0 W (#295).
+                    if (power <= 0.0 &&
+                        (attrs.hasAttribute(QLatin1String("PowerLow")) ||
+                         attrs.hasAttribute(QLatin1String("PowerHigh")))) {
+                        const double lo = dblAttr("PowerLow");
+                        const double hi = dblAttr("PowerHigh", lo);
+                        power = (lo + hi) / 2.0;
+                    }
                     if (dur > 0)
                         intervals.append(makeFlatInterval(dur, power));
 

--- a/tests/fixtures/steady_state_range.zwo
+++ b/tests/fixtures/steady_state_range.zwo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<workout_file>
+    <name>Steady State Range Test</name>
+    <author>Test</author>
+    <description>Intervals.icu exports a power-range step as a SteadyState with PowerLow/PowerHigh (no single Power). Expected: midpoint (0.43+0.75)/2 = 0.59.</description>
+    <workout>
+        <SteadyState Duration="3600" PowerLow="0.43" PowerHigh="0.75"/>
+    </workout>
+</workout_file>

--- a/tests/intervals_icu/tst_importer_workout_zwo.cpp
+++ b/tests/intervals_icu/tst_importer_workout_zwo.cpp
@@ -50,6 +50,7 @@ private slots:
     // ── Fixture file parsing ─────────────────────────────────────────────────
     void testSteadyState_intervalCount();
     void testSteadyState_power();
+    void testSteadyState_powerRange();
     void testSteadyState_duration();
     void testSteadyState_name();
 
@@ -110,6 +111,21 @@ void TstImporterWorkoutZwo::testSteadyState_power()
     QCOMPARE(iv.getPowerStepType(), Interval::FLAT);
     QVERIFY(qAbs(iv.getFTP_start() - 0.75) < 1e-6);
     QVERIFY(qAbs(iv.getFTP_end()   - 0.75) < 1e-6);
+}
+
+// Intervals.icu exports a power-range step as a SteadyState carrying
+// PowerLow/PowerHigh instead of a single Power. It must parse as the midpoint,
+// not 0 W (#295).
+void TstImporterWorkoutZwo::testSteadyState_powerRange()
+{
+    const QByteArray data = readFixture("steady_state_range.zwo");
+    Workout w = ImporterWorkoutZwo::importFromByteArray(data, "test");
+    QVERIFY(!w.getLstInterval().isEmpty());
+    const Interval iv = w.getLstInterval().first();
+    QCOMPARE(iv.getPowerStepType(), Interval::FLAT);
+    // (0.43 + 0.75) / 2 = 0.59  (NOT 0)
+    QVERIFY(qAbs(iv.getFTP_start() - 0.59) < 1e-6);
+    QVERIFY(qAbs(iv.getFTP_end()   - 0.59) < 1e-6);
 }
 
 void TstImporterWorkoutZwo::testSteadyState_duration()


### PR DESCRIPTION
## Intervals.icu workouts import 0% FTP / 0 W for power-range intervals (closes #295)

When a workout is synced from Intervals.icu, intervals that have a **power range**
(e.g. "43–75%") imported as **0% FTP / 0 W**, even though the source data is valid.
Manual ERG/MRC import of the same workout was correct — confirming the problem is in
the automatic (ZWO) sync path, not the data.

### Cause
The auto-sync parses the downloaded **ZWO**. Its `<SteadyState>` handler read only
the `Power` attribute, but Intervals.icu exports a power-range step as a
`<SteadyState>` carrying **`PowerLow`/`PowerHigh`** and **no single `Power`** — so
`Power` defaulted to `0` and the interval became 0 W.

### Fix
When a `SteadyState` has no positive `Power` but does carry `PowerLow`/`PowerHigh`,
use the **midpoint** (`(0.43 + 0.75) / 2 = 0.59`), matching what the manual ERG/MRC
import already produces. Standard single-`Power` steps are unchanged.

### Tests
Adds `tests/fixtures/steady_state_range.zwo` + a unit test; the ZWO importer suite
passes 23/23. App builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
