### PR TITLE
feat(zwift): Zwift Click v2 controller support via the trainer's FC82 relay

### DIFF
--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -829,6 +829,40 @@
               is in control); it becomes active again on free / test intervals.</li>
         </ul>
 
+        <h3>Zwift Click v2 controllers</h3>
+        <p>
+          You can shift (and control more of the workout) with a pair of <strong>Zwift Click v2</strong>
+          controllers. They're read <strong>through your trainer</strong> — the trainer holds the link to
+          the controllers, so there's nothing to pair separately and the connection stays solid for the
+          whole ride.
+        </p>
+        <ul>
+          <li><strong>Pair your trainer</strong> as usual — the controllers are read through it, so the
+              trainer must be connected for them to work.</li>
+          <li>Make sure <strong>Virtual shifting</strong> is enabled (on the <em>Bluetooth / Smart
+              Trainer</em> settings page) so the shift paddles change gears.</li>
+          <li><strong>Once the workout window is open, press any controller button to wake it</strong> —
+              the buttons then start working automatically, no separate pairing step.</li>
+        </ul>
+        <p>The buttons map to these workout actions:</p>
+        <div class="guide-table-wrap">
+          <table class="guide-table">
+            <thead>
+              <tr><th>Control</th><th>Action</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><strong>Right paddle</strong></td><td>Shift up — harder gear</td></tr>
+              <tr><td><strong>Left paddle</strong></td><td>Shift down — easier gear</td></tr>
+              <tr><td><strong>Y</strong></td><td>Increase difficulty (+1% FTP)</td></tr>
+              <tr><td><strong>B</strong></td><td>Decrease difficulty (−1% FTP)</td></tr>
+              <tr><td><strong>A</strong></td><td>Start / pause the workout</td></tr>
+              <tr><td><strong>Z</strong></td><td>Stop / start the radio music</td></tr>
+              <tr><td><strong>D-pad ◀ / ▶</strong></td><td>Previous / next radio station</td></tr>
+              <tr><td><strong>D-pad ▲ / ▼</strong></td><td>Radio volume up / down</td></tr>
+            </tbody>
+          </table>
+        </div>
+
         <h3>ERG tips</h3>
         <ul>
           <li>Maintain a <strong>smooth, consistent cadence</strong> (85–95 rpm is typical). Abrupt cadence changes

--- a/src/btle/btle.pri
+++ b/src/btle/btle.pri
@@ -31,11 +31,13 @@ contains(QMAKE_PLATFORM, wasm) {
         $$PWD/btle_uuids.h \
         $$PWD/simulator_hub.h
 
-    # Read-only Zwift exploration harness (Phase 1) needs native QtBluetooth.
+    # Native-only Zwift harness + the Click-via-trainer relay (QtBluetooth).
     SOURCES += $$PWD/zwift/zwift_probe.cpp \
-               $$PWD/zwift/trainer_gear_test.cpp
+               $$PWD/zwift/trainer_gear_test.cpp \
+               $$PWD/zwift/zwift_click_relay.cpp
     HEADERS += $$PWD/zwift/zwift_probe.h \
-               $$PWD/zwift/trainer_gear_test.h
+               $$PWD/zwift/trainer_gear_test.h \
+               $$PWD/zwift/zwift_click_relay.h
 }
 
 # Zwift virtual-shifting protocol codec — pure bytes, platform-independent.

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -1,5 +1,7 @@
 #include "btle_hub.h"
 #include "btle_uuids.h"
+#include "zwift/zwift_click_relay.h"
+#include "zwift/zwift_protocol.h"
 
 #include "logger.h"
 #include <QLowEnergyDescriptor>
@@ -22,6 +24,8 @@ static const QBluetoothUuid CyclingPower          (QBluetoothUuid::CyclingPower)
 static const QBluetoothUuid FitnessMachine        (quint16(0x1826));
 // Battery Service – standard BT SIG service for battery level percentage
 static const QBluetoothUuid BatteryService        (quint16(0x180F));
+// Zwift proprietary trainer service (FC82) – relays a linked Zwift Click v2.
+static const QBluetoothUuid ZwiftService          (QString::fromLatin1(ZwiftProtocol::Uuid::Service));
 
 // Characteristics
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -111,6 +115,12 @@ void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
     delete m_ftmsService;     m_ftmsService     = nullptr;
     delete m_moxyService;     m_moxyService     = nullptr;
     delete m_batteryService;  m_batteryService  = nullptr;
+    // Keep the Click relay across reconnects so the workout's button wiring stays
+    // valid; just detach it from the service we're about to delete (it re-attaches
+    // when FC82 is re-discovered). The relay (parented to this) is freed with us.
+    if (m_clickRelay)
+        m_clickRelay->detach();
+    delete m_zwiftService;    m_zwiftService    = nullptr;
 
     m_firstCscMeasurement   = true;
     m_ftmsControlRequested  = false;
@@ -357,6 +367,17 @@ void BtleHub::onServiceDiscovered(const QBluetoothUuid &serviceUuid)
             connect(m_batteryService, &QLowEnergyService::characteristicRead,
                     this, &BtleHub::onCharacteristicChanged);
             setupService(m_batteryService);
+        }
+    }
+    else if (serviceUuid == BtleUuid::ZwiftService) {
+        // Zwift Click v2 read through the trainer's FC82 relay. The relay drives
+        // its own setup/notifications on this service (BtleHub doesn't parse it).
+        m_zwiftService = m_controller->createServiceObject(serviceUuid, this);
+        if (m_zwiftService) {
+            if (!m_clickRelay)
+                m_clickRelay = new ZwiftClickRelay(this);
+            m_clickRelay->attachService(m_zwiftService);
+            LOG_INFO("BtleHub", QStringLiteral("Zwift FC82 found — Click relay enabled"));
         }
     }
 }

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -23,6 +23,8 @@
  *   - Fitness Machine Service / FTMS   (0x1826)  indoor-bike data + resistance control
  *   - Moxy Muscle Oxygen Service (0xAAB0) SmO2 + tHb
  */
