### PR TITLE
fix(btle): don't auto-reconnect after an intentional disconnect

### DIFF
--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -104,6 +104,7 @@ void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
     m_ftmsLastAckedCmd.clear();
     m_reconnectDevice   = device;
     m_reconnectAttempts = 0;
+    m_userDisconnect    = false;
 
     m_controller = QLowEnergyController::createCentral(device, this);
 
@@ -123,6 +124,11 @@ void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
 
 void BtleHub::disconnectFromDevice()
 {
+    // Intentional teardown: cancel any pending reconnect and suppress the one
+    // that onControllerDisconnected() would otherwise schedule.
+    m_userDisconnect = true;
+    if (m_reconnectTimer)
+        m_reconnectTimer->stop();
     if (m_controller) {
         m_controller->disconnectFromDevice();
     }
@@ -272,7 +278,9 @@ void BtleHub::onControllerDisconnected()
     m_hrSeen = false;
     emit deviceDisconnected();
 
-    if (m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS)
+    // Only an unexpected drop should auto-reconnect; an intentional
+    // disconnectFromDevice() must stay disconnected.
+    if (!m_userDisconnect && m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS)
         m_reconnectTimer->start(RECONNECT_INTERVAL_MS);
 }
 

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -176,6 +176,12 @@ private:
     QTimer              *m_reconnectTimer    = nullptr;
     QBluetoothDeviceInfo m_reconnectDevice;
     int                  m_reconnectAttempts = 0;
+    // Set by disconnectFromDevice() so an intentional teardown (rescan, Skip,
+    // workout close, device removed) does NOT schedule an auto-reconnect — a
+    // stale hub reconnecting mid-teardown issued reads against a controller
+    // being destroyed ("A method was called at an unexpected time"). Mirrors
+    // BtleHubWasm. Cleared by connectToDevice() (an intentional connect).
+    bool                 m_userDisconnect    = false;
     static constexpr int MAX_RECONNECT_ATTEMPTS = 3;
     static constexpr int RECONNECT_INTERVAL_MS  = 5000;
 


### PR DESCRIPTION
## What

Desktop `BtleHub::onControllerDisconnected()` scheduled an auto-reconnect on **every** disconnect, including intentional ones (rescan teardown, "Skip", workout close, device removed/re-paired). A stale hub would then silently reconnect and start reading characteristics against a controller mid-teardown, producing in the logs:

```
Could not obtain characteristic read result (x3)
Device disconnected
Could not await service operation (A method was called at an unexpected time.)
```

(Surfaced from a Windows v0.0.182 session log while rescanning before opening a workout.)

## Fix

Add the `m_userDisconnect` guard the WASM hub (`btle_hub_wasm.cpp`) already has:
- set it in `disconnectFromDevice()` and stop any pending reconnect timer,
- clear it in `connectToDevice()` (an intentional connect),
- only schedule the reconnect on an **unexpected** drop.

## Testing

Builds + links clean locally. Validated on Windows: Rescan / Skip / close-workout no longer trigger a reconnect storm or the "unexpected time" errors. (Can't repro on Linux CI without trainer hardware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
