### PR TITLE
fix(ci): unbreak mac intervals-icu integration build on new Xcode

### DIFF
--- a/tests/intervals_icu_integration/intervals_icu_integration_tests.pro
+++ b/tests/intervals_icu_integration/intervals_icu_integration_tests.pro
@@ -48,3 +48,13 @@ SOURCES += \
 HEADERS += \
     tst_intervals_icu_integration.h \
     ../../src/persistence/db/intervals_icu_api.h
+
+# Qt 6.7.3's <QtCore> qyieldcpu.h calls the ARM intrinsic __yield() without
+# including <arm_acle.h>; newer Xcode (macos-latest runner image) promotes
+# -Wimplicit-function-declaration to a hard error. This is a core-only test
+# (QT = core network testlib), so unlike the gui/widgets test targets nothing
+# transitively pulls in <arm_acle.h> first. __yield is a clang builtin and
+# still lowers correctly, so keep it a warning rather than a hard error.
+macx {
+    QMAKE_CXXFLAGS += -Wno-error=implicit-function-declaration
+}


### PR DESCRIPTION
## Problem

The master Build Workflow went red after the `macos-latest` runner image bumped Xcode. The new clang promotes `-Wimplicit-function-declaration` to a **hard error**, and Qt 6.7.3's `<QtCore>` header `qyieldcpu.h` calls the ARM intrinsic `__yield()` without including `<arm_acle.h>`:

```
qyieldcpu.h:35:5: error: implicitly declaring library function '__yield'
  with type 'void ()' [-Werror,-Wimplicit-function-declaration]
```

This is a deterministic **compile** failure (it fails at "Build integration tests", before any test runs), not a flake. It's infra-driven: the prior master run passed with no mac-touching change; only the runner image changed. Because `package_mac` -> `publish` depend on `build_mac`, a red mac build also blocks releases.

Only `build_mac / test_intervals_icu_integration` is affected: its include chain (network/IntervalsIcuApi sources) reaches `qyieldcpu.h` without `<arm_acle.h>` being pulled in first, unlike the gui/widgets test targets.

## Fix

`__yield` is a clang builtin that lowers correctly even when implicitly declared, so demote the diagnostic back to a warning for this target on mac:

```pro
macx {
    QMAKE_CXXFLAGS += -Wno-error=implicit-function-declaration
}
```

Preferred over force-including `<arm_acle.h>` because the flag is portable across runner archs.

## Verification

Full `build.yml` is green on this branch, including `build_mac / test_intervals_icu_integration` (was failing, now passes).

## Follow-up (not in this PR)

A more durable guard would be pinning `runs-on: macos-latest` to a fixed image so an Xcode bump can't silently break the build again. Left out here to keep this a focused hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
