### PR TITLE
feat(workout): gear up/down adjusts difficulty in ERG, shifts gear in slope

### DIFF
--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -240,14 +240,19 @@ void TopMenuWorkout::updateGear(int gear, int count, bool ergMode)
     if (!m_gearLabel)
         return;
     if (ergMode) {
+        // Gears don't drive resistance under ERG, so the ▲/▼ buttons re-task to
+        // nudging workout difficulty (same as the +/- graph buttons). Keep them
+        // enabled; dim the label to signal the gear number itself is inactive.
         m_gearLabel->setText(QStringLiteral("Gear %1/%2 · ERG").arg(gear).arg(count));
         m_gearLabel->setStyleSheet(QStringLiteral("color: gray;"));   // dimmed in ERG
+        m_gearDownBtn->setToolTip(tr("Lower workout difficulty (Down arrow)"));
+        m_gearUpBtn->setToolTip(tr("Raise workout difficulty (Up arrow)"));
     } else {
         m_gearLabel->setText(QStringLiteral("Gear %1/%2").arg(gear).arg(count));
         m_gearLabel->setStyleSheet(QString());
+        m_gearDownBtn->setToolTip(tr("Easier gear (Down arrow)"));
+        m_gearUpBtn->setToolTip(tr("Harder gear (Up arrow)"));
     }
-    if (m_gearDownBtn) m_gearDownBtn->setEnabled(!ergMode);
-    if (m_gearUpBtn)   m_gearUpBtn->setEnabled(!ergMode);
 }
 
 void TopMenuWorkout::flashWidget(QWidget *w)

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -235,24 +235,13 @@ void TopMenuWorkout::setGearVisible(bool visible)
         m_gearWidget->setVisible(visible);
 }
 
-void TopMenuWorkout::updateGear(int gear, int count, bool ergMode)
+void TopMenuWorkout::updateGear(int gear, int count)
 {
     if (!m_gearLabel)
         return;
-    if (ergMode) {
-        // Gears don't drive resistance under ERG, so the ▲/▼ buttons re-task to
-        // nudging workout difficulty (same as the +/- graph buttons). Keep them
-        // enabled; dim the label to signal the gear number itself is inactive.
-        m_gearLabel->setText(QStringLiteral("Gear %1/%2 · ERG").arg(gear).arg(count));
-        m_gearLabel->setStyleSheet(QStringLiteral("color: gray;"));   // dimmed in ERG
-        m_gearDownBtn->setToolTip(tr("Lower workout difficulty (Down arrow)"));
-        m_gearUpBtn->setToolTip(tr("Raise workout difficulty (Up arrow)"));
-    } else {
-        m_gearLabel->setText(QStringLiteral("Gear %1/%2").arg(gear).arg(count));
-        m_gearLabel->setStyleSheet(QString());
-        m_gearDownBtn->setToolTip(tr("Easier gear (Down arrow)"));
-        m_gearUpBtn->setToolTip(tr("Harder gear (Up arrow)"));
-    }
+    // Only shown when gears actually drive resistance (the dialog hides the whole
+    // indicator under ERG), so there's no ERG state to render here.
+    m_gearLabel->setText(QStringLiteral("Gear %1/%2").arg(gear).arg(count));
 }
 
 void TopMenuWorkout::flashWidget(QWidget *w)

--- a/src/ui/components/topmenuworkout.h
+++ b/src/ui/components/topmenuworkout.h
@@ -52,10 +52,10 @@ public:
     void setTargetHeartRate(double percentageLTHR, int range);
 
     // Virtual-shifting gear indicator (#293): ▼ gear N/24 ▲ in the middle of the
-    // top bar. Shown while shifting is available; during ERG intervals it shows
-    // dimmed with "ERG" and inactive arrows.
+    // top bar. Shown only while gears drive resistance; the dialog hides it
+    // during ERG intervals (gears do nothing there).
     void setGearVisible(bool visible);
