### PR TITLE
fix(shutdown): delete web views before profile release on quit

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1120,6 +1120,16 @@ void MainWindow::closeEvent(QCloseEvent *event) {
         return;
     }
 
+    // This MainWindow is heap-allocated in main.cpp and never deleted on quit,
+    // so its QWebEngineView children (and their pages) would otherwise outlive
+    // the default QWebEngineProfile, which Qt releases at process exit:
+    // "Release of profile requested but WebEnginePage still not deleted."
+    // Delete the views now — synchronously, before the event loop ends — so
+    // every page is gone before the profile is. Recurses into nested views
+    // (e.g. the workout/creator web pages inside child widgets).
+    for (auto *webView : findChildren<QWebEngineView*>())
+        delete webView;
+
     // quitOnLastWindowClosed is disabled (see main.cpp), so quit explicitly
     // once the main window has finished closing.
     qApp->quit();


### PR DESCRIPTION
## What

At shutdown the logs showed (3×):

```
Release of profile requested but WebEnginePage still not deleted. Expect troubles !
```

`MainWindow` is heap-allocated in `main.cpp` and **never deleted on the quit path** (`closeEvent` → `qApp->quit()`; no `Desctructor MainWindow` line ever logged). So its `QWebEngineView` children — and their pages — outlive the default `QWebEngineProfile`, which Qt releases at process exit. The related teardown is a known crash source on macOS/Windows (see the existing comment at `mainwindow.cpp`).

## Fix

In `closeEvent`, before `qApp->quit()`, delete all `QWebEngineView` children so every page is gone before the profile is released. `findChildren` recurses into the nested workout/creator web pages too. The logout path returns earlier and is unaffected (there `main.cpp` deletes the window via `deleteLater()`, so no double-free with `delete ui`).

## Testing

Builds + links clean locally; app runs without regression. Validated on Windows: no more `Release of profile` warnings on close. (Doesn't reproduce on Linux — the headless screenshot/sensor-check modes quit via `qApp->quit()` directly and bypass `closeEvent`, and the warning is config-specific.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