+class ZwiftClickRelay;
+
 class BtleHub : public QObject
 {
     Q_OBJECT
@@ -30,6 +32,11 @@ class BtleHub : public QObject
 public:
     explicit BtleHub(QObject *parent = nullptr);
     ~BtleHub();
+
+    // If the connected trainer exposes the Zwift FC82 service, a linked Zwift
+    // Click v2 is read through the trainer's relay (auto-detected — no opt-in;
+    // the relay no-ops until a Click is woken). Non-null only for such trainers.
+    ZwiftClickRelay *zwiftClickRelay() const { return m_clickRelay; }
 
     // Connect to the selected BLE device. Call after the scanner dialog has
     // chosen a device.
@@ -153,6 +160,10 @@ private:
     QLowEnergyService *m_ftmsService     = nullptr;
     QLowEnergyService *m_moxyService     = nullptr;
     QLowEnergyService *m_batteryService  = nullptr;
+    QLowEnergyService *m_zwiftService    = nullptr;   // FC82 (Zwift Click relay)
+
+    // Zwift Click v2 read via the trainer's FC82 relay (auto-detected). Owned here.
+    ZwiftClickRelay *m_clickRelay = nullptr;
 
     bool m_ftmsControlRequested = false;
     bool m_ftmsControlGranted   = false;

--- a/src/btle/zwift/zwift_click_relay.cpp
+++ b/src/btle/zwift/zwift_click_relay.cpp
@@ -22,7 +22,7 @@ const char *const kSetupSteps[] = {
 const QByteArray kZwiftClickName = QByteArrayLiteral("Zwift Click");
 
 // Relayed RideOn that makes the linked Click start streaming buttons (the one
-// command that actually matters — see notes/zwift-cog-protocol-findings.md).
+// command that actually matters).
 QByteArray relayedRideOn() { return QByteArray::fromHex("4e08021208526964654f6e0203"); }
 
 constexpr int  kButtonDebounceMs = 300;   // one physical press counts once

--- a/src/btle/zwift/zwift_click_relay.cpp
+++ b/src/btle/zwift/zwift_click_relay.cpp
@@ -1,0 +1,275 @@
+#include "zwift_click_relay.h"
+
+#include "zwift_protocol.h"
+#include "logger.h"
+
+#include <QDateTime>
+#include <QLowEnergyDescriptor>
+#include <QTimer>
+
+namespace {
+const QByteArray kNotifyOn   = QByteArray::fromHex("0100");
+const QByteArray kIndicateOn = QByteArray::fromHex("0200");
+
+// The trainer-side relay setup written to the FC82 control point before the
+// Click is connected (configures the trainer's ZCS relay). Sent once, paced.
+const char *const kSetupSteps[] = {
+    "410805", "000800", "442001", "440801",
+    "410805", "000810", "0008800a", "450801",
+};
+
+// "Zwift Click" name bytes the trainer announces in its 0x47 device frame.
+const QByteArray kZwiftClickName = QByteArrayLiteral("Zwift Click");
+
+// Relayed RideOn that makes the linked Click start streaming buttons (the one
+// command that actually matters — see notes/zwift-cog-protocol-findings.md).
+QByteArray relayedRideOn() { return QByteArray::fromHex("4e08021208526964654f6e0203"); }
+
+constexpr int  kButtonDebounceMs = 300;   // one physical press counts once
+constexpr int  kRideOnDelayMs    = 4500;  // 441002 → RideOn gap (matches capture)
+constexpr int  kProgressMs       = 4000;  // re-send RideOn if no frames yet
+constexpr int  kMaxRetries       = 8;
+constexpr int  kWatchdogMs       = 5000;
+constexpr int  kStallMs          = 20000; // >20 s silent ⇒ stalled
+} // namespace
+
+ZwiftClickRelay::ZwiftClickRelay(QObject *parent) : QObject(parent)
+{
+    m_notifyUuid   = QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::Measurement));
+    m_controlUuid  = QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::ControlPoint));
+    m_indicateUuid = QBluetoothUuid(QString::fromLatin1(ZwiftProtocol::Uuid::Response));
+}
+
+void ZwiftClickRelay::detach()
+{
+    if (m_watchdog)
+        m_watchdog->stop();
+    if (m_fc82) {
+        disconnect(m_fc82, nullptr, this, nullptr);   // drop links to the dying service
+        m_fc82 = nullptr;
+    }
+    // Reset the handshake state so a later attach starts over; pending timers
+    // become no-ops while m_fc82 is null.
+    m_setupDone = m_connectSent = m_rideOnSent = m_sawRelay = m_stalled = false;
+    m_retries = 0;
+    m_lastRelayMs = 0;
+    m_lastBitmap = 0xFFFFFFFFu;
+}
+
+void ZwiftClickRelay::attachService(QLowEnergyService *fc82Service)
+{
+    if (!fc82Service || fc82Service == m_fc82)
+        return;
+    detach();                          // clear any previous service + state
+    m_fc82 = fc82Service;
+    if (!m_clock.isValid())
+        m_clock.start();
+
+    connect(m_fc82, &QLowEnergyService::stateChanged,
+            this, &ZwiftClickRelay::onServiceStateChanged);
+    connect(m_fc82, &QLowEnergyService::characteristicChanged,
+            this, &ZwiftClickRelay::onCharacteristicChanged);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const auto discovered  = QLowEnergyService::RemoteServiceDiscovered;
+    const auto discovering = QLowEnergyService::RemoteServiceDiscovering;
+#else
+    const auto discovered  = QLowEnergyService::ServiceDiscovered;
+    const auto discovering = QLowEnergyService::DiscoveringServices;
+#endif
+    if (m_fc82->state() == discovered)
+        beginSetup();
+    else if (m_fc82->state() != discovering)
+        m_fc82->discoverDetails();
+}
+
+void ZwiftClickRelay::onServiceStateChanged(QLowEnergyService::ServiceState state)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (state != QLowEnergyService::RemoteServiceDiscovered)
+#else
+    if (state != QLowEnergyService::ServiceDiscovered)
+#endif
+        return;
+    beginSetup();
+}
+
+void ZwiftClickRelay::beginSetup()
+{
+    if (m_setupDone || !m_fc82)
+        return;
+    m_setupDone = true;
+
+    // Subscribe FC82 notify + indicate so we receive the relayed Click frames.
+    for (const QLowEnergyCharacteristic &c : m_fc82->characteristics()) {
+        const QLowEnergyDescriptor cccd =
+            c.descriptor(QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
+        if (!cccd.isValid())
+            continue;
+        if (c.properties() & QLowEnergyCharacteristic::Notify)
+            m_fc82->writeDescriptor(cccd, kNotifyOn);
+        else if (c.properties() & QLowEnergyCharacteristic::Indicate)
+            m_fc82->writeDescriptor(cccd, kIndicateOn);
+    }
+
+    // RideOn handshake, then the trainer-relay setup bytes (paced so we don't
+    // overrun the control point).
+    writeControl(ZwiftProtocol::rideOnTrainerHandshake());
+    int delay = 0;
+    for (const char *hex : kSetupSteps) {
+        const QByteArray bytes = QByteArray::fromHex(hex);
+        delay += 120;
+        QTimer::singleShot(delay, this, [this, bytes] { writeControl(bytes); });
+    }
+    LOG_INFO("ZwiftClickRelay", QStringLiteral("FC82 relay armed — waiting for the Click"));
+}
+
+void ZwiftClickRelay::writeControl(const QByteArray &bytes)
+{
+    if (!m_fc82)
+        return;
+    const QLowEnergyCharacteristic cp = m_fc82->characteristic(m_controlUuid);
+    if (!cp.isValid())
+        return;
+    const auto mode = (cp.properties() & QLowEnergyCharacteristic::WriteNoResponse)
+                          ? QLowEnergyService::WriteWithoutResponse
+                          : QLowEnergyService::WriteWithResponse;
+    m_fc82->writeCharacteristic(cp, bytes, mode);
+}
+
+void ZwiftClickRelay::onCharacteristicChanged(const QLowEnergyCharacteristic &c,
+                                              const QByteArray &value)
+{
+    Q_UNUSED(c);
+    if (value.isEmpty())
+        return;
+
+    // Any 0x4e frame is a relayed Click frame (handshake/status/button) → live.
+    if (m_rideOnSent && quint8(value.at(0)) == 0x4e) {
+        m_lastRelayMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_stalled) {
+            m_stalled = false;
+            emit relayActiveChanged(true);
+            LOG_WARN("ZwiftClickRelay", QStringLiteral("relay RESUMED — Click reconnected"));
+        }
+        if (!m_sawRelay) {
+            m_sawRelay = true;
+            emit relayActiveChanged(true);
+            LOG_INFO("ZwiftClickRelay", QStringLiteral("Click relaying through trainer — live"));
+            if (!m_watchdog) {
+                m_watchdog = new QTimer(this);
+                connect(m_watchdog, &QTimer::timeout, this, &ZwiftClickRelay::watchdogTick);
+            }
+            m_watchdog->start(kWatchdogMs);
+        }
+    }
+
+    // Decode a relayed button frame and dispatch transitions.
+    quint32 bitmap;
+    if (ZwiftProtocol::decodeRelayedClickButtons(value, bitmap)) {
+        handleBitmap(bitmap);
+        return;
+    }
+
+    // The trainer announced the linked Click → ask it to connect (once).
+    if (!m_connectSent && quint8(value.at(0)) == 0x47 && value.contains(kZwiftClickName))
+        requestClickConnect();
+}
+
+void ZwiftClickRelay::requestClickConnect()
+{
+    m_connectSent = true;
+    writeControl(QByteArray::fromHex("441002"));
+    // The trainer needs a few seconds to link + discover the Click before a
+    // relayed RideOn can reach it; checkProgress retries if we're early.
+    QTimer::singleShot(kRideOnDelayMs, this, [this] { relayRideOn(false); });
+    LOG_INFO("ZwiftClickRelay", QStringLiteral("Click announced — connecting via trainer"));
+}
+
+void ZwiftClickRelay::relayRideOn(bool isRetry)
+{
+    if (!m_fc82 || m_sawRelay)
+        return;                 // detached, or already streaming
+    if (isRetry && m_retries >= kMaxRetries) {
+        LOG_WARN("ZwiftClickRelay",
+                 QStringLiteral("no relayed frames after %1 attempts").arg(m_retries));
+        return;
+    }
+    if (isRetry)
+        ++m_retries;
+    m_rideOnSent = true;
+    writeControl(relayedRideOn());
+    QTimer::singleShot(kProgressMs, this, &ZwiftClickRelay::checkProgress);
+}
+
+void ZwiftClickRelay::checkProgress()
+{
+    if (m_sawRelay)
+        return;
+    relayRideOn(/*isRetry=*/true);
+}
+
+void ZwiftClickRelay::watchdogTick()
+{
+    if (!m_fc82 || !m_sawRelay)
+        return;
+    const qint64 quietMs = QDateTime::currentMSecsSinceEpoch() - m_lastRelayMs;
+    if (quietMs <= kStallMs)
+        return;
+    if (!m_stalled) {
+        m_stalled = true;
+        emit relayActiveChanged(false);
+        LOG_WARN("ZwiftClickRelay",
+                 QStringLiteral("relay quiet %1s — re-connecting the Click").arg(quietMs / 1000));
+    }
+    // A long silence means the Click left the trainer's range and the trainer
+    // dropped its link (LED back to flashing) — RideOn alone won't bring it back.
+    // Re-issue the connect (441002) so the trainer re-links it, then re-arm.
+    writeControl(QByteArray::fromHex("441002"));
+    writeControl(relayedRideOn());
+}
+
+void ZwiftClickRelay::handleBitmap(quint32 bitmap)
+{
+    const quint32 changed = bitmap ^ m_lastBitmap;
+    if (!changed) {
+        m_lastBitmap = bitmap;
+        return;
+    }
+    for (int bit = 0; bit < 32; ++bit) {
+        if (!(changed & (1u << bit)))
+            continue;
+        if (ZwiftProtocol::clickButtonPressed(bitmap, bit) && acceptButton(bit))
+            dispatchButton(bit);
+    }
+    m_lastBitmap = bitmap;
+}
+
+bool ZwiftClickRelay::acceptButton(int bit)
+{
+    if (bit < 0 || bit >= 32)
+        return false;
+    const qint64 now = m_clock.isValid() ? m_clock.elapsed() : 0;
+    if (now - m_lastButtonMs[bit] < kButtonDebounceMs)
+        return false;           // repeated edge
+    m_lastButtonMs[bit] = now;
+    return true;
+}
+
+void ZwiftClickRelay::dispatchButton(int bit)
+{
+    using namespace ZwiftClick;
+    switch (bit) {
+    case UpShiftBit:   emit paddleUpPressed();    break;
+    case DownShiftBit: emit paddleDownPressed();  break;
+    case ButtonABit:   emit buttonAPressed();     break;
+    case ButtonBBit:   emit buttonBPressed();     break;
+    case ButtonYBit:   emit buttonYPressed();     break;
+    case ButtonZBit:   emit buttonZPressed();     break;
+    case DpadLeftBit:  emit dpadLeftPressed();    break;
+    case DpadUpBit:    emit dpadUpPressed();      break;
+    case DpadRightBit: emit dpadRightPressed();   break;
+    case DpadDownBit:  emit dpadDownPressed();    break;
+    default:           emit unmappedButton(bit);  break;
+    }
+}

