### PR TITLE
fix(workout): guard interval-jump crash + check column for done workouts

### DIFF
--- a/src/model/workouttablemodel.cpp
+++ b/src/model/workouttablemodel.cpp
@@ -75,7 +75,7 @@ int WorkoutTableModel::rowCount(const QModelIndex &parent) const {
 int WorkoutTableModel::columnCount(const QModelIndex &parent) const {
 
     Q_UNUSED(parent);
-    return 11;
+    return 12;   // 0-9 metrics, 10 Graph, 11 Done (check)
 }
 
 
@@ -114,16 +114,9 @@ QVariant WorkoutTableModel::data(const QModelIndex &index, int role) const {
     }
 
 
-    ///Background
-    if (role == Qt::BackgroundRole && account->hashWorkoutDone.contains(work.getName())) {
-        //        QColor colorCadenceShapeTarget(150,150,150);
-        QLinearGradient linearGrad(QPointF(0, 0), QPointF(0, 125));
-        linearGrad.setColorAt(1, Qt::white);
-        linearGrad.setColorAt(0, QColor(150,150,150));
-
-        return QBrush(linearGrad);
-    }
-
+    // "Done" workouts used to tint the whole row (a white->grey gradient that
+    // looked bad in dark mode). They're now shown with a check in the Done column
+    // instead — see the DisplayRole for the last column below.
 
     ///Highlight colour for user-created workout names
     if (role == Qt::ForegroundRole && index.column() == 0 && account->enable_studio_mode && work.getWorkoutNameEnum() == Workout::MAP_TEST)
@@ -136,6 +129,14 @@ QVariant WorkoutTableModel::data(const QModelIndex &index, int role) const {
                               static_cast<AppTheme::Mode>(account->app_theme)) == AppTheme::Dark;
         return QVariant::fromValue(dark ? QColor(0x5C, 0x9C, 0xFF)   // #5C9CFF
                                         : QColor(0x15, 0x4F, 0xC2)); // #154FC2
+    }
+
+    /// Done check: centred + green (legible on both themes)
+    if (index.column() == 11) {
+        if (role == Qt::TextAlignmentRole)
+            return QVariant(Qt::AlignCenter);
+        if (role == Qt::ForegroundRole)
+            return QVariant::fromValue(QColor(0x2F, 0xAF, 0x5A)); // #2FAF5A
     }
 
 
