### PR TITLE
fix(workout): stop dialog reopening on switch to race + persist multimedia choice

### DIFF
--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -826,6 +826,11 @@ void DialogConfig::on_comboBox_startTrigger_activated(int index) {
 void DialogConfig::on_comboBox_displayVideo_activated(int index) {
     parentDialog->showVideoPlayer(index);
 
+    // Persist the choice immediately so the next workout opens on the same pane,
+    // even if the user closes this dialog without pressing OK.
+    account->display_video = index;
+    account->saveDisplayPrefs();
+
     //web browser
     ui->label_homePage->setVisible(index == 1);
     ui->lineEdit_homePage->setVisible(index == 1);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -2813,6 +2813,12 @@ QQuickWidget *WorkoutDialog::ensureRaceView() {
     }
     if (!raceView) {
         raceView = new QQuickWidget(this);
+        // If this view ever needs a native window, confine it to the view rather
+        // than promoting the dialog's own window (which would tear the dialog down
+        // and rebuild it). The main guard against that, though, is building this
+        // view at show time while hidden (see showEvent) so the realization is a
+        // one-time, invisible event and never happens on a mid-workout switch.
+        raceView->setAttribute(Qt::WA_DontCreateNativeAncestors, true);
         raceView->setResizeMode(QQuickWidget::SizeRootObjectToView);
         raceView->rootContext()->setContextProperty(QStringLiteral("race"), raceController);
         raceView->setSource(QUrl(QStringLiteral("qrc:/game/qml/RetroRace.qml")));
@@ -3302,6 +3308,14 @@ void WorkoutDialog::showEvent(QShowEvent *event) {
         webPlayerLoaded = true;
         QTimer::singleShot(0, this, [this]() {
             ensureWebPlayer()->loadHomePageIfNeeded();
+            // Build the retro-race view now too, for the same reason: its native
+            // OpenGL surface is realized once here while it can stay hidden, so
+            // switching to it mid-workout never tears down and rebuilds the dialog
+            // window (which looked like the workout reopening). Skip where the race
+            // isn't offered (studio / free ride) — there's no single "player".
+            if (!(account->enable_studio_mode
+                  || workout.getWorkoutNameEnum() == Workout::OPEN_RIDE))
+                ensureRaceView();
             // Re-assert the selected content view now that the dialog is mapped.
             // The native QVideoWidget (Standard video) does not paint when first
             // shown pre-map during init, leaving a black pane until the dropdown


### PR DESCRIPTION
## What

Switching the workout dialog's content pane to the retro race built its
`QQuickWidget` lazily and added it to the dialog mid-workout. Realizing that
view's OpenGL surface then (alongside the embedded web-engine view) tore down and
rebuilt the dialog's native window. Symptoms: the workout appeared to **reopen**,
came back on the **video player**, and its non-modal **settings dialog became
unreachable** (orphaned by the window recreation).

## Fix

- **Pre-build the race view at show time, deferred and hidden** — exactly as the
  web player already is (see `showEvent`). The native/OpenGL surface is realized
  once, invisibly, so a later switch only toggles visibility and never recreates
  the dialog window. Skipped where the race isn't offered (studio / free ride).
- Keep `WA_DontCreateNativeAncestors` on the view as a guard; do **not** force
  `WA_NativeWindow` (a `QQuickWidget` composites via the backing store and
  shouldn't be promoted to its own native window).
- **Persist the multimedia choice the instant the dropdown changes**
  (`account->saveDisplayPrefs()`), so the next workout reopens on the same pane
  even if the settings dialog is closed without OK.

## Testing
- Builds clean (Qt 6.10 local, qmake); headless `--screenshots` run clean.
- Validated live: video → race switch no longer reopens the dialog, settings
  stays reachable, the workout keeps running, and the chosen pane persists across
  workouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