--- a/src/btle/zwift/zwift_click_relay.h
+++ b/src/btle/zwift/zwift_click_relay.h
@@ -10,24 +10,20 @@
 class QTimer;
 
 /*
- * Reads a Zwift Click v2 controller through the TRAINER'S FC82 relay — the way
- * real Zwift does it — instead of connecting to the flaky Click BLE devices
- * directly. The Click links to the trainer; the trainer relays its button frames
- * to us over FC82, so the link is held by the trainer (BLE central) and stays
- * stable for a whole workout (validated with a ~15-min soak).
+ * Reads a Click v2 controller through the trainer's FC82 relay instead of
+ * connecting to the controller's own (unstable) BLE device directly. The
+ * controller links to the trainer; the trainer relays its button frames to us
+ * over FC82, so the BLE link is held by the trainer and stays stable for a whole
+ * workout (validated with a ~15-min soak).
  *
  * BtleHub owns the trainer connection; when it discovers the FC82 service it
- * hands the service here and this object drives the relay handshake and decodes
- * the relayed button frames into the same high-level action signals the (now
- * removed) direct ZwiftClickManager emitted.
+ * hands the service here, and this object drives the relay handshake and decodes
+ * the relayed button frames into high-level action signals.
  *
- * Protocol (see notes/zwift-cog-protocol-findings.md): subscribe FC82
- * notify/indicate + write "RideOn 02 03" and the relay-setup bytes to the
- * control point; when the trainer announces the linked "Zwift Click" (a 0x47
- * device frame) ask it to connect (441002); once the Click's channel is up relay
- * a "RideOn" to it; buttons then stream as 0x4e-wrapped 0x23 frames (same
- * active-low bitmap we already decode). No crypto. A watchdog re-pings if the
- * relay falls silent. Native only.
+ * The handshake subscribes to FC82 notify/indicate, writes the relay-setup
+ * sequence to the control point, asks the trainer to connect the linked
+ * controller once it is announced, and then reads the streamed button frames. A
+ * watchdog re-pings if the relay falls silent. Native only.
  */
 class ZwiftClickRelay : public QObject
 {

--- a/src/btle/zwift/zwift_click_relay.h
+++ b/src/btle/zwift/zwift_click_relay.h
@@ -1,0 +1,104 @@
+#ifndef ZWIFT_CLICK_RELAY_H
+#define ZWIFT_CLICK_RELAY_H
+
+#include <QObject>
+#include <QBluetoothUuid>
+#include <QElapsedTimer>
+#include <QLowEnergyCharacteristic>
+#include <QLowEnergyService>
+
+class QTimer;
+
+/*
+ * Reads a Zwift Click v2 controller through the TRAINER'S FC82 relay — the way
+ * real Zwift does it — instead of connecting to the flaky Click BLE devices
+ * directly. The Click links to the trainer; the trainer relays its button frames
+ * to us over FC82, so the link is held by the trainer (BLE central) and stays
+ * stable for a whole workout (validated with a ~15-min soak).
+ *
+ * BtleHub owns the trainer connection; when it discovers the FC82 service it
+ * hands the service here and this object drives the relay handshake and decodes
+ * the relayed button frames into the same high-level action signals the (now
+ * removed) direct ZwiftClickManager emitted.
+ *
+ * Protocol (see notes/zwift-cog-protocol-findings.md): subscribe FC82
+ * notify/indicate + write "RideOn 02 03" and the relay-setup bytes to the
+ * control point; when the trainer announces the linked "Zwift Click" (a 0x47
+ * device frame) ask it to connect (441002); once the Click's channel is up relay
+ * a "RideOn" to it; buttons then stream as 0x4e-wrapped 0x23 frames (same
+ * active-low bitmap we already decode). No crypto. A watchdog re-pings if the
+ * relay falls silent. Native only.
+ */
+class ZwiftClickRelay : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ZwiftClickRelay(QObject *parent = nullptr);
+
+    // Drive the relay on an FC82 service object created by BtleHub. Safe to call
+    // whether the service is still discovering or already discovered, and to call
+    // again with a NEW service after a trainer reconnect (state is reset; callers
+    // that wired our signals stay wired since this object persists).
+    void attachService(QLowEnergyService *fc82Service);
+
+    // Stop using the current service (it's about to be destroyed on a trainer
+    // disconnect) and reset state so the next attachService restarts cleanly.
+    void detach();
+
+signals:
+    // One signal per physical button (debounced, fired on press). The relay knows
+    // only the controller's buttons; the caller decides what each does, so the
+    // action mapping can change without touching the relay. The two shift paddles
+    // are the only fixed-purpose buttons (that's their physical identity).
+    void paddleUpPressed();    // right paddle  (bit 12)
+    void paddleDownPressed();  // left  paddle  (bit 8)
+    void buttonAPressed();     // bit 4
+    void buttonBPressed();     // bit 5
+    void buttonYPressed();     // bit 6
+    void buttonZPressed();     // bit 7
+    void dpadLeftPressed();    // bit 0
+    void dpadUpPressed();      // bit 1
+    void dpadRightPressed();   // bit 2
+    void dpadDownPressed();    // bit 3
+
+    // True once relayed Click frames are flowing, false if the watchdog flags a
+    // stall — for optional status UI / logging.
+    void relayActiveChanged(bool active);
+    void unmappedButton(int bitIndex);
+
+private slots:
+    void onServiceStateChanged(QLowEnergyService::ServiceState state);
+    void onCharacteristicChanged(const QLowEnergyCharacteristic &c, const QByteArray &value);
+
+private:
+    void beginSetup();                       // subscribe + RideOn + relay-setup writes
+    void writeControl(const QByteArray &bytes);
+    void requestClickConnect();              // 441002 once the Click is announced
+    void relayRideOn(bool isRetry);          // tell the Click to start streaming
+    void checkProgress();                    // re-send RideOn until frames flow
+    void watchdogTick();                     // re-ping if the relay falls silent
+    void handleBitmap(quint32 bitmap);
+    bool acceptButton(int bit);
+    void dispatchButton(int bit);
+
+    QLowEnergyService *m_fc82 = nullptr;
+    QBluetoothUuid     m_notifyUuid;
+    QBluetoothUuid     m_controlUuid;
+    QBluetoothUuid     m_indicateUuid;
+
+    bool   m_setupDone    = false;
+    bool   m_connectSent  = false;   // sent 441002
+    bool   m_rideOnSent   = false;   // relayed RideOn to the Click
+    bool   m_sawRelay     = false;   // a relayed 0x4e frame arrived → live
+    int    m_retries      = 0;
+    qint64 m_lastRelayMs  = 0;
+    bool   m_stalled      = false;
+
+    quint32       m_lastBitmap = 0xFFFFFFFFu;
+    QElapsedTimer m_clock;                    // per-bit debounce clock
+    qint64        m_lastButtonMs[32] = {0};
+
+    QTimer *m_watchdog = nullptr;
+};
+
+#endif // ZWIFT_CLICK_RELAY_H

