### PR TITLE
feat(queue): add Start Queue button; harden queue advance (#208)

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -388,6 +388,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
     connect(ui->tab_workout1, &Main_WorkoutPage::addWorkoutToQueue,
             this, &MainWindow::addWorkoutToQueue);
+    connect(m_queuePanel, &QueuePanelWidget::startQueueRequested,
+            this, &MainWindow::startWorkoutQueue);
 
 #ifdef GC_WASM_BUILD
     // Expose the demo-workout test hook so Playwright can drive the app into
@@ -693,13 +695,57 @@ void MainWindow::saveAndNavigateToWorkout(const Workout &workout, const QString 
 }
 
 /////////////////////////////////////////////////////////////////////////////////
-void MainWindow::tryAdvanceWorkoutQueue()
+// Launch the queue from item #1 (triggered by the Start button). Dequeues the
+// first workout itself and runs it directly; the normal finished()→advance chain
+// then handles the rest. Dequeuing here is what prevents the double-run the issue
+// describes (where double-clicking a list row also re-ran it as queue item #1).
+void MainWindow::startWorkoutQueue()
 {
-    if (m_workoutQueue->isEmpty())
+    if (m_launchingWorkout || isInsideWorkout)
         return;
 
-    const QString nextName = m_workoutQueue->name(0);
-    const QString nextPath = m_workoutQueue->filePath(0);
+    // Take the next non-blank item atomically (see tryAdvanceWorkoutQueue).
+    QString name;
+    QString path;
+    while (!m_workoutQueue->isEmpty()) {
+        name = m_workoutQueue->name(0);
+        path = m_workoutQueue->dequeueFilePath();
+        if (!path.isEmpty())
+            break;
+    }
+    if (path.isEmpty())
+        return;
+
+    XmlUtil xml;
+    Workout first = xml.parseSingleWorkoutXml(path);
+    if (!first.getName().isEmpty()) {
+        executeWorkout(first);
+    } else {
+        QMessageBox::warning(this,
+                             tr("Queue Error"),
+                             tr("Could not load the queued workout:\n%1\n(%2)").arg(name, path));
+        tryAdvanceWorkoutQueue();
+    }
+}
+
+void MainWindow::tryAdvanceWorkoutQueue()
+{
+    // Take the next item NOW (atomically), skipping any blank entries. The
+    // countdown below spins a nested event loop, so if we only read here and
+    // deferred the dequeue, a re-entrant advance could read the same item again
+    // or observe a half-updated queue — that produced the empty-path "Could not
+    // load the next queued workout" error.
+    QString nextName;
+    QString nextPath;
+    while (!m_workoutQueue->isEmpty()) {
+        nextName = m_workoutQueue->name(0);
+        nextPath = m_workoutQueue->dequeueFilePath();
+        if (!nextPath.isEmpty())
+            break;
+    }
+    if (nextPath.isEmpty())
+        return;
+
     WorkoutCountdownDialog countdown(nextName, 60, this);
     if (countdown.exec() != QDialog::Accepted) {
         // User chose "Cancel Queue" — clear the remaining queue so it doesn't
@@ -711,16 +757,18 @@ void MainWindow::tryAdvanceWorkoutQueue()
 
     // Defer via singleShot so this stack frame fully unwinds before
     // the next workout begins — avoids unbounded recursion with long queues.
-    QTimer::singleShot(0, this, [this, nextPath]() {
+    QTimer::singleShot(0, this, [this, nextName, nextPath]() {
         XmlUtil xmlNext;
         Workout next = xmlNext.parseSingleWorkoutXml(nextPath);
-        m_workoutQueue->dequeueFilePath();
         if (!next.getName().isEmpty()) {
             executeWorkout(next);
         } else {
             QMessageBox::warning(this,
                                  tr("Queue Error"),
-                                 tr("Could not load the next queued workout:\n%1").arg(nextPath));
+                                 tr("Could not load the next queued workout:\n%1\n(%2)")
+                                     .arg(nextName, nextPath));
+            // The bad entry is already removed; keep the queue moving.
+            tryAdvanceWorkoutQueue();
         }
     });
 }

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -189,6 +189,7 @@ private:
     void saveAndNavigateToWorkout(const Workout &workout, const QString &subFolder);
 
     void tryAdvanceWorkoutQueue();
+    void startWorkoutQueue();
 
     // Screenshot mode helpers
     Workout makeDemoWorkout() const;

--- a/src/ui/queuepanelwidget.cpp
+++ b/src/ui/queuepanelwidget.cpp
@@ -13,12 +13,16 @@ QueuePanelWidget::QueuePanelWidget(WorkoutQueue *queue, QWidget *parent)
     layout->setContentsMargins(6, 6, 6, 6);
     layout->setSpacing(4);
 
-    auto *titleLbl = new QLabel(tr("<b>Workout Queue</b>"), this);
-    layout->addWidget(titleLbl);
+    // No title label here: the enclosing QDockWidget already shows "Workout Queue".
 
     m_list = new QListWidget(this);
     m_list->setDragDropMode(QAbstractItemView::NoDragDrop);
     layout->addWidget(m_list, 1);
+
+    // Start the queue from item #1.
+    m_startBtn = new QPushButton(tr("▶ Start Queue"), this);
+    m_startBtn->setToolTip(tr("Start the first workout in the queue"));
+    layout->addWidget(m_startBtn);
 
     // Button row
     auto *btnRow = new QHBoxLayout();
@@ -43,6 +47,7 @@ QueuePanelWidget::QueuePanelWidget(WorkoutQueue *queue, QWidget *parent)
     m_statusLbl->setStyleSheet("color: #888; font-style: italic;");
     layout->addWidget(m_statusLbl);
 
+    connect(m_startBtn,  &QPushButton::clicked, this, &QueuePanelWidget::startQueueRequested);
     connect(m_removeBtn, &QPushButton::clicked, this, &QueuePanelWidget::onRemove);
     connect(m_upBtn,     &QPushButton::clicked, this, &QueuePanelWidget::onMoveUp);
     connect(m_downBtn,   &QPushButton::clicked, this, &QueuePanelWidget::onMoveDown);
@@ -59,6 +64,7 @@ void QueuePanelWidget::refresh()
         m_list->addItem(QString("%1. %2").arg(i + 1).arg(m_queue->name(i)));
 
     const bool hasItems = !m_queue->isEmpty();
+    m_startBtn->setEnabled(hasItems);
     m_removeBtn->setEnabled(hasItems);
     m_upBtn->setEnabled(hasItems);
     m_downBtn->setEnabled(hasItems);

--- a/src/ui/queuepanelwidget.h
+++ b/src/ui/queuepanelwidget.h
@@ -16,6 +16,10 @@ class QueuePanelWidget : public QWidget
 public:
     explicit QueuePanelWidget(WorkoutQueue *queue, QWidget *parent = nullptr);
 
+signals:
+    /// Emitted when the user clicks Start; MainWindow launches queue item #1.
+    void startQueueRequested();
+
 private slots:
     void refresh();
     void onRemove();
@@ -27,6 +31,7 @@ private:
     WorkoutQueue  *m_queue      = nullptr;
     QListWidget   *m_list       = nullptr;
     QLabel        *m_statusLbl  = nullptr;
+    QPushButton   *m_startBtn   = nullptr;
     QPushButton   *m_removeBtn  = nullptr;
     QPushButton   *m_upBtn      = nullptr;
     QPushButton   *m_downBtn    = nullptr;

--- a/src/ui/workoutcountdowndialog.cpp
+++ b/src/ui/workoutcountdowndialog.cpp
@@ -19,6 +19,7 @@ WorkoutCountdownDialog::WorkoutCountdownDialog(const QString &nextWorkoutName,
     layout->setContentsMargins(20, 20, 20, 20);
 
     m_label = new QLabel(this);
+    m_label->setTextFormat(Qt::RichText);
     m_label->setAlignment(Qt::AlignCenter);
     m_label->setWordWrap(true);
     QFont f = m_label->font();
@@ -48,8 +49,8 @@ WorkoutCountdownDialog::WorkoutCountdownDialog(const QString &nextWorkoutName,
 
 void WorkoutCountdownDialog::updateLabel()
 {
-    m_label->setText(tr("Next workout:\n<b>%1</b>\n\nStarting in <b>%2</b> second(s)…")
-                     .arg(m_workoutName)
+    m_label->setText(tr("Next workout:<br><b>%1</b><br><br>Starting in <b>%2</b> second(s)…")
+                     .arg(m_workoutName.toHtmlEscaped())
                      .arg(m_remaining));
 }
 


### PR DESCRIPTION
## Summary

Implements **part 1** of #208 (the Start button + queue-advance robustness); the larger "reuse one live WorkoutDialog/BLE session across queued items" idea (part 2) is intentionally deferred.

### What changed
- **Start Queue button** in the queue panel — launches queue item #1 directly. `MainWindow::startWorkoutQueue()` dequeues the first item itself, so the workout no longer has to be double-clicked in the list (which could run it twice: once standalone, once as queue item #1). Enabled only when the queue is non-empty; implicitly disabled while a workout runs.
- **Hardened queue advance** — `tryAdvanceWorkoutQueue()`/`startWorkoutQueue()` now take the next item *atomically* instead of reading `filePath(0)` up front and dequeuing later inside a deferred `singleShot`. The countdown dialog's nested event loop let a re-entrant advance run against a half-updated queue, which surfaced as the empty-path **"Could not load the next queued workout"** error. Blank entries are now skipped, the queue self-heals past a bad entry, and the error message shows name + path.
- **UI polish** — dropped the redundant in-panel "Workout Queue" title (the dock title bar already shows it) and render the countdown dialog as rich text (bold/line-breaks instead of literal `<b>` tags).

### Acceptance criteria (#208)
- [x] A clear way to start the queue from the panel (Start button), launching item #1.
- [x] Starting the queue does not double-run the first workout.
- [x] Connection handling between queued workouts decided: keep the existing per-workout re-prompt (session reuse deferred to part 2).
- [x] Behaviour documented in the commit (countdown, skip, cancel-queue).

### Testing
Built locally (Qt 6.10 / QWT 6.3.0) and validated in the running app: Start Queue, auto-advance, Start Now, Cancel Queue, blank-entry skip, and the corrected countdown text.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
