### PR TITLE
fix(workout): mini-graph icon left of value + match detailed widget font

### DIFF
--- a/src/ui/components/infowidget.cpp
+++ b/src/ui/components/infowidget.cpp
@@ -20,7 +20,7 @@ InfoWidget::InfoWidget(QWidget *parent) : QWidget(parent), ui(new Ui::InfoWidget
     // the light/dark palette keep coming from the theme): hero live value,
     // medium secondary stats, small muted captions.
     setStyleSheet(QStringLiteral(R"(
-        QLabel#label_currentValue { font: 600 30pt 'Inter'; }
+        QLabel#label_currentValue { font: 600 25pt 'Inter'; }
         QLabel#label_targetValue, QLabel#label_range { font: 15pt 'Inter'; }
         QLabel#label_avgInterval, QLabel#label_maxInterval,
         QLabel#label_avgWorkout,  QLabel#label_maxWorkout { font: 600 13pt 'Inter'; }

--- a/src/ui/plots/iconitem.cpp
+++ b/src/ui/plots/iconitem.cpp
@@ -1,6 +1,8 @@
 #include "iconitem.h"
 #include "util.h"
 
+#include <QFontMetricsF>
+
 IconItem::IconItem() {}
 
 
@@ -24,8 +26,23 @@ void IconItem::draw( QPainter *painter,
     // pixmap's DPR, so the icon stays a 35px logical box but isn't upscaled blurry).
     const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
     const QPixmap pixmap = Util::loadIconForDpr(path, 35, dpr);
+    const QSizeF iconSize = pixmap.deviceIndependentSize();
 
-    QPointF p(canvasRect.center().x()+30, canvasRect.top());
+    // Sit immediately to the LEFT of the centred value number and vertically
+    // centre on it (matching the detailed InfoWidget), rather than floating at a
+    // fixed offset above. QwtPlotTextLabel draws the number centred horizontally,
+    // inset from the top by its 5px margin.
+    const QFontMetricsF fm(valueFont);
+    const qreal textWidth  = fm.horizontalAdvance(valueText);
+    const qreal textHeight = fm.height();
+    const qreal margin     = 5.0;   // QwtPlotTextLabel default margin
+    const qreal gap        = 6.0;   // space between icon and number
+
+    const qreal textLeft = canvasRect.center().x() - textWidth / 2.0;
+    const qreal textTop  = canvasRect.top() + margin;
+
+    QPointF p(textLeft - gap - iconSize.width(),
+              textTop + textHeight / 2.0 - iconSize.height() / 2.0);
     painter->drawPixmap(p, pixmap);
 
 }

--- a/src/ui/plots/iconitem.h
+++ b/src/ui/plots/iconitem.h
@@ -2,6 +2,8 @@
 #define ICONITEM_H
 
 #include <QPainter>
+#include <QFont>
+#include <QString>
 #include "qwt_plot_item.h"
 
 class IconItem : public QwtPlotItem
@@ -10,11 +12,12 @@ public:
     IconItem();
     void draw( QPainter *painter, const QwtScaleMap &, const QwtScaleMap &, const QRectF &canvasRect ) const;
     QString iconType;
+
+    // The live value drawn beside the icon (the big centred number) and its
+    // font, so the icon can sit immediately to the LEFT of that number and be
+    // vertically centred on it — matching the detailed InfoWidget layout.
+    QString valueText = "0";
+    QFont   valueFont;
 };
 
-
-
-
-
 #endif // ICONITEM_H
-

--- a/src/ui/plots/workoutplotzoomer.cpp
+++ b/src/ui/plots/workoutplotzoomer.cpp
@@ -172,8 +172,10 @@ void WorkoutPlotZoomer::init(GRAPH_TYPE graph, bool firstInit) {
         canvas()->setStyleSheet(" QwtPlotCanvas { background-color: rgb(35, 35, 35); }");
         canvas()->setCursor(Qt::CrossCursor);
 
-        QFont fontBig;
-        fontBig.setPointSize(24);
+        // Match the detailed InfoWidget hero value exactly: 600 30pt 'Inter'.
+        QFont fontBig("Inter");
+        fontBig.setPointSize(30);
+        fontBig.setWeight(QFont::DemiBold);   // CSS weight 600
 
         valueQwtText = QwtText("0");
         valueQwtText.setBorderRadius(3.0);

--- a/src/ui/plots/workoutplotzoomer.cpp
+++ b/src/ui/plots/workoutplotzoomer.cpp
@@ -172,9 +172,9 @@ void WorkoutPlotZoomer::init(GRAPH_TYPE graph, bool firstInit) {
         canvas()->setStyleSheet(" QwtPlotCanvas { background-color: rgb(35, 35, 35); }");
         canvas()->setCursor(Qt::CrossCursor);
 
-        // Match the detailed InfoWidget hero value exactly: 600 30pt 'Inter'.
+        // Match the detailed InfoWidget hero value exactly: 600 25pt 'Inter'.
         QFont fontBig("Inter");
-        fontBig.setPointSize(30);
+        fontBig.setPointSize(25);
         fontBig.setWeight(QFont::DemiBold);   // CSS weight 600
 
         valueQwtText = QwtText("0");

--- a/src/ui/plots/workoutplotzoomer.cpp
+++ b/src/ui/plots/workoutplotzoomer.cpp
@@ -217,6 +217,9 @@ void WorkoutPlotZoomer::init(GRAPH_TYPE graph, bool firstInit) {
 
         icon->attach(this);
         icon->setZ(12);
+        // Let the icon measure the value number so it can sit just left of it.
+        icon->valueFont = fontBig;
+        icon->valueText = "0";
 
 
         zone1 = new ZoneItem( "Zone Start");
@@ -628,11 +631,13 @@ void WorkoutPlotZoomer::updateTextLabelValue(int value) {
     if(value < 0) {
         valueQwtText.setText("-");
         qwtTextLabel->setText( valueQwtText );
+        if (icon) icon->valueText = "-";
         return;
     }
 
     valueQwtText.setText(QString::number(value));
     qwtTextLabel->setText( valueQwtText );
+    if (icon) icon->valueText = valueQwtText.text();
 
 
     /// Ajust graph if we have no target right now

--- a/src/ui/plots/workoutplotzoomer.h
+++ b/src/ui/plots/workoutplotzoomer.h
@@ -101,7 +101,7 @@ private:
     MarkerItem *markerLineMiddle;
     ZoneItem *zone1;
     ZoneItem *zone2;
-    IconItem *icon ;
+    IconItem *icon = nullptr;
 
 
     int target;


### PR DESCRIPTION
## What

Polish for the three bottom mini-graphs (`WorkoutPlotZoomer`) so the live value
reads like the detailed `InfoWidget`.

- **Icon left of the number, vertically levelled.** The metric icon used to
  float at a fixed offset to the right of and above the value. `IconItem` now
  measures the centred value number (it is handed the value text + font) and
  sits immediately to its left, vertically centred on it.
- **Matching font.** The value now uses the same `600 25pt 'Inter'` as the
  detailed widget's hero value (was a plain 24pt). The detailed widget's hero
  value was nudged from 30pt to 25pt at the same time so both stay matched and
  a little more compact.

## Testing
- Builds clean (Qt 6.10 local, qmake).
- Headless `--screenshots` workout capture: the mini-graph value matches the
  detailed panel in size/weight and the icon hugs the left of the number,
  levelled, as the value width changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
