### PR TITLE
UI tweaks: native spinbox, filter checkbox, editor Save, slimmer splitter

### DIFF
--- a/src/ui/apptheme.h
+++ b/src/ui/apptheme.h
@@ -222,9 +222,12 @@ public:
 "QComboBox QAbstractItemView {"
 "  background-color: #3a3a3a; color: #e0e0e0; selection-background-color: #4a7ab5;"
 "}"
-"QSpinBox {"
-"  background-color: #3a3a3a; color: #e0e0e0; border: 1px solid #555; border-radius: 3px;"
-"}"
+// No QSpinBox rule on purpose. Styling the base switches the spin box to CSS
+// box rendering, and on the Windows style that collapses the down-button to ~0
+// height (you can step up but not down). With the explicit dark palette set in
+// apply(), Qt's native style already draws a correct dark spin box - with native,
+// properly sized, clickable up/down arrows on every platform. (Same reasoning as
+// the QCheckBox::indicator note below.)
 "QPushButton {"
 "  background-color: #3d3d3d; color: #e0e0e0; border: 1px solid #555; border-radius: 3px; padding: 4px 10px;"
 "}"

--- a/src/ui/main_workoutpage.ui
+++ b/src/ui/main_workoutpage.ui
@@ -115,6 +115,16 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="4">
+       <widget class="QCheckBox" name="checkBox">
+        <property name="text">
+         <string>Show Included Workouts</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -196,44 +206,6 @@
      <property name="bottomMargin">
       <number>3</number>
      </property>
-     <item>
-      <widget class="QCheckBox" name="checkBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>145</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Show Included Workouts</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>5</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item>
       <widget class="QPushButton" name="pushButton_refresh">
        <property name="sizePolicy">

--- a/src/ui/workout_editor/workoutcreator.ui
+++ b/src/ui/workout_editor/workoutcreator.ui
@@ -161,7 +161,7 @@ QPushButton#pushButton_add, #pushButton_repeat, #pushButton_copy, #pushButton_de
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
+      <item row="0" column="4" rowspan="2">
        <widget class="QPushButton" name="pushButton_save_workout">
         <property name="enabled">
          <bool>false</bool>

--- a/src/ui/workoutdialog.ui
+++ b/src/ui/workoutdialog.ui
@@ -119,7 +119,7 @@ QwtScaleWidget {
       <bool>true</bool>
      </property>
      <property name="handleWidth">
-      <number>10</number>
+      <number>6</number>
      </property>
      <widget class="TopMenuWorkout" name="widget_topMenu" native="true">
       <property name="sizePolicy">


### PR DESCRIPTION
## What

A batch of small UI tweaks (List / Editor / workout dialog / Devices), grouped into one branch.

1. **Native QSpinBox (Windows down-button fix).** The dark theme styled the `QSpinBox` base, switching it to CSS box rendering; on the Windows style that collapsed the `::down-button` to ~0 height, so the spin boxes (ERG ramp, dropout timeout, battery threshold) could only step up, not down. Drop the `QSpinBox` stylesheet rule and let the native style draw it - the app already sets an explicit dark palette, so it renders dark with native, properly-sized, clickable arrows on every platform (no custom assets).
2. **"Show Included Workouts" into the filter row.** Moved from the bottom bar into the top filter grid (new row under Name/Creator), so all filtering controls are together. Bottom bar now holds just Refresh.
3. **Editor Save button aligned right.** Moved to its own right-hand column (spanning the two field rows) so it mirrors the List page's Clear button.
4. **Slimmer splitter handle** in the workout dialog (handleWidth 10 → 6).

No logic changes - object names preserved, so existing slots stay wired.

## Testing

- Builds clean (qmake6 + QWT 6.3.0).
- Rendered each affected page via `--screenshots` (Devices spinboxes, List filter, Editor meta).
- Spinbox down-button behaviour needs a final check on Windows (the collapse is Windows-style-specific); rendering/native arrows confirmed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
