### PR TITLE
fix(workout): prevent triple WorkoutDialog on launch + slim pre-workout sensor screen

### DIFF
--- a/src/btle/sensor_connect_dialog.cpp
+++ b/src/btle/sensor_connect_dialog.cpp
@@ -68,23 +68,20 @@ SensorConnectDialog::SensorConnectDialog(
     mainLayout->addStretch();
 
     // ── Buttons ───────────────────────────────────────────────────────────────
+    // Kept deliberately minimal: just Manage Sensors (edit the saved devices) and
+    // Continue (start once something is connected). Discovery and reconnect are
+    // automatic, so Rescan/Skip would only add clutter to the pre-workout screen.
     QHBoxLayout *btnRow = new QHBoxLayout();
     m_btnManage   = new QPushButton(tr("Manage Sensors…"), this);
-    m_btnRescan   = new QPushButton(tr("Rescan"), this);
-    m_btnSkip     = new QPushButton(tr("Skip"), this);
     m_btnContinue = new QPushButton(tr("Continue"), this);
     m_btnContinue->setDefault(true);
 
     btnRow->addWidget(m_btnManage);
     btnRow->addStretch();
-    btnRow->addWidget(m_btnRescan);
-    btnRow->addWidget(m_btnSkip);
     btnRow->addWidget(m_btnContinue);
     mainLayout->addLayout(btnRow);
 
     connect(m_btnContinue, &QPushButton::clicked, this, &SensorConnectDialog::onContinueClicked);
-    connect(m_btnSkip,     &QPushButton::clicked, this, &SensorConnectDialog::onSkipClicked);
-    connect(m_btnRescan,   &QPushButton::clicked, this, &SensorConnectDialog::onRescanClicked);
     connect(m_btnManage,   &QPushButton::clicked, this, &SensorConnectDialog::onManageClicked);
 
     // ── Discovery agent ─────────────────────────────────────────────────────
@@ -144,19 +141,6 @@ void SensorConnectDialog::startDiscovery()
     }
     refreshButtons();
     m_agent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
-}
-
-void SensorConnectDialog::resetForRescan()
-{
-    if (m_agent && m_agent->isActive())
-        m_agent->stop();
-    m_autoContinueTimer->stop();
-    teardownHubs();
-    for (int i = 0; i < m_slots.size(); ++i) {
-        m_slots[i].status = SlotStatus::Searching;
-        m_slots[i].hub    = nullptr;
-        updateSlotUi(i);
-    }
 }
 
 void SensorConnectDialog::teardownHubs()
@@ -259,22 +243,6 @@ void SensorConnectDialog::onContinueClicked()
     if (m_agent && m_agent->isActive())
         m_agent->stop();
     accept();
-}
-
-void SensorConnectDialog::onSkipClicked()
-{
-    m_autoContinueTimer->stop();
-    if (m_agent && m_agent->isActive())
-        m_agent->stop();
-    teardownHubs();   // discard any connections – caller falls back to manual scan
-    accept();
-}
-
-void SensorConnectDialog::onRescanClicked()
-{
-    resetForRescan();
-    startDiscovery();
-    refreshButtons();
 }
 
 void SensorConnectDialog::onManageClicked()

--- a/src/btle/sensor_connect_dialog.h
+++ b/src/btle/sensor_connect_dialog.h
@@ -58,8 +58,6 @@ private slots:
     void onScanFinished();
     void onScanError(QBluetoothDeviceDiscoveryAgent::Error error);
     void onContinueClicked();
-    void onSkipClicked();
-    void onRescanClicked();
     void onManageClicked();
 
 private:
@@ -74,7 +72,6 @@ private:
     };
 
     void startDiscovery();
-    void resetForRescan();
     void teardownHubs();
     void updateSlotUi(int slotIndex);
     void refreshButtons();
@@ -92,8 +89,6 @@ private:
     bool  m_hubsDetached = false;
 
     QPushButton *m_btnContinue = nullptr;
-    QPushButton *m_btnSkip     = nullptr;
-    QPushButton *m_btnRescan   = nullptr;
     QPushButton *m_btnManage   = nullptr;
 
     QTimer *m_autoContinueTimer = nullptr;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -16,6 +16,7 @@
 #include <QTextStream>
 #include <QGuiApplication>
 #include <QStyleHints>
+#include <QScopeGuard>
 
 #include "util.h"
 #include "logger.h"
@@ -1323,6 +1324,16 @@ void MainWindow::on_actionOpen_Ride_triggered()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::executeWorkout(Workout workout) {
+
+    // Re-entrancy guard: the launch flow below runs nested event loops (the
+    // connection-method / sensor dialogs and the BLE connect wait), during which
+    // a queued double-click on the workout list could otherwise re-enter here and
+    // spawn a second (or third) WorkoutDialog. Block until this launch resolves;
+    // once the workout is actually running isInsideWorkout keeps it blocked.
+    if (m_launchingWorkout || isInsideWorkout)
+        return;
+    m_launchingWorkout = true;
+    auto launchGuard = qScopeGuard([this]() { m_launchingWorkout = false; });
 
     DialogConnectionMethod connDlg(this);
     if (connDlg.exec() != QDialog::Accepted)

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -224,6 +224,11 @@ private:
 
     int currentIndexLeftMenu;
     bool isInsideWorkout;
+    // Guards executeWorkout() against re-entry while a launch is still in flight
+    // (connection/sensor dialogs, BLE connect wait) so a second double-click can
+    // never spawn a second WorkoutDialog. isInsideWorkout takes over once the
+    // workout is actually running.
+    bool m_launchingWorkout = false;
 
     QString lastWorkoutNameDownloaded;
 


### PR DESCRIPTION
## What

Two pre-workout fixes (reported together as "workout dialog opens 3 windows").

### 1. Prevent triple `WorkoutDialog` on launch
Every launch path funnels through `MainWindow::executeWorkout()`, which runs
nested event loops (the connection-method dialog, the sensor-connect dialog, and
the BLE connect wait). A queued/buffered double-click on the workout list could
re-enter `executeWorkout()` before the first launch resolved and spawn a second
or third `WorkoutDialog` — the symptom in the logs was the full dialog
constructor (`GOT HERE WORKOTUDI1` / `DialogConfig constructor`) running 2-3×.

A scoped `m_launchingWorkout` flag now guards re-entry until the launch resolves;
`isInsideWorkout` keeps it blocked once the workout is actually running. The
flag is cleared on every exit via `qScopeGuard`, so cancelling any of the launch
dialogs leaves the next launch free.

### 2. Slim the pre-workout sensor screen
`SensorConnectDialog` is trimmed to just **Manage Sensors…** and **Continue**.
Discovery and reconnect are already automatic, so the **Rescan** and **Skip**
buttons only added clutter. Their now-unused slots/helpers are removed too.
Backing out is still possible via the window close / Escape.

## Testing
- Builds clean (Qt 6.10 local, qmake).
- Headless `--screenshots` smoke run: clean exit, no asserts/crashes.
- Validated on real hardware (BLE trainer + HR): a single workout window opens
  and the sensor screen shows the two buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
