### PR TITLE
fix(ble): retry connect-phase failures so flaky pairing recovers

### DIFF
--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -81,6 +81,17 @@ void BtleHub::setWheelCircumferenceMm(int mm)
 
 void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
 {
+    // Fresh, user-initiated connect: remember the target and reset the retry
+    // budget. The actual controller setup (and every retry) goes through
+    // attemptConnection(), which must NOT reset the budget.
+    m_reconnectDevice   = device;
+    m_reconnectAttempts = 0;
+    m_userDisconnect    = false;
+    attemptConnection();
+}
+
+void BtleHub::attemptConnection()
+{
     if (m_controller) {
         m_controller->disconnectFromDevice();
         delete m_controller;
@@ -102,11 +113,8 @@ void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
     m_ftmsPendingCmd.clear();
     m_ftmsLastSentCmd.clear();
     m_ftmsLastAckedCmd.clear();
-    m_reconnectDevice   = device;
-    m_reconnectAttempts = 0;
-    m_userDisconnect    = false;
 
-    m_controller = QLowEnergyController::createCentral(device, this);
+    m_controller = QLowEnergyController::createCentral(m_reconnectDevice, this);
 
     connect(m_controller, &QLowEnergyController::connected,
             this, &BtleHub::onControllerConnected);
@@ -268,6 +276,9 @@ void BtleHub::simulateNotification(quint16 characteristicUuid, const QByteArray 
 void BtleHub::onControllerConnected()
 {
     LOG_INFO("BtleHub", QStringLiteral("Device connected — discovering services"));
+    // A successful link refreshes the retry budget so a later drop gets its
+    // own full set of attempts.
+    m_reconnectAttempts = 0;
     m_controller->discoverServices();
 }
 
@@ -286,17 +297,37 @@ void BtleHub::onControllerDisconnected()
 
 void BtleHub::onReconnectTimer()
 {
-    LOG_INFO("BtleHub", QStringLiteral("Reconnect attempt ") + QString::number(m_reconnectAttempts + 1));
     ++m_reconnectAttempts;
-    connectToDevice(m_reconnectDevice);
+    LOG_INFO("BtleHub", QStringLiteral("Reconnect attempt ") + QString::number(m_reconnectAttempts));
+    // Go through attemptConnection() (not connectToDevice) so the running
+    // attempt count is preserved and MAX_RECONNECT_ATTEMPTS actually caps.
+    attemptConnection();
 }
 
 void BtleHub::onControllerError(QLowEnergyController::Error error)
 {
-    const QString errStr = m_controller->errorString();
+    const QString errStr = m_controller ? m_controller->errorString()
+                                        : QStringLiteral("controller error");
     LOG_WARN("BtleHub",
              QStringLiteral("BLE controller error ") + QString::number(static_cast<int>(error))
              + QStringLiteral(": ") + errStr);
+
+    // A connect-phase failure (BlueZ connect timeout / adapter busy) is often
+    // transient. Retry a few times before surfacing the error to the UI rather
+    // than failing the workout on the first miss — onControllerDisconnected only
+    // auto-reconnects drops that happen AFTER a successful connect.
+    const bool connectPhase =
+        !m_controller
+        || (m_controller->state() != QLowEnergyController::DiscoveredState
+            && m_controller->state() != QLowEnergyController::ConnectedState);
+
+    if (connectPhase && !m_userDisconnect
+        && m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+        if (m_reconnectTimer && !m_reconnectTimer->isActive())
+            m_reconnectTimer->start(RECONNECT_INTERVAL_MS);
+        return;
+    }
+
     emit connectionError(errStr);
 }
 

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -121,6 +121,10 @@ private slots:
     void onReconnectTimer();
 
 private:
+    // (Re)create the controller and start a connection to m_reconnectDevice
+    // without touching m_reconnectAttempts, so connect-phase retries keep a
+    // running count against MAX_RECONNECT_ATTEMPTS.
+    void attemptConnection();
     void setupService(QLowEnergyService *service);
     void enableNotification(QLowEnergyService *service,
                             const QLowEnergyCharacteristic &characteristic);


### PR DESCRIPTION
## What

Fixes intermittent BLE pairing failures: pairing sometimes errored out with `Connect to device failed due to timeout` (controller error 5) and gave up on the **first** miss, killing the workout. BlueZ's initial connect is frequently slow/flaky, so a single miss shouldn't be fatal.

## Root cause

1. **No retry on the initial connect.** `BtleHub::onControllerError()` just logged and emitted `connectionError`. The auto-reconnect path (`onControllerDisconnected` -> reconnect timer) only covers drops **after** a successful connect; a connect-phase timeout never reached it, so the workout failed on the first attempt.
2. **The retry counter never engaged.** `onReconnectTimer()` incremented `m_reconnectAttempts` but then called `connectToDevice()`, which reset it to `0` - so `MAX_RECONNECT_ATTEMPTS` never capped and the increment was meaningless.

## Changes (`src/btle/btle_hub.cpp` / `.h`)

- `onControllerError()` now **retries connect-phase failures** (controller not yet `Connected`/`Discovered`) via the existing reconnect timer, up to `MAX_RECONNECT_ATTEMPTS`, and only surfaces `connectionError` to the UI once the budget is exhausted.
- Split the controller setup into a new private `attemptConnection()` used by **both** the reconnect timer and the connect-phase retry, so the running attempt count is preserved. `connectToDevice()` resets the budget only for a fresh, user-initiated connect; a successful link (`onControllerConnected`) refreshes it so a later drop gets its own full set of attempts.

Net effect: a flaky first connect now silently retries a few times and recovers, instead of erroring out. Look for `Reconnect attempt N` in the log when it kicks in.

## Testing

- Builds clean (`make -j`).
- Validated live on real hardware (trainer pairing): connects that previously errored out now retry and recover.

## Not included (follow-up)

The Zwift Click stream watchdog churn (both controllers going QUIET/re-kicking every ~3s, adding BLE contention during a workout) is a separate contributor and intentionally left for a follow-up branch so this trainer-connect fix can be evaluated on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