-    void updateGear(int gear, int count, bool ergMode);
+    void updateGear(int gear, int count);
     /// Briefly highlight a toolbar control (green pulse) so the rider sees an
     /// input registered, whatever the source (keys or on-screen).
     void flashShift(int direction);   // ▲ if > 0 else ▼ gear button

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2403,9 +2403,18 @@ void WorkoutDialog::setupZwiftClick()
 }
 
 void WorkoutDialog::shiftGear(int delta) {
-    // Ignore shifts unless gears are actually driving resistance — during an
-    // ERG-owned interval (or with virtual shifting off / workout over) the gear
-    // is not in control, so changing the number would just be misleading.
+    // During an ERG-owned interval a virtual gear has no effect, so the gear-up/
+    // gear-down controls (Zwift Click buttons, the toolbar ▲/▼, or the Up/Down
+    // keys) instead nudge the whole-workout difficulty - the same action as the
+    // +/- graph buttons. In slope/free-ride they keep changing the virtual gear.
+    if (ergOwnsThisInterval()) {
+        if (delta > 0)      emit increaseDifficulty();
+        else if (delta < 0) emit decreaseDifficulty();
+        return;
+    }
+    // Ignore shifts unless gears are actually driving resistance — with virtual
+    // shifting off / workout over the gear is not in control, so changing the
+    // number would just be misleading.
     if (!gearsDriveNow())
         return;
     const int g = qBound(1, m_virtualGear + delta, kVirtualGearCount);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2426,14 +2426,16 @@ void WorkoutDialog::shiftGear(int delta) {
     ui->widget_topMenu->flashShift(delta);   // confirm the shift on the toolbar
 }
 
-// Refresh the top-bar gear indicator: visible whenever a trainer is controllable
-// (hidden in studio or with no trainer). During an ERG-owned interval it shows
-// dimmed with "ERG"; otherwise the gear is active and shiftable.
+// Refresh the top-bar gear indicator. It's a virtual-gear concept, so it's shown
+// only when gears actually drive resistance: a trainer is controllable (not in
+// studio) AND we're not in an ERG-owned interval. In ERG the gear means nothing,
+// so the whole indicator is hidden (the gear up/down controls re-task to
+// difficulty there - see shiftGear()).
 void WorkoutDialog::updateGearIndicator() {
-    const bool show = virtualShiftingActive();
+    const bool show = virtualShiftingActive() && !ergOwnsThisInterval();
     ui->widget_topMenu->setGearVisible(show);
     if (show)
-        ui->widget_topMenu->updateGear(m_virtualGear, kVirtualGearCount, ergOwnsThisInterval());
+        ui->widget_topMenu->updateGear(m_virtualGear, kVirtualGearCount);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What

Re-task the gear up/down controls so they adapt to the trainer mode:

- **ERG mode** (ERG-owned interval): gear up/down **adjust workout difficulty** - the same action as the +/- graph buttons.
- **Slope / free-ride**: gear up/down **change the virtual gear** (unchanged behavior).

This is applied centrally in `WorkoutDialog::shiftGear()`, so all three input paths behave identically:

- **Zwift Click** buttons
- **keyboard Up/Down arrows** (route through `shiftGear()` when virtual shifting is on; still fall back to difficulty when virtual shifting is off)
- the on-screen toolbar ▲/▼

## Gear indicator under ERG

The top-bar gear indicator (`Gear x/y`) is a virtual-gear concept and means nothing under ERG, so it's now **hidden entirely during ERG-owned intervals** instead of showing a dimmed `· ERG` label. It reappears in slope/free-ride and on rest intervals where gears actually drive resistance. Drops the now-unused `ergMode` arg from `TopMenuWorkout::updateGear`.

## Testing

- Builds clean locally (qmake6 + QWT 6.3.0).
- Validated in-app: in an ERG power interval the Click/Up-Down inputs nudge graph difficulty and the gear label is gone; in slope/rest segments the gear label returns and the controls shift gears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