--- a/src/btle/zwift/zwift_protocol.cpp
+++ b/src/btle/zwift/zwift_protocol.cpp
@@ -138,6 +138,93 @@ bool decodeRidingData(const QByteArray &frame, RidingData &out)
     return true;
 }
 
+bool decodeClickButtons(const QByteArray &frame, quint32 &bitmapOut)
+{
+    if (frame.isEmpty() ||
+        static_cast<quint8>(frame.at(0)) != static_cast<quint8>(Command::ButtonStatus))
+        return false;
+
+    int pos = 1;
+    while (pos < frame.size()) {
+        quint64 tag;
+        if (!getVarint(frame, pos, tag))
+            return false;
+        const int field    = static_cast<int>(tag >> 3);
+        const int wireType = static_cast<int>(tag & 0x7);
+
+        switch (wireType) {
+        case 0: {                       // varint
+            quint64 value;
+            if (!getVarint(frame, pos, value))
+                return false;
+            if (field == 1)             // the button bitmap
+                bitmapOut = static_cast<quint32>(value);
+            break;
+        }
+        case 2: {                       // length-delimited — skip
+            quint64 len;
+            if (!getVarint(frame, pos, len))
+                return false;
+            pos += static_cast<int>(len);
+            break;
+        }
+        case 5: pos += 4; break;        // 32-bit
+        case 1: pos += 8; break;        // 64-bit
+        default: return false;
+        }
+        if (pos > frame.size())
+            return false;
+    }
+    return true;
+}
+
+bool decodeRelayedClickButtons(const QByteArray &frame, quint32 &bitmapOut)
+{
+    if (frame.isEmpty() || static_cast<quint8>(frame.at(0)) != 0x4e)
+        return false;
+
+    int pos = 1;
+    while (pos < frame.size()) {
+        quint64 tag;
+        if (!getVarint(frame, pos, tag))
+            return false;
+        const int field    = static_cast<int>(tag >> 3);
+        const int wireType = static_cast<int>(tag & 0x7);
+
+        switch (wireType) {
+        case 0: {                       // varint — skip
+            quint64 v;
+            if (!getVarint(frame, pos, v))
+                return false;
+            break;
+        }
+        case 2: {                       // length-delimited
+            quint64 len;
+            if (!getVarint(frame, pos, len))
+                return false;
+            if (pos + static_cast<int>(len) > frame.size())
+                return false;
+            if (field == 2)             // the inner relayed Click frame
+                return decodeClickButtons(frame.mid(pos, static_cast<int>(len)), bitmapOut);
+            pos += static_cast<int>(len);
+            break;
+        }
+        case 5: pos += 4; break;
+        case 1: pos += 8; break;
+        default: return false;
+        }
+    }
+    return false;
+}
+
+QByteArray rideOnTrainerHandshake()
+{
+    QByteArray b = QByteArrayLiteral("RideOn");
+    b.append(char(0x02));
+    b.append(char(0x03));
+    return b;
+}
+
 } // namespace ZwiftProtocol
 
 namespace ZwiftGears {

--- a/src/btle/zwift/zwift_protocol.h
+++ b/src/btle/zwift/zwift_protocol.h
@@ -102,12 +102,11 @@ inline bool clickButtonPressed(quint32 bitmap, int bitIndex) {
     return (bitmap & (1u << bitIndex)) == 0;
 }
 
-// ── Trainer-relayed Click button frame (the real Zwift path) ─────────────────
-// A Zwift-protocol trainer (0xFC82) RELAYS a linked Click's frames to the app,
-// wrapped as: [0x4e][protobuf{ field2 = <inner Click frame> }]. When the inner
-// frame is a 0x23 button frame, extract its active-low bitmap. Returns false if
-// this isn't a 0x4e relay carrying a button frame. (Captured from a live Zwift
-// session — see notes/zwift-cog-protocol-findings.md.)
+// ── Trainer-relayed Click button frame ───────────────────────────────────────
+// An FC82 trainer RELAYS a linked Click's frames to the app, wrapped as:
+// [0x4e][protobuf{ field2 = <inner Click frame> }]. When the inner frame is a
+// 0x23 button frame, extract its active-low bitmap. Returns false if this isn't
+// a 0x4e relay carrying a button frame.
 bool decodeRelayedClickButtons(const QByteArray &frame, quint32 &bitmapOut);
 
 // The full RideOn handshake Zwift writes to the trainer's FC82 control point to

--- a/src/btle/zwift/zwift_protocol.h
+++ b/src/btle/zwift/zwift_protocol.h
@@ -37,6 +37,7 @@ inline constexpr char Response[]     = "00000004-19ca-4651-86e5-fa29dcdd09d1"; /
 enum class Command : quint8 {
     RidingData     = 0x03,  // incoming notification (HubRidingData)
     TrainerControl = 0x04,  // outgoing to control point (HubCommand)
+    ButtonStatus   = 0x23,  // incoming Click button bitmap (notify on 0x0002)
 };
 
 // The handshake the app writes once subscribed. Trailing bytes (if any) are
@@ -86,6 +87,34 @@ struct RidingData {
 // 0x03 or the protobuf stream is malformed. Unknown fields are skipped.
 bool decodeRidingData(const QByteArray &frame, RidingData &out);
 
+// ── Incoming: Zwift Click button status (command 0x23) ───────────────────────
+// The Click (fw 1.2.0) streams an UNENCRYPTED status frame ~2×/s on the 0x0002
+// measurement char: [0x23][field 1 = varint], where field 1 is a 32-bit
+// ACTIVE-LOW button bitmap — idle is 0xFFFFFFFF and a held button clears its
+// bit (e.g. 0xFFFFEFFF = bit 12 down). Confirmed via --zwift-probe on hardware.
+// Decode a 0x23 frame into the raw bitmap. Returns false if the command byte is
+// not 0x23 or the stream is malformed. Map specific bits to +/- with the helper
+// below once the per-button bits are nailed down from a hardware capture.
+bool decodeClickButtons(const QByteArray &frame, quint32 &bitmapOut);
+
+// Convenience: a button is "pressed" when its bit is 0 (active-low).
+inline bool clickButtonPressed(quint32 bitmap, int bitIndex) {
+    return (bitmap & (1u << bitIndex)) == 0;
+}
+
+// ── Trainer-relayed Click button frame (the real Zwift path) ─────────────────
+// A Zwift-protocol trainer (0xFC82) RELAYS a linked Click's frames to the app,
+// wrapped as: [0x4e][protobuf{ field2 = <inner Click frame> }]. When the inner
+// frame is a 0x23 button frame, extract its active-low bitmap. Returns false if
+// this isn't a 0x4e relay carrying a button frame. (Captured from a live Zwift
+// session — see notes/zwift-cog-protocol-findings.md.)
+bool decodeRelayedClickButtons(const QByteArray &frame, quint32 &bitmapOut);
+
+// The full RideOn handshake Zwift writes to the trainer's FC82 control point to
+// start the relay stream: "RideOn" + 0x02 0x03 (bare "RideOn" alone is what the
+// trainer's own riding-data needs; the +0203 trailer matches the captured app).
+QByteArray rideOnTrainerHandshake();
+
 } // namespace ZwiftProtocol
 
 // ── Virtual gear table ───────────────────────────────────────────────────────
@@ -101,6 +130,27 @@ namespace ZwiftSim {
 constexpr quint32 CWaX10000  = 5100;   // CW·a·10000  → 0.51
 constexpr quint32 CrrX100000 = 400;    // Crr·100000  → 0.004
 } // namespace ZwiftSim
+
+// ── Zwift Click / Play shifter button bits ───────────────────────────────────
+// The +/- shifters are two separate single-paddle BLE devices (or the two
+// paddles of a Play pair). Each reports its shift paddle on a FIXED bit of the
+// 0x23 active-low bitmap, confirmed on hardware (fw 1.2.0): right/up paddle =
+// bit 12, left/down paddle = bit 8. Other buttons (d-pad, Y/Z/A/B) occupy other
+// bits — surfaced raw for later mapping (radio/volume/pause/etc.).
+namespace ZwiftClick {
+constexpr int UpShiftBit   = 12;  // right paddle → shift up   (+1)
+constexpr int DownShiftBit = 8;   // left  paddle → shift down (-1)
+// Left controller d-pad.
+constexpr int DpadLeftBit  = 0;
+constexpr int DpadUpBit    = 1;
+constexpr int DpadRightBit = 2;
+constexpr int DpadDownBit  = 3;
+// Right controller action buttons.
+constexpr int ButtonABit   = 4;
+constexpr int ButtonBBit   = 5;
+constexpr int ButtonYBit   = 6;
+constexpr int ButtonZBit   = 7;
+} // namespace ZwiftClick
 
 namespace ZwiftGears {
 constexpr int    Count    = 24;

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -9,6 +9,8 @@
 #include <QPainter>
 #include <QStyle>
 #include <QHBoxLayout>
+#include <QToolButton>
+#include <QTimer>
 #include "util.h"
 
 namespace {
@@ -120,6 +122,8 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     ui->pushButton_playPauseRadio->setIconSize(iconSize);
     ui->pushButton_nextRadio->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaSkipForward, iconSize, iconColor));
     ui->pushButton_nextRadio->setIconSize(iconSize);
+    ui->label_radioVolumeIcon->setPixmap(
+        tintedStandardIcon(style(), QStyle::SP_MediaVolume, iconSize, iconColor).pixmap(iconSize));
 
     // Window/config controls: render light icons on the always-dark toolbar,
     // instead of the legacy opaque-black PNGs that the dark theme broke.
@@ -192,10 +196,11 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     m_gearDownBtn->setAutoRaise(true);
     m_gearDownBtn->setToolTip(tr("Easier gear (Down arrow)"));
 
-    m_gearLabel = new QLabel(QStringLiteral("⚙ –"), m_gearWidget);
+    m_gearLabel = new QLabel(QStringLiteral("Gear –"), m_gearWidget);
     m_gearLabel->setAlignment(Qt::AlignCenter);
-    m_gearLabel->setMinimumWidth(72);
-    m_gearLabel->setToolTip(tr("Virtual gear"));
+    m_gearLabel->setMinimumWidth(92);
+    m_gearLabel->setToolTip(tr("Virtual gear — shift with the ▼/▲ arrows, the "
+                               "Up/Down keys, or a Zwift Click v2"));
 
     m_gearUpBtn = new QToolButton(m_gearWidget);
     m_gearUpBtn->setText(QStringLiteral("▲"));
@@ -214,15 +219,14 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     // .ui stylesheet doesn't reach these dynamically-created widgets).
     m_gearWidget->setStyleSheet(QStringLiteral("color: white;"));
     m_gearWidget->setVisible(false);
-    // Centre it: an expanding stretch before the gear balances the bar's right
-    // spacer (the left spacer is fixed), so the gear lands near the middle.
+    // Anchor it on the LEFT, right after the timer. Don't centre it with a
+    // floating stretch — the radio status label changes width as stations change
+    // and that was shoving the gear indicator around.
     const int timerIdx = ui->horizontalLayout->indexOf(ui->frame_timer);
-    if (timerIdx >= 0) {
-        ui->horizontalLayout->insertStretch(timerIdx + 1, 1);
-        ui->horizontalLayout->insertWidget(timerIdx + 2, m_gearWidget);
-    } else {
+    if (timerIdx >= 0)
+        ui->horizontalLayout->insertWidget(timerIdx + 1, m_gearWidget);
+    else
         ui->horizontalLayout->addWidget(m_gearWidget);
-    }
 }
 
 void TopMenuWorkout::setGearVisible(bool visible)
