### PR TITLE
feat(gears): retune virtual shifting - easier low gears, harder top, lower start

### DIFF
--- a/src/btle/zwift/virtual_gear.h
+++ b/src/btle/zwift/virtual_gear.h
@@ -16,10 +16,11 @@
  */
 namespace VirtualGear {
 
-constexpr int    Count        = 24;     // virtual gears (matches Zwift)
+constexpr int    Count            = 30;  // virtual gears
+constexpr int    DefaultStartGear = 6;   // easy gear the first slope interval opens in
 constexpr double RefCadence   = 85.0;   // cadence at which the base watts apply
-constexpr double EasiestCoeff = 0.5;    // gear 1 multiplier
-constexpr double HardestCoeff = 2.0;    // gear Count multiplier
+constexpr double EasiestCoeff = 0.25;   // gear 1 multiplier (true granny gear ≈ 0.12×FTP)
+constexpr double HardestCoeff = 2.2;    // gear Count multiplier
 constexpr double BaseFtpFrac  = 0.48;   // mid gear @ RefCadence ≈ 0.6×FTP
 constexpr double DefaultFtp   = 200.0;  // used when the rider FTP is unknown
 
@@ -50,7 +51,7 @@ inline int targetWatts(int gear, double cadence, double ftp)
 // value is in the trainer's 0.1-unit resistance representation (2AD6 range).
 // Mapped linearly across a usable middle band of a 0..100 range so the extremes
 // aren't unrideable; clamped to the trainer's actual [min,max].
-constexpr int EasiestResistance = 15;   // gear 1   (1.5)
+constexpr int EasiestResistance = 8;    // gear 1   (0.8) - easy spin
 constexpr int HardestResistance = 85;   // gear Count (8.5)
 
 inline int resistanceLevel(int gear, int minLevel = 0, int maxLevel = 100)

--- a/src/btle/zwift/virtual_gear.h
+++ b/src/btle/zwift/virtual_gear.h
@@ -20,7 +20,7 @@ constexpr int    Count            = 30;  // virtual gears
 constexpr int    DefaultStartGear = 6;   // easy gear the first slope interval opens in
 constexpr double RefCadence   = 85.0;   // cadence at which the base watts apply
 constexpr double EasiestCoeff = 0.25;   // gear 1 multiplier (true granny gear ≈ 0.12×FTP)
-constexpr double HardestCoeff = 2.2;    // gear Count multiplier
+constexpr double HardestCoeff = 3.0;    // gear Count multiplier (top gear ≈ 1.44×FTP @ ref cadence)
 constexpr double BaseFtpFrac  = 0.48;   // mid gear @ RefCadence ≈ 0.6×FTP
 constexpr double DefaultFtp   = 200.0;  // used when the rider FTP is unknown
 
@@ -42,7 +42,8 @@ inline int targetWatts(int gear, double cadence, double ftp)
     // Aero-like: power ∝ cadence² so spinning faster in a gear costs more.
     const double cadFactor = (cad / RefCadence) * (cad / RefCadence);
     const double watts = BaseFtpFrac * effFtp * coeffForGear(gear) * cadFactor;
-    return qBound(20, int(qRound(watts)), int(qRound(1.6 * effFtp)));
+    // Top gear at race cadence can demand up to ~2×FTP (short grind/surge).
+    return qBound(20, int(qRound(watts)), int(qRound(2.0 * effFtp)));
 }
 
 // ── Resistance-level shifting (FTMS 0x04) ────────────────────────────────────
@@ -52,7 +53,7 @@ inline int targetWatts(int gear, double cadence, double ftp)
 // Mapped linearly across a usable middle band of a 0..100 range so the extremes
 // aren't unrideable; clamped to the trainer's actual [min,max].
 constexpr int EasiestResistance = 8;    // gear 1   (0.8) - easy spin
-constexpr int HardestResistance = 85;   // gear Count (8.5)
+constexpr int HardestResistance = 95;   // gear Count (9.5) - hard grind
 
 inline int resistanceLevel(int gear, int minLevel = 0, int maxLevel = 100)
 {

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1589,7 +1589,9 @@ void WorkoutDialog::moveToNextInterval() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void WorkoutDialog::startWorkout() {
 
-    m_virtualGear = (VirtualGear::Count + 1) / 2;   // every workout starts mid-gear
+    // Open each workout in an easy gear; the rider's shifts then persist across
+    // intervals (only reset here, at workout start).
+    m_virtualGear = VirtualGear::DefaultStartGear;
     updateGearIndicator();
 
     emit startClock();

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -313,7 +313,7 @@ private:
     // virtual gear that drives the trainer via the (working) FTMS ERG path,
     // cadence-aware so it feels like a gear rather than a flat ERG clamp.
     static constexpr int kVirtualGearCount = VirtualGear::Count;
-    int  m_virtualGear = (VirtualGear::Count + 1) / 2;   // start mid-gear
+    int  m_virtualGear = VirtualGear::DefaultStartGear;   // start in an easy gear
     bool m_trainerSupportsResistanceLevel = false;       // FTMS 0x04 available?
     bool virtualShiftingActive() const;           // a trainer is under our control
     bool ergOwnsThisInterval() const;             // ERG enabled + active power target


### PR DESCRIPTION
## What

Retune the virtual-shifting gear model so slope-mode gears are usable across the whole rider range: genuinely easy at the bottom, hard enough at the top, and opening in a sensible gear.

All values live in one header (`src/btle/zwift/virtual_gear.h`) so they stay easy to tune.

### Changes
- **More gears**: `Count` 24 -> 30 (finer steps).
- **Lower, persisted start gear**: new `DefaultStartGear = 6`. Each workout opens in an easy gear instead of mid (was 12/24); the rider's shifts then persist across intervals (gear only resets at workout start, as before).
- **Easier low end**: `EasiestCoeff` 0.5 -> 0.25 - gear 1 is now a true granny gear (~0.12×FTP, ≈24W @FTP200) instead of ~0.24×FTP (which reached ~90W at high FTP/cadence).
- **Harder top end** (so strong riders have range): `HardestCoeff` 2.2 -> 3.0 (top gear ≈ 1.44×FTP at ref cadence), ERG watts cap 1.6×FTP -> 2.0×FTP (top gear scales with cadence into a short grind/surge), and `HardestResistance` 85 -> 95 on the FTMS-0x04 fixed-brake path.

### Resulting range (watts scale with FTP and cadence²)
| gear | FTP200 / 85rpm | FTP250 / 85rpm | FTP300 / 90rpm |
|---|---|---|---|
| 1 | 24 | 30 | 40 |
| 6 (start) | 70 | 87 | 117 |
| 15 | 151 | 189 | 255 |
| 30 | 288 (399 @100rpm) | 360 | 484 |

## Testing
- `make -j` builds clean; headless screenshot run starts and exits cleanly.
- No unit tests pin gear values, so nothing to update.
- Gear *feel* is subjective and will be validated on the trainer post-merge; the constants are centralized for quick follow-up tuning.

## Notes
Two trainer paths are retuned consistently: ERG `setLoad` (cadence-aware target watts, most trainers) and `setResistance` (FTMS 0x04 fixed brake). No behaviour change outside the gear model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