@@ -184,6 +185,9 @@ QVariant WorkoutTableModel::data(const QModelIndex &index, int role) const {
             if (work.getWorkoutNameEnum() == Workout::MAP_TEST)
                 return ("-");
             return qRound(work.getTrainingStressScore());
+        }
+        else if(index.column() == 11) {  // Done — a check when the workout is marked done
+            return account->hashWorkoutDone.contains(work.getName()) ? QStringLiteral("✓") : QString();
         }
 
         else if(index.column() == 20) {
@@ -327,6 +331,9 @@ QVariant WorkoutTableModel::headerData(int section, Qt::Orientation  orientation
         else if (section == 10) {
             return tr("Graph");
         }
+        else if (section == 11) {
+            return tr("Completed");
+        }
         else {
             return tr("colum not defined");
         }
@@ -371,6 +378,9 @@ QVariant WorkoutTableModel::headerData(int section, Qt::Orientation  orientation
         }
         else if (section == 10) {
             return tr("Graph");
+        }
+        else if (section == 11) {
+            return QString();   // no visible header for the small Done column
         }
         else {
             return tr("colum not defined");

--- a/src/ui/main_workoutpage.cpp
+++ b/src/ui/main_workoutpage.cpp
@@ -104,7 +104,10 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     ui->tableView_workout->setColumnWidth(7, 40);
     ui->tableView_workout->setColumnWidth(8, 40);
     ui->tableView_workout->setColumnWidth(9, 40);
-    ui->tableView_workout->horizontalHeader()->setStretchLastSection(true);
+    ui->tableView_workout->setColumnWidth(11, 34);   // Done (check) — small, no header
+    // Let the Graph column fill the remaining width (it used to be the last
+    // section; the new Done column is last now, so stretch the Graph explicitly).
+    ui->tableView_workout->horizontalHeader()->setSectionResizeMode(10, QHeaderView::Stretch);
     ui->tableView_workout->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableView_workout->setSelectionBehavior(QAbstractItemView::SelectRows);
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1497,8 +1497,10 @@ void WorkoutDialog::moveToInterval(int nbInterval, double secWorkout, double sta
     copyLstInterval.replace(currentInterval, intervalToModify);
 
 
-    //Remove interval that we skipped (if clicked more than 1 interval ahead)
-    for (int i=0; i<nbIntervalToDelete; i++) {
+    //Remove interval that we skipped (if clicked more than 1 interval ahead).
+    // Guard the index: an abnormal jump (e.g. negative time-done) can over-count
+    // nbIntervalToDelete; removeAt() past the end is undefined behaviour (crash).
+    for (int i=0; i<nbIntervalToDelete && copyLstInterval.size() > currentInterval+1; i++) {
         copyLstInterval.removeAt(currentInterval+1);
     }
 
@@ -1521,10 +1523,20 @@ void WorkoutDialog::moveToInterval(int nbInterval, double secWorkout, double sta
         changeIntervalsDataWorkout(lastIntervalEndTime_msec, timeElapsed_sec, intervalPausedTime_msec, false, currentIntervalObj.isTestInterval());
     }
 
-    //Go to selected interval
+    //Go to selected interval (clamp the index — getInterval() uses at() with no
+    //bounds check, so an out-of-range index would segfault).
     currentInterval++;
+    if (currentInterval >= workout.getLstInterval().size())
+        currentInterval = workout.getLstInterval().size() - 1;
     currentIntervalObj = workout.getInterval(currentInterval);
     adjustTargets(currentIntervalObj);
+
+    // Keep the game's interval label in step with a manual jump (adjustTargets
+    // already refreshes the power/cadence/HR targets, but not the message).
+    if (raceController) {
+        raceController->markIntervalBoundary();
+        raceController->setIntervalMessage(currentIntervalObj.getDisplayMessage());
+    }
 
     if (currentIntervalObj.getDisplayMessage() != "")
         ui->widget_workoutPlot->setDisplayIntervalMessage(false, currentIntervalObj.getDisplayMessage(), account->nb_sec_show_interval);
@@ -1562,7 +1574,8 @@ void WorkoutDialog::moveToNextInterval() {
     changeIntervalDisplayNextSecond = false;
     ignoreCondition = true;
 
-
+    if (currentInterval + 1 >= workout.getLstInterval().size())
+        return;   // already on the last interval — no next to preview (at() would crash)
     Interval newInterval = workout.getLstInterval().at(currentInterval+1);
     if (newInterval.getDisplayMessage() != "")
         ui->widget_workoutPlot->setDisplayIntervalMessage(false, newInterval.getDisplayMessage(), account->nb_sec_show_interval);


### PR DESCRIPTION
Two small workout-app fixes Maxime hit while testing.

## 1. Crash when skipping intervals via the graph
Clicking the workout graph to jump to a later interval could **segfault**.
`Workout::getInterval()` uses `QList::at()` with no bounds check, and the jump
path (`moveToInterval`) could index out of range — the `removeAt` loop can
over-count when the time-done goes negative (`we did: -7.912 …`), and
`currentInterval++` can run past the end. Added bounds guards (the `removeAt`
loop, a clamp before `getInterval()`, and the matching `at(currentInterval+1)`
in `moveToNextInterval`).

Also: the in-workout game/retro-race interval label didn't update on a **manual**
graph jump (only on automatic interval changes) — `moveToInterval` now pushes the
new interval's message + marker too.

> Note: the underlying negative time-done is a separate, pre-existing timing
> anomaly in the jump bookkeeping; these guards make it non-fatal but don't
> root-cause it.

## 2. "Done" workouts: check column instead of a row tint
Marking a workout done painted the whole row with a white→grey gradient that
looks bad in dark mode. Replaced it with a small, **header-less check column** at
the end of the list: a green ✓ when the workout is in `hashWorkoutDone`, and the
BackgroundRole tint removed. The Graph column now stretches to fill (it was the
last/stretched section); the new check column is a fixed 34 px with an empty
header (a "Completed" tooltip on hover).

> A "number of times done" count was discussed but deferred — `hashWorkoutDone`
> is a boolean set today, so a real count needs new tracking (e.g. auto-increment
> on completion). Can add in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