@@ -236,15 +240,37 @@ void TopMenuWorkout::updateGear(int gear, int count, bool ergMode)
     if (!m_gearLabel)
         return;
     if (ergMode) {
-        m_gearLabel->setText(QStringLiteral("⚙ %1/%2  ERG").arg(gear).arg(count));
+        m_gearLabel->setText(QStringLiteral("Gear %1/%2 · ERG").arg(gear).arg(count));
         m_gearLabel->setStyleSheet(QStringLiteral("color: gray;"));   // dimmed in ERG
     } else {
-        m_gearLabel->setText(QStringLiteral("⚙ %1/%2").arg(gear).arg(count));
+        m_gearLabel->setText(QStringLiteral("Gear %1/%2").arg(gear).arg(count));
         m_gearLabel->setStyleSheet(QString());
     }
     if (m_gearDownBtn) m_gearDownBtn->setEnabled(!ergMode);
     if (m_gearUpBtn)   m_gearUpBtn->setEnabled(!ergMode);
 }
+
+void TopMenuWorkout::flashWidget(QWidget *w)
+{
+    if (!w || !w->isEnabled())
+        return;
+    // Remember the resting style once (so rapid re-flashes don't latch green as
+    // the base), pulse green, then restore.
+    if (!w->property("flashBaseStyle").isValid())
+        w->setProperty("flashBaseStyle", w->styleSheet());
+    const QString base = w->property("flashBaseStyle").toString();
+    w->setStyleSheet(base + QStringLiteral(" background:#4caf50; border-radius:4px;"));
+    QTimer::singleShot(180, w, [w, base]() { w->setStyleSheet(base); });
+}
+
+void TopMenuWorkout::flashShift(int direction)
+{
+    flashWidget(direction > 0 ? m_gearUpBtn : m_gearDownBtn);
+}
+
+void TopMenuWorkout::flashRadioPrev()      { flashWidget(ui->pushButton_prevRadio); }
+void TopMenuWorkout::flashRadioNext()      { flashWidget(ui->pushButton_nextRadio); }
+void TopMenuWorkout::flashRadioPlayPause() { flashWidget(ui->pushButton_playPauseRadio); }
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -338,6 +364,15 @@ void TopMenuWorkout::updateRadioStatus(QString status) {
     ui->label_radioStatus->fadeIn(400);
 
 
+}
+
+void TopMenuWorkout::updateRadioVolume(int percent) {
+    ui->label_radioVolume->setText(QString::number(percent) + QStringLiteral("%"));
+    // Flash the sound icon only on a real volume change — not when a station
+    // change re-applies the same volume (and not on the initial set).
+    if (m_lastRadioVolumePct >= 0 && percent != m_lastRadioVolumePct)
+        flashWidget(ui->label_radioVolumeIcon);
+    m_lastRadioVolumePct = percent;
 }
 
 

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -651,15 +651,18 @@ void TopMenuWorkout::setTargetHeartRate(double percentageLTHR, int range) {
 ////////////////////////////////////////////////////////////
 void TopMenuWorkout::on_pushButton_prevRadio_clicked()
 {
+    flashWidget(ui->pushButton_prevRadio);
     emit prevRadio();
 }
 
 void TopMenuWorkout::on_pushButton_playPauseRadio_clicked()
 {
+    flashWidget(ui->pushButton_playPauseRadio);
     emit playPauseRadio();
 }
 
 void TopMenuWorkout::on_pushButton_nextRadio_clicked()
 {
+    flashWidget(ui->pushButton_nextRadio);
     emit nextRadio();
 }

--- a/src/ui/components/topmenuworkout.h
+++ b/src/ui/components/topmenuworkout.h
@@ -56,6 +56,12 @@ public:
     // dimmed with "ERG" and inactive arrows.
     void setGearVisible(bool visible);
     void updateGear(int gear, int count, bool ergMode);
+    /// Briefly highlight a toolbar control (green pulse) so the rider sees an
+    /// input registered, whatever the source (keys, on-screen, or a Zwift Click).
+    void flashShift(int direction);   // ▲ if > 0 else ▼ gear button
+    void flashRadioPrev();
+    void flashRadioNext();
+    void flashRadioPlayPause();
 
 
 
@@ -88,6 +94,7 @@ public slots:
     void changeConfigIcon(bool insideConfig);
 
     void updateRadioStatus(QString status);
+    void updateRadioVolume(int percent);
 
     //radio
     void radioStartedPlaying();
@@ -128,11 +135,15 @@ private :
 private:
     Ui::TopMenuWorkout *ui;
 
+    /// Pulse a widget green for ~180 ms, then restore its resting style.
+    void flashWidget(QWidget *w);
+
     // Virtual-shifting gear indicator widgets (built in the constructor).
     QWidget     *m_gearWidget = nullptr;
     QToolButton *m_gearDownBtn = nullptr;
     QToolButton *m_gearUpBtn   = nullptr;
     QLabel      *m_gearLabel   = nullptr;
+    int          m_lastRadioVolumePct = -1;   // flash the volume icon only on change
 
     bool hasTargetPower;
     bool hasTargetCad;

--- a/src/ui/components/topmenuworkout.ui
+++ b/src/ui/components/topmenuworkout.ui
@@ -748,6 +748,32 @@ border-radius: 1px;
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QLabel" name="label_radioVolumeIcon">
+           <property name="toolTip">
+            <string>Radio volume</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_radioVolume">
+           <property name="toolTip">
+            <string>Radio volume</string>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>34</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>—</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -183,6 +183,21 @@ void DialogConfig::on_pushButton_nextRadio_clicked()
     playNextOrPreviousRadio(true);
 }
 
