### PR TITLE
docs: drop Retro Race screenshot from README; move refresh note to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,8 @@ Validation checklist:
 - Screenshots live in `docs/assets/screenshots/`; regenerate with
   `--screenshots /tmp/shots` (set `app_theme=1` in the QSettings conf for dark mode)
   when the UI changes. The README/guide reference them via `docs/assets/...`.
+  Shortcut: run `scripts/update-screenshots.sh` — it captures the app in headless
+  dark-theme mode and overwrites the docs screenshots in place (build the app first).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,6 @@ For everything about **using** the app — pairing sensors, finding / importing 
 |---------------------------------------|
 | ![Studio mode configuration — per-rider name, FTP/LTHR, sensors, and ERG control for up to 8 riders](docs/assets/screenshots/screenshot_studio_mode.png) |
 
-| Retro Race — ghost-race game mode |
-|-----------------------------------|
-| ![Retro Race — a pseudo-3D ghost race in the workout player; your live power drives your rider against a ghost replay](docs/assets/screenshots/screenshot_retro_race.png) |
-
-> **Refreshing these images:** run `scripts/update-screenshots.sh`. It captures
-> the app in headless dark-theme mode and overwrites the docs screenshots in
-> place (build the app first — see [Building](#building)).
-
 ## Building
 
 All three platforms are built and tested automatically via GitHub Actions CI (see `.github/workflows/build.yml`). Use `MaximumTrainer.pro` with `qmake` and a standard C++ compiler.


### PR DESCRIPTION
Removes the **Retro Race** entry from the README Screenshots gallery - it's not needed there (the feature stays documented on the Pages site: `docs/index.html` and `docs/user-guide.html`).

Also moves the `scripts/update-screenshots.sh` refresh note out of the README and into the agent guidance in `CLAUDE.md`, alongside the existing screenshot-regeneration notes.

The `screenshot_retro_race.png` asset is kept (still referenced by the Pages docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
