### PR TITLE
diagnostic: log workout clock elapsed per tick (chase instant-finish)

### DIFF
--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1093,6 +1093,14 @@ void WorkoutDialog::checkMAPTestOver() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutDialog::update1sec(double totalTimeElapsed_sec) {
 
+    // Diagnostic (temporary): the log timestamps on this line reveal whether the
+    // Clock ticks faster than real time (the "workout / race finishes instantly"
+    // report seen on one PC). Normally one line per real second with clockElapsed
+    // incrementing by 1; a burst of lines, or clockElapsed jumping, points at the
+    // Clock / QElapsedTimer.
+    qDebug() << "[update1sec] clockElapsed=" << totalTimeElapsed_sec
+             << "interval" << currentInterval << "/" << workout.getNbInterval();
+
     //    qDebug() << "#Update 1sec" << totalTimeElapsed_sec;
     int totalTimeElapsed_sec_i = (int)totalTimeElapsed_sec;
 


### PR DESCRIPTION
## What

Diagnostic-only change to chase the "workout / retro race finishes instantly (YOU WIN on open)" report seen on one Windows PC (and not reproducible on Linux or a second Windows machine).

Adds one log line per workout tick in `WorkoutDialog::update1sec`:

```
[update1sec] clockElapsed=<seconds> interval <n>/<N>
```

No behaviour change otherwise.

## Why

For a non-empty workout, the race can only show "YOU WIN" via `workoutOver()`, which means the workout advanced through every interval - i.e. the `Clock` ran faster than real time on that machine. This log makes the device tell us which it is:

- **many lines within the same real second** (timestamps cluster), `clockElapsed` marching 1,2,3,… fast → the `QElapsedTimer`/timer is firing too fast
- **`clockElapsed` jumping** (e.g. 1 → 480 in one step) → the elapsed value itself is wrong

Once the log identifies the cause, the real fix (interval bounds guards, race dt clamp, importer open-failure warning) lands in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