+void DialogConfig::radioVolumeUp()
+{
+    ui->slider_volumeRadio->setValue(ui->slider_volumeRadio->value() + 5);
+}
+
+void DialogConfig::radioVolumeDown()
+{
+    ui->slider_volumeRadio->setValue(ui->slider_volumeRadio->value() - 5);
+}
+
+int DialogConfig::radioVolume() const
+{
+    return ui->slider_volumeRadio->value();
+}
+
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 void DialogConfig::playNextOrPreviousRadio(bool next) {

--- a/src/ui/dialogconfig.h
+++ b/src/ui/dialogconfig.h
@@ -53,6 +53,12 @@ public slots:
     void radioStoppedPlaying();
 
     void playPauseRadio();
+    /// Nudge radio volume (e.g. from a Zwift Click d-pad). The slider's
+    /// valueChanged already drives the player + persistence.
+    void radioVolumeUp();
+    void radioVolumeDown();
+    /// Current radio volume (0-100), for the workout top-bar indicator.
+    int radioVolume() const;
 
 
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -68,6 +68,7 @@
 #include "btle_scanner_dialog.h"
 #include "btle_sensor_store.h"
 #include "sensor_connect_dialog.h"
+#include "zwift_click_relay.h"
 #endif
 #include "sensorswidget.h"
 #include "studiowidget.h"
@@ -1353,6 +1354,7 @@ void MainWindow::executeWorkout(Workout workout) {
     if (connDlg.exec() != QDialog::Accepted)
         return;
 
+
     // ── Simulation path ───────────────────────────────────────────────────
     if (connDlg.selectedMethod() == DialogConnectionMethod::Simulation) {
         // In Studio mode simulate every selected rider; otherwise a single rider.
@@ -1596,6 +1598,12 @@ void MainWindow::startWorkoutWithHubs(const Workout &workout,
     WorkoutDialog *w = new WorkoutDialog(workout, lstRadio, vecUserStudio);
     w->setAttribute(Qt::WA_DeleteOnClose);
     w->setWindowModality(Qt::ApplicationModal);
+
+    // Zwift Click v2 read through the trainer's FC82 relay (opt-in). The relay is
+    // owned by the trainer hub; non-null only for a Zwift-protocol trainer with
+    // the option enabled.
+    if (BtleHub *trainerHub = hubsByRole.value(BtleSensorRole::Trainer, nullptr))
+        w->setClickRelay(trainerHub->zwiftClickRelay());
 
     QSet<BtleHub*> allHubs;
     wireHubsToDialog(w, hubsByRole, allHubs);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -249,6 +249,7 @@ private:
     QStringList    m_scLoadLog;    // captured setLoad/setSlope (trainer control)
     WorkoutDialog *m_ssWorkoutDlg = nullptr;
     SimulatorHub  *m_ssSimHub     = nullptr;
+
     QList<SimulatorHub*> m_ssStudioHubs;   // per-rider sim hubs for the studio-workout shot
     // Saved so screenshot mode (which toggles studio mode + rider count for its
     // captures) can restore the user's real settings before quitting.

--- a/src/ui/plots/workoutplot.cpp
+++ b/src/ui/plots/workoutplot.cpp
@@ -799,6 +799,19 @@ void WorkoutPlot::decreaseDifficulty() {
     setDifficulty(difficultyPercent - 1);
 }
 
+void WorkoutPlot::flashDifficulty(bool increase) {
+    QToolButton *btn = increase ? btnIncreaseDifficulty : btnDecreaseDifficulty;
+    if (!btn)
+        return;
+    // The resting look comes from widgetDifficulty's stylesheet (QToolButton
+    // selector), so the button's own stylesheet is empty at rest — restore to
+    // that. Keep border-radius so the green pulse matches the button shape.
+    btn->setStyleSheet(QStringLiteral(
+        "background-color: #4caf50; color: white; border: none;"
+        " border-radius: 3px; font-size: 22px; font-weight: bold;"));
+    QTimer::singleShot(180, btn, [btn]() { btn->setStyleSheet(QString()); });
+}
+
 void WorkoutPlot::setDifficulty(int percentageIncrease) {
 
     const int clamped = qBound(-100, percentageIncrease, 100);

--- a/src/ui/plots/workoutplot.h
+++ b/src/ui/plots/workoutplot.h
@@ -85,6 +85,10 @@ public slots:
     void increaseDifficulty();
     void decreaseDifficulty();
 
+    // Pulse the matching +/− button green on any difficulty change (keys,
+    // on-screen, or Zwift Click), mirroring the gear/radio flash.
+    void flashDifficulty(bool increase);
+
 
 
 

--- a/src/ui/sensorswidget.cpp
+++ b/src/ui/sensorswidget.cpp
@@ -124,9 +124,10 @@ void SensorsWidget::buildUi()
     trainerLayout->addWidget(m_virtualShiftingCheck);
 
     QLabel *vsHint = new QLabel(
-        tr("Adds ▲/▼ gear shifting (keyboard or the on-screen arrows) so a "
-           "single-cog trainer has usable resistance on free rides and tests. "
-           "Leave off if you shift with a real cassette."), trainerGroup);
+        tr("Adds ▲/▼ gear shifting — by keyboard, the on-screen arrows, or the "
+           "paddles on a Zwift Click v2 — so a single-cog trainer has usable "
+           "resistance on free rides and tests. Leave off if you shift with a "
+           "real cassette."), trainerGroup);
     vsHint->setWordWrap(true);
     vsHint->setStyleSheet(QStringLiteral("color: #777; font-size: 11px;"));
     trainerLayout->addWidget(vsHint);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1353,6 +1353,13 @@ void WorkoutDialog::adjustWorkoutDifficulty(int percentageIncrease) {
     currentIntervalObj = workout.getInterval(currentInterval);
     adjustTargets(currentIntervalObj);
 
+    // Pulse the on-screen +/− button green on any difficulty change (keys,
+    // on-screen, or Zwift Click Y/B), like the gear and radio controls.
+    if (percentageIncrease > currentWorkoutDifficultyPercentage)
+        ui->widget_workoutPlot->flashDifficulty(true);
+    else if (percentageIncrease < currentWorkoutDifficultyPercentage)
+        ui->widget_workoutPlot->flashDifficulty(false);
+
     currentWorkoutDifficultyPercentage = percentageIncrease;
 }
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -39,6 +39,9 @@
 #include <QQuickWidget>
 #include <QQmlContext>
 #include "retroracecontroller.h"
+#ifndef Q_OS_WASM
+#include "zwift_click_relay.h"
+#endif
 #include "dialogcalibrate.h"
 #include "dialogcalibratepm.h"
 #include "dialogkeyboardshortcuts.h"
@@ -647,6 +650,20 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
     connect(ui->widget_topMenu, SIGNAL(prevRadio()), dconfig, SLOT(on_pushButton_prevRadio_clicked()) );
     connect(ui->widget_topMenu, SIGNAL(playPauseRadio()), dconfig, SLOT(playPauseRadio()) );
     connect(ui->widget_topMenu, SIGNAL(nextRadio()), dconfig, SLOT(on_pushButton_nextRadio_clicked()) );
+
+    // Radio volume indicator in the top bar — reflects the config slider, so it
+    // updates whether the volume changes via the dialog or a Zwift Click d-pad.
+    connect(dconfig, SIGNAL(signal_volumeRadioChanged(int)), ui->widget_topMenu, SLOT(updateRadioVolume(int)) );
+    ui->widget_topMenu->updateRadioVolume(dconfig->radioVolume());
+
+    // Flash the matching top-bar control on each radio action (any source: keys,
+    // on-screen, or a Zwift Click d-pad/Z), mirroring the gear-shift feedback.
+    // (Volume flashes from updateRadioVolume on an actual value change, so it
+    // doesn't pulse when a station change merely re-applies the same volume.)
+    connect(this, &WorkoutDialog::F6previous,  ui->widget_topMenu, &TopMenuWorkout::flashRadioPrev);
+    connect(this, &WorkoutDialog::F8next,      ui->widget_topMenu, &TopMenuWorkout::flashRadioNext);
+    connect(this, &WorkoutDialog::F7playPause, ui->widget_topMenu, &TopMenuWorkout::flashRadioPlayPause);
+
 
 
 
@@ -1293,10 +1310,10 @@ void WorkoutDialog::adjustWorkoutDifficulty(int percentageIncrease) {
 
     //    qDebug() << "ADJUST WORKOUT DIFFICULTY!!" << percentageIncrease << "diff100: " << diffFromActualDifficulty;
 
-    // pause workout if not paused
-    if (!isWorkoutPaused) {
-        start_or_pause_workout();
-    }
+    // Adjust difficulty live — rebuild the targets/plot without pausing. The
+    // old code paused here (and never resumed), so every ±% nudge stopped the
+    // workout; the sibling insertInterval() already drops the same pause as
+    // "should be done in real time".
 
     // Compute new workout
     QList<Interval> lstIntervalAdjusted;
@@ -1326,6 +1343,11 @@ void WorkoutDialog::adjustWorkoutDifficulty(int percentageIncrease) {
     ui->wid_1_workoutPlot_HeartrateZoom->setWorkoutData(workout, WorkoutPlotZoomer::HEART_RATE, false);
     ui->wid_2_workoutPlot_PowerZoom->setWorkoutData(workout, WorkoutPlotZoomer::POWER, false);
     ui->wid_3_workoutPlot_CadenceZoom->setWorkoutData(workout, WorkoutPlotZoomer::CADENCE, false);
+
+    // setWorkoutData() rebuilds the plot from scratch, dropping the "now" marker
+    // and the done-zone shading — re-apply the current position so the big graph
+    // still shows where we are instead of looking brand new.
+    ui->widget_workoutPlot->updateMarkerTimeNow(timeElapsed_sec);
 
     //adjust mini-graph and widget to new target
     currentIntervalObj = workout.getInterval(currentInterval);
@@ -2427,8 +2449,36 @@ void WorkoutDialog::sendGearLoad() {
     }
 }
 
+void WorkoutDialog::setClickRelay(ZwiftClickRelay *relay)
+{
+#ifndef Q_OS_WASM
+    if (!relay)
+        return;
+    // The relay is owned by the trainer's BtleHub (lives as long as the trainer
+    // connection); we just wire its button actions for this workout.
+    m_clickRelay = relay;
+    // Button → action map (edit here if you want to remap a button; the relay
+    // only reports which button was pressed).
+    connect(m_clickRelay, &ZwiftClickRelay::paddleUpPressed,   this, [this]() { shiftGear(+1); });
+    connect(m_clickRelay, &ZwiftClickRelay::paddleDownPressed, this, [this]() { shiftGear(-1); });
+    connect(m_clickRelay, &ZwiftClickRelay::buttonYPressed, this, &WorkoutDialog::increaseDifficulty);
+    connect(m_clickRelay, &ZwiftClickRelay::buttonBPressed, this, &WorkoutDialog::decreaseDifficulty);
+    connect(m_clickRelay, &ZwiftClickRelay::buttonAPressed, this, [this]() { start_or_pause_workout(); });
+    connect(m_clickRelay, &ZwiftClickRelay::buttonZPressed, this, [this]() { emit F7playPause(); });  // stop/start music
+    connect(m_clickRelay, &ZwiftClickRelay::dpadLeftPressed,  this, &WorkoutDialog::F6previous);
+    connect(m_clickRelay, &ZwiftClickRelay::dpadRightPressed, this, &WorkoutDialog::F8next);
+    connect(m_clickRelay, &ZwiftClickRelay::dpadUpPressed,   dconfig, &DialogConfig::radioVolumeUp);
+    connect(m_clickRelay, &ZwiftClickRelay::dpadDownPressed, dconfig, &DialogConfig::radioVolumeDown);
+#else
+    Q_UNUSED(relay);
+#endif
+}
+
 void WorkoutDialog::shiftGear(int delta) {
-    if (isWorkoutOver)
+    // Ignore shifts unless gears are actually driving resistance — during an
+    // ERG-owned interval (or with virtual shifting off / workout over) the gear
+    // is not in control, so changing the number would just be misleading.
+    if (!gearsDriveNow())
         return;
     const int g = qBound(1, m_virtualGear + delta, kVirtualGearCount);
     if (g == m_virtualGear)
@@ -2436,6 +2486,7 @@ void WorkoutDialog::shiftGear(int delta) {
     m_virtualGear = g;
     sendGearLoad();
     updateGearIndicator();
+    ui->widget_topMenu->flashShift(delta);   // confirm the shift on the toolbar
 }
 
 // Refresh the top-bar gear indicator: visible whenever a trainer is controllable

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -39,6 +39,7 @@ class DialogConfig;     // forward declaration
 class WebBrowserView;   // forward declaration (lazily created web video player)
 class QQuickWidget;
 class RetroRaceController;   // retro ghost-race view
+class ZwiftClickRelay;       // Zwift Click v2 input via the trainer's FC82 relay
 
 namespace Ui {
 class WorkoutDialog;
@@ -54,6 +55,11 @@ public:
     ~WorkoutDialog();
 
     void reject();
+
+    /// Wire a Zwift Click v2 (read via the trainer's FC82 relay) to workout
+    /// actions. The relay is owned by the trainer's BtleHub, not this dialog.
+    /// No-op if relay is nullptr.
+    void setClickRelay(ZwiftClickRelay *relay);
 
     /// Mark a controllable trainer (FTMS / simulator) as wired for this solo
     /// workout so sendLoads()/sendSlopes() emit ERG targets.  Historically
@@ -326,6 +332,13 @@ private:
     //Internet radio player
 #ifdef GC_HAVE_QTMULTIMEDIA
     QtMediaPlayer *radioPlayer;
+#endif
+
+    // Zwift Click v2 controller input (native BLE). Created when virtual
+    // shifting is on and controllers are paired; maps buttons to shift /
+    // difficulty / start-pause / lap / radio actions.
+#ifndef Q_OS_WASM
+    ZwiftClickRelay *m_clickRelay = nullptr;   // owned by the trainer's BtleHub
 #endif
 
     // Embedded web video player (QWebEngine-based), created and loaded in the

--- a/tests/btle/btle_tests.pro
+++ b/tests/btle/btle_tests.pro
@@ -22,16 +22,20 @@ TEMPLATE = app
 DESTDIR  = ../../build/tests
 
 # ── BtleHub sources ──────────────────────────────────────────────────────────
-INCLUDEPATH += ../../src/btle ../../src/app
+INCLUDEPATH += ../../src/btle ../../src/btle/zwift ../../src/app
 
 SOURCES += \
     ../../src/app/logger.cpp \
     ../../src/btle/btle_hub.cpp \
     ../../src/btle/simulator_hub.cpp \
+    ../../src/btle/zwift/zwift_click_relay.cpp \
+    ../../src/btle/zwift/zwift_protocol.cpp \
     tst_btle_hub.cpp
 
 HEADERS += \
     ../../src/app/logger.h \
     ../../src/btle/btle_hub.h \
     ../../src/btle/simulator_hub.h \
+    ../../src/btle/zwift/zwift_click_relay.h \
+    ../../src/btle/zwift/zwift_protocol.h \
     btle_device_simulator.h

--- a/tests/integration/btle_api_tests.pro
+++ b/tests/integration/btle_api_tests.pro
@@ -24,14 +24,18 @@ TEMPLATE = app
 
 DESTDIR  = ../../build/tests
 
-INCLUDEPATH += ../../src/btle ../../src/app
+INCLUDEPATH += ../../src/btle ../../src/btle/zwift ../../src/app
 
 SOURCES += \
     ../../src/app/logger.cpp \
     ../../src/btle/btle_hub.cpp \
+    ../../src/btle/zwift/zwift_click_relay.cpp \
+    ../../src/btle/zwift/zwift_protocol.cpp \
     tst_btle_api.cpp
 
 HEADERS += \
     ../../src/app/logger.h \
     ../../src/btle/btle_hub.h \
-    ../../src/btle/btle_uuids.h
+    ../../src/btle/btle_uuids.h \
+    ../../src/btle/zwift/zwift_click_relay.h \
+    ../../src/btle/zwift/zwift_protocol.h

--- a/tests/zwift/tst_zwift_protocol.cpp
+++ b/tests/zwift/tst_zwift_protocol.cpp
@@ -32,6 +32,14 @@ private slots:
     void testDecode_skipsUnknownLengthDelimited();
     void testDecode_truncatedVarint();
 
+    // ── decodeClickButtons (0x23) ────────────────────────────────────────────
+    void testClick_idleBitmap();
+    void testClick_pressedBit();
+    void testClick_wrongCommandByte();
+    void testRelay_extractsButtonBitmap();
+    void testRelay_idle();
+    void testRelay_notAButtonFrame();
+
     // ── gear table ───────────────────────────────────────────────────────────
     void testGears_endpoints();
     void testGears_monotonic();
@@ -127,6 +135,66 @@ void TstZwiftProtocol::testDecode_truncatedVarint()
     const QByteArray frame = QByteArray::fromHex("0308ff");
     RidingData d;
     QVERIFY(!decodeRidingData(frame, d));
+}
+
+void TstZwiftProtocol::testClick_idleBitmap()
+{
+    // Real idle frame captured from a Zwift Click fw 1.2.0 on 0x0002.
+    const QByteArray frame = QByteArray::fromHex("2308ffffffff0f");
+    quint32 bitmap = 0;
+    QVERIFY(decodeClickButtons(frame, bitmap));
+    QCOMPARE(bitmap, quint32(0xFFFFFFFFu));        // all buttons released
+    QVERIFY(!clickButtonPressed(bitmap, 12));
+}
+
+void TstZwiftProtocol::testClick_pressedBit()
+{
+    // Real "button down" frame: bit 12 cleared (active-low) → 0xFFFFEFFF.
+    const QByteArray frame = QByteArray::fromHex("2308ffdfffff0f");
+    quint32 bitmap = 0;
+    QVERIFY(decodeClickButtons(frame, bitmap));
+    QCOMPARE(bitmap, quint32(0xFFFFEFFFu));
+    QVERIFY(clickButtonPressed(bitmap, 12));        // active-low: bit 12 is down
+    QVERIFY(!clickButtonPressed(bitmap, 11));
+    QVERIFY(!clickButtonPressed(bitmap, 13));
+}
+
+void TstZwiftProtocol::testClick_wrongCommandByte()
+{
+    // A riding-data (0x03) frame must not parse as a Click button frame.
+    const QByteArray frame = QByteArray::fromHex("0308c801");
+    quint32 bitmap = 0;
+    QVERIFY(!decodeClickButtons(frame, bitmap));
+    QVERIFY(!decodeClickButtons(QByteArray(), bitmap));
+}
+
+void TstZwiftProtocol::testRelay_extractsButtonBitmap()
+{
+    // Real trainer-relayed frame from a live Zwift capture: 0x4e wrapper around
+    // the inner 0x23 button frame with bit 12 cleared (up shift).
+    const QByteArray frame = QByteArray::fromHex("4e080212072308ffdfffff0f");
+    quint32 bitmap = 0;
+    QVERIFY(decodeRelayedClickButtons(frame, bitmap));
+    QCOMPARE(bitmap, quint32(0xFFFFEFFFu));
+    QVERIFY(clickButtonPressed(bitmap, 12));
+}
+
+void TstZwiftProtocol::testRelay_idle()
+{
+    const QByteArray frame = QByteArray::fromHex("4e080212072308ffffffff0f");
+    quint32 bitmap = 0;
+    QVERIFY(decodeRelayedClickButtons(frame, bitmap));
+    QCOMPARE(bitmap, quint32(0xFFFFFFFFu));
+}
+
+void TstZwiftProtocol::testRelay_notAButtonFrame()
+{
+    // A relayed 0x2a capability frame (field 2 not a 0x23 frame) → not buttons.
+    const QByteArray frame = QByteArray::fromHex("4e080212182a0803121112110818100018");
+    quint32 bitmap = 0;
+    QVERIFY(!decodeRelayedClickButtons(frame, bitmap));
+    // And a plain riding-data frame must not parse as a relay.
+    QVERIFY(!decodeRelayedClickButtons(QByteArray::fromHex("0308c801"), bitmap));
 }
 
 void TstZwiftProtocol::testGears_endpoints()


### PR DESCRIPTION
Closes #300

Reads **Zwift Click v2** shifters through the trainer's FC82 relay, instead of connecting to the controllers directly. The trainer holds the link and relays the buttons, so it's stable for a whole ride, needs no pairing, and
is **auto-detected** when the trainer exposes FC82 (no setting).

Button map: paddles shift gears, Y/B difficulty ±1%, A start/pause, Z stop/start
music, d-pad radio stations + volume. The gear ▲/▼ and radio controls flash green
on any input (keys, on-screen, or Click).

Native (desktop) only. Builds clean; `tests/zwift` passes 27/27; hardware-validated
on a JetBlack Victory + Click v2 (full button set, ~15-min soak, drop/recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
