### PR TITLE
fix(ui): render icons at device pixel ratio (HiDPI / Windows 150% blur)

### DIFF
--- a/src/app/util.cpp
+++ b/src/app/util.cpp
@@ -532,6 +532,19 @@ bool Util::unzipFile(QString zipFilename , QString filename) {
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+QPixmap Util::loadIconForDpr(const QString &resourcePath, int logicalSize, qreal devicePixelRatio)
+{
+    if (devicePixelRatio <= 0.0)
+        devicePixelRatio = 1.0;
+    QPixmap src(resourcePath);
+    if (src.isNull())
+        return src;
+    const int device = qRound(logicalSize * devicePixelRatio);
+    QPixmap scaled = src.scaled(device, device, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(devicePixelRatio);
+    return scaled;
+}
+
 QColor Util::getColor(Color color) {
 
 

--- a/src/app/util.h
+++ b/src/app/util.h
@@ -59,6 +59,13 @@ public:
     static QString getStringFromUCHAR(unsigned char* ch);
     static QColor getColor(Color color);
 
+    // Load a resource pixmap scaled into a `logicalSize` square, rendered crisp
+    // for the given device pixel ratio. The result carries the DPR, so a QLabel
+    // or QIcon lays it out at logicalSize device-independent px but renders at
+    // full resolution - no blur on HiDPI / fractional-scale (e.g. Windows 150%)
+    // displays. Pass a widget's devicePixelRatioF() (or qApp->devicePixelRatio()).
+    static QPixmap loadIconForDpr(const QString &resourcePath, int logicalSize, qreal devicePixelRatio);
+
 
     //// Folders
     static bool checkFolderPathIsValidForWrite(QString path);

--- a/src/ui/components/infowidget.cpp
+++ b/src/ui/components/infowidget.cpp
@@ -3,6 +3,7 @@
 
 #include <QDebug>
 #include "myconstants.h"
+#include "util.h"
 
 
 
@@ -272,17 +273,12 @@ void InfoWidget::setTypeInfoBox(TypeInfoBox type) {
     this->type = type;
 
     int size = 35;
-    QPixmap pixmapPower = QPixmap(":/image/icon/power2");
-    QPixmap pixmapCadence = QPixmap(":/image/icon/crank2");
-    QPixmap pixmapSpeed = QPixmap(":/image/icon/speed");
-    QPixmap pixmapHr = QPixmap(":/image/icon/heart2");
-    QPixmap pixmapTarget = QPixmap(":/image/icon/target");
-
-    pixmapPower = pixmapPower.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapCadence = pixmapCadence.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapSpeed = pixmapSpeed.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapHr = pixmapHr.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapTarget = pixmapTarget.scaled(size-10, size-10, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    const qreal dpr = devicePixelRatioF();
+    QPixmap pixmapPower   = Util::loadIconForDpr(":/image/icon/power2", size, dpr);
+    QPixmap pixmapCadence = Util::loadIconForDpr(":/image/icon/crank2", size, dpr);
+    QPixmap pixmapSpeed   = Util::loadIconForDpr(":/image/icon/speed",  size, dpr);
+    QPixmap pixmapHr      = Util::loadIconForDpr(":/image/icon/heart2", size, dpr);
+    QPixmap pixmapTarget  = Util::loadIconForDpr(":/image/icon/target", size - 10, dpr);
 
 
     ui->label_imageTarget->setPixmap(pixmapTarget);

--- a/src/ui/components/stylehelper.cpp
+++ b/src/ui/components/stylehelper.cpp
@@ -102,11 +102,22 @@ void StyleHelper::drawIconWithShadow(const QIcon &icon, const QRect &rect,
                                      QPainter *p, QIcon::Mode iconMode, int radius, const QColor &color, const QPoint &offset)
 {
     QPixmap cache;
-    QString pixmapName = QString::fromLatin1("icon %0 %1 %2").arg(icon.cacheKey()).arg(iconMode).arg(rect.height());
+    // The in-parameters (rect, radius, offset) are device-independent (dip)
+    // pixels, but the pixmap/shadow compositing below must happen in real device
+    // pixels or the icon is rasterised at 1x and upscaled by the compositor -
+    // blurry on any HiDPI / fractional-scale (e.g. Windows 150%) display.
+    const qreal devicePixelRatio = p->device()->devicePixelRatioF();
+    const int   deviceRadius = qRound(radius * devicePixelRatio);
+    const QPoint deviceOffset(qRound(offset.x() * devicePixelRatio),
+                              qRound(offset.y() * devicePixelRatio));
+    QString pixmapName = QString::fromLatin1("icon %0 %1 %2 %3")
+                             .arg(icon.cacheKey()).arg(iconMode).arg(rect.height())
+                             .arg(devicePixelRatio);
 
     if (!QPixmapCache::find(pixmapName, &cache)) {
-        QPixmap px = icon.pixmap(rect.size());
-        cache = QPixmap(px.size() + QSize(radius * 2, radius * 2));
+        QPixmap px = icon.pixmap(rect.size(), devicePixelRatio, iconMode);
+        px.setDevicePixelRatio(1.0);   // composite below in raw device pixels
+        cache = QPixmap(px.size() + QSize(deviceRadius * 2, deviceRadius * 2));
         cache.fill(Qt::transparent);
 
         QPainter cachePainter(&cache);
@@ -125,19 +136,19 @@ void StyleHelper::drawIconWithShadow(const QIcon &icon, const QRect &rect,
         }
 
         // Draw shadow
-        QImage tmp(px.size() + QSize(radius * 2, radius * 2 + 1), QImage::Format_ARGB32_Premultiplied);
+        QImage tmp(px.size() + QSize(deviceRadius * 2, deviceRadius * 2 + 1), QImage::Format_ARGB32_Premultiplied);
         tmp.fill(Qt::transparent);
 
         QPainter tmpPainter(&tmp);
         tmpPainter.setCompositionMode(QPainter::CompositionMode_Source);
-        tmpPainter.drawPixmap(QPoint(radius, radius), px);
+        tmpPainter.drawPixmap(QPoint(deviceRadius, deviceRadius), px);
         tmpPainter.end();
 
         // blur the alpha channel
         QImage blurred(tmp.size(), QImage::Format_ARGB32_Premultiplied);
         blurred.fill(Qt::transparent);
         QPainter blurPainter(&blurred);
-        qt_blurImage(&blurPainter, tmp, radius, false, true);
+        qt_blurImage(&blurPainter, tmp, deviceRadius, false, true);
         blurPainter.end();
 
         tmp = blurred;
@@ -157,11 +168,15 @@ void StyleHelper::drawIconWithShadow(const QIcon &icon, const QRect &rect,
         cachePainter.drawImage(QRect(0, 0, cache.rect().width(), cache.rect().height()), tmp);
 
         // Draw the actual pixmap...
-        cachePainter.drawPixmap(QPoint(radius, radius) + offset, px);
+        cachePainter.drawPixmap(QPoint(deviceRadius, deviceRadius) + deviceOffset, px);
+        cache.setDevicePixelRatio(devicePixelRatio);
         QPixmapCache::insert(pixmapName, cache);
     }
 
+    // cache holds device pixels; map back to dip when placing it.
     QRect targetRect = cache.rect();
-    targetRect.moveCenter(rect.center());
-    p->drawPixmap(targetRect.topLeft() - offset, cache);
+    targetRect.setSize(QSize(qRound(cache.width()  / devicePixelRatio),
+                             qRound(cache.height() / devicePixelRatio)));
+    targetRect.moveCenter(rect.center() - offset);
+    p->drawPixmap(targetRect, cache);
 }

--- a/src/ui/components/topmenuworkout.cpp
+++ b/src/ui/components/topmenuworkout.cpp
@@ -19,20 +19,26 @@ QIcon tintedStandardIcon(QStyle *style, QStyle::StandardPixmap sp,
     // Qt's title-bar standard pixmaps have differing native sizes (e.g. min and
     // close are ~11x13 while max is 16x16) and pixmap(size) does not upscale.
     // Scale the source up to the requested size so the toolbar icons render at
-    // a uniform visual size.
-    QPixmap source = style->standardIcon(sp).pixmap(size);
-    if (source.size() != size)
-        source = source.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    QPixmap out(size);
+    // a uniform visual size. Composite in real device pixels (size * DPR) and
+    // tag the result with the DPR, or the glyph is rasterised at 1x and upscaled
+    // by the compositor - blurry on HiDPI / fractional-scale (Windows 150%).
+    const qreal dpr = qApp->devicePixelRatio();
+    const QSize physical(qRound(size.width() * dpr), qRound(size.height() * dpr));
+    QPixmap source = style->standardIcon(sp).pixmap(size, dpr);
+    source.setDevicePixelRatio(1.0);   // composite below in raw device pixels
+    if (source.size() != physical)
+        source = source.scaled(physical, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QPixmap out(physical);
     out.fill(Qt::transparent);
     QPainter p(&out);
     // Centre the (aspect-preserved) glyph within the target canvas.
-    const int x = (size.width()  - source.width())  / 2;
-    const int y = (size.height() - source.height()) / 2;
+    const int x = (physical.width()  - source.width())  / 2;
+    const int y = (physical.height() - source.height()) / 2;
     p.drawPixmap(x, y, source);
     p.setCompositionMode(QPainter::CompositionMode_SourceIn);
     p.fillRect(out.rect(), color);
     p.end();
+    out.setDevicePixelRatio(dpr);
     return QIcon(out);
 }
 
@@ -73,15 +79,11 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
 
 
     int size = 25;
-    QPixmap pixmapPower = QPixmap(":/image/icon/power2");
-    QPixmap pixmapCadence = QPixmap(":/image/icon/crank2");
-    QPixmap pixmapHr = QPixmap(":/image/icon/heart2");
-    QPixmap pixmapRadio = QPixmap(":/image/icon/radio");
-
-    pixmapPower = pixmapPower.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapCadence = pixmapCadence.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapHr = pixmapHr.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapRadio = pixmapRadio.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    const qreal dpr = devicePixelRatioF();
+    QPixmap pixmapPower   = Util::loadIconForDpr(":/image/icon/power2", size, dpr);
+    QPixmap pixmapCadence = Util::loadIconForDpr(":/image/icon/crank2", size, dpr);
+    QPixmap pixmapHr      = Util::loadIconForDpr(":/image/icon/heart2", size, dpr);
+    QPixmap pixmapRadio   = Util::loadIconForDpr(":/image/icon/radio",  size, dpr);
 
 
     ui->label_imagePower->setPixmap(pixmapPower);
@@ -123,7 +125,8 @@ TopMenuWorkout::TopMenuWorkout(QWidget *parent) : QWidget(parent), ui(new Ui::To
     ui->pushButton_nextRadio->setIcon(tintedStandardIcon(style(), QStyle::SP_MediaSkipForward, iconSize, iconColor));
     ui->pushButton_nextRadio->setIconSize(iconSize);
     ui->label_radioVolumeIcon->setPixmap(
-        tintedStandardIcon(style(), QStyle::SP_MediaVolume, iconSize, iconColor).pixmap(iconSize));
+        tintedStandardIcon(style(), QStyle::SP_MediaVolume, iconSize, iconColor)
+            .pixmap(iconSize, devicePixelRatioF()));
 
     // Window/config controls: render light icons on the always-dark toolbar,
     // instead of the legacy opaque-black PNGs that the dark theme broke.

--- a/src/ui/components/userstudiowidget.cpp
+++ b/src/ui/components/userstudiowidget.cpp
@@ -2,6 +2,7 @@
 #include "ui_userstudiowidget.h"
 
 #include "myconstants.h"
+#include "util.h"
 
 
 
@@ -18,16 +19,11 @@ UserStudioWidget::UserStudioWidget(int userID, QString displayName, double FTP, 
     ui->setupUi(this);
 
     int size = 20; //20x20
-    QPixmap pixmapPower = QPixmap(":/image/icon/power2");
-    QPixmap pixmapCadence = QPixmap(":/image/icon/crank2");
-    QPixmap pixmapHr = QPixmap(":/image/icon/heart2");
-    QPixmap pixmapTarget = QPixmap(":/image/icon/target");
-
-
-    pixmapPower = pixmapPower.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapCadence = pixmapCadence.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapHr = pixmapHr.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmapTarget = pixmapTarget.scaled(size-5, size-5, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    const qreal dpr = devicePixelRatioF();
+    QPixmap pixmapPower   = Util::loadIconForDpr(":/image/icon/power2", size, dpr);
+    QPixmap pixmapCadence = Util::loadIconForDpr(":/image/icon/crank2", size, dpr);
+    QPixmap pixmapHr      = Util::loadIconForDpr(":/image/icon/heart2", size, dpr);
+    QPixmap pixmapTarget  = Util::loadIconForDpr(":/image/icon/target", size - 5, dpr);
 
 
     ui->label_image_power->setPixmap(pixmapPower);

--- a/src/ui/plots/iconitem.cpp
+++ b/src/ui/plots/iconitem.cpp
@@ -1,4 +1,5 @@
 #include "iconitem.h"
+#include "util.h"
 
 IconItem::IconItem() {}
 
@@ -11,25 +12,18 @@ void IconItem::draw( QPainter *painter,
 
 {
 
-    QPixmap pixmap;
-    if (iconType == "POWER") {
-        pixmap = QPixmap(":/image/icon/power2");
-    }
-    else if (iconType == "CADENCE") {
-        pixmap = QPixmap(":/image/icon/crank2");
-    }
-    else if (iconType == "HEART_RATE") {
-        pixmap = QPixmap(":/image/icon/heart2");
-        pixmap = pixmap.scaled(35,35, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    }
-    else if (iconType == "SPEED") {
-        pixmap = QPixmap(":/image/icon/speed");
-    }
-//    else if (iconType == "DONE_CHECK") {
-//        pixmap = QPixmap(":/image/icon/check");
-//    }
-//    pixmap = pixmap.scaled(QSize(30,30),  Qt::KeepAspectRatio);
+    QString path;
+    if (iconType == "POWER")           path = ":/image/icon/power2";
+    else if (iconType == "CADENCE")    path = ":/image/icon/crank2";
+    else if (iconType == "HEART_RATE") path = ":/image/icon/heart2";
+    else if (iconType == "SPEED")      path = ":/image/icon/speed";
+    if (path.isEmpty())
+        return;
 
+    // Render crisp for the canvas' device pixel ratio (drawPixmap honours the
+    // pixmap's DPR, so the icon stays a 35px logical box but isn't upscaled blurry).
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+    const QPixmap pixmap = Util::loadIconForDpr(path, 35, dpr);
 
     QPointF p(canvasRect.center().x()+30, canvasRect.top());
     painter->drawPixmap(p, pixmap);


### PR DESCRIPTION
## What

Fixes blurry icons on HiDPI / fractional-scale displays (reported on Windows at 150%). Every raster-icon path in the app rasterized icons at a device-pixel-ratio of 1 and let the compositor upscale them, leaving them soft on any scaled display.

## Changes

- **`StyleHelper::drawIconWithShadow`** (main-window sidebar: Workout / Intervals.icu / Studio / Devices / History) - ported Qt Creator's HiDPI-correct path: render at the painter's `devicePixelRatio`, composite the shadow/blur in real device pixels, tag the cache with the DPR.
- **`topmenuworkout`** (workout top toolbar) - `tintedStandardIcon` now composites QStyle standard pixmaps in real device pixels (media transport, volume, window max/close, start/pause); the radio thumbnail / metric labels and the volume icon go through the new DPR-aware loader.
- **`infowidget` + `userstudiowidget`** - metric icons (power/cadence/speed/HR/target) loaded DPR-aware.
- **`iconitem`** (QWT plot markers) - drawn DPR-aware.
- New **`Util::loadIconForDpr()`** - scales a resource pixmap into a logical box at the target devicePixelRatio and tags it, so QLabel/QIcon/QPainter lay it out at logical size but render at full resolution.

No-op at 100% scale (DPR 1), so no regression on standard displays.

## Testing

- Builds clean (qmake6 + QWT 6.3.0).
- Validated via `--screenshots` at `QT_SCALE_FACTOR=1.5` (same `devicePixelRatioF()` path as Windows 150%): sidebar and workout-toolbar icons render sharp instead of upscaled-blurry; before/after diff is dramatic.
- Validated in-app at 100% scale: no regression (icons unchanged).

## Follow-up (not in this PR)

The power/cadence/speed source PNGs (`fa-bolt` / `fa-gear` / `fa-dashboard`) are only 35px, so in the 35px metric boxes they're only as crisp as the source allows at 150%. Higher-res art for those three would finish the job; everything with a high-res source is now fully crisp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
