### PR TITLE
feat(history): complete Workout History Dashboard (#144)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1225,3 +1225,34 @@ jobs:
 
     - name: Run PlanAdherence tests
       run: ./build/tests/plan_adherence_tests -v2
+
+  test_history:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: ${{ env.QT_VERSION }}
+        host: 'linux'
+        target: 'desktop'
+        arch: 'linux_gcc_64'
+        cache: true
+        cache-key-prefix: qt-linux
+
+    - name: Build History tests
+      run: |
+        mkdir -p build/tests
+        cd tests/history
+        qmake history_tests.pro
+        make -j$(nproc)
+
+    - name: Run History tests
+      run: ./build/tests/history_tests -v2

--- a/src/fitness/pmccalculator.cpp
+++ b/src/fitness/pmccalculator.cpp
@@ -10,15 +10,23 @@ QList<PmcPoint> PmcCalculator::compute(const QList<WorkoutHistorySummary> &histo
     if (history.isEmpty())
         return {};
 
-    // Build a date → TSS map (sum multiple activities on the same day)
+    // Build a date → TSS map (sum multiple activities on the same day).
+    // Skip entries with an invalid start time (e.g. activities whose FIT file
+    // had no session data) — a null QDate would otherwise poison `earliest` and
+    // make the day-by-day loop below never terminate.
     QHash<QDate, double> tssByDate;
-    QDate earliest = history.first().startTime.date();
+    QDate earliest;
     for (const WorkoutHistorySummary &s : history) {
         const QDate d = s.startTime.date();
+        if (!d.isValid())
+            continue;
         tssByDate[d] += s.tss;
-        if (d < earliest)
+        if (!earliest.isValid() || d < earliest)
             earliest = d;
     }
+
+    if (!earliest.isValid())
+        return {};
 
     // Start the computation leadInDays before the first activity so the EMAs
     // have time to warm up from zero.

--- a/src/model/model.pri
+++ b/src/model/model.pri
@@ -38,6 +38,7 @@ HEADERS += src/model/interval.h\
     $$PWD/trackpoint.h \
     $$PWD/userstudio.h \
     $$PWD/workouthistorysummary.h \
+    $$PWD/workouthistorydetail.h \
     $$PWD/planadherence.h \
     $$PWD/planadherencestore.h \
     $$PWD/workoutqueue.h

--- a/src/model/workouthistorydetail.h
+++ b/src/model/workouthistorydetail.h
@@ -1,0 +1,43 @@
+#ifndef WORKOUTHISTORYDETAIL_H
+#define WORKOUTHISTORYDETAIL_H
+
+#include <QVector>
+
+/// One per-second (or per-record) sample re-read from a stored activity FIT file.
+/// Missing channels are left at their default (a negative sentinel for "absent").
+struct ActivityRecordPoint
+{
+    int    elapsedSec = 0;
+    int    power      = -1;
+    int    heartRate  = -1;
+    int    cadence    = -1;
+    double distanceKm = -1.0;
+};
+
+/// One lap / interval summary re-read from a stored activity FIT file.
+struct ActivityLap
+{
+    int    durationSec     = 0;
+    int    avgPowerW       = 0;
+    int    maxPowerW       = 0;
+    int    normalizedPower = 0;
+    int    avgHrBpm        = 0;
+    int    maxHrBpm        = 0;
+    int    avgCadence      = 0;
+    double distanceKm      = 0.0;
+};
+
+/// Full drill-down detail for a single stored activity: the time-series records
+/// (for the power/HR/cadence graph) plus per-lap summaries.
+struct WorkoutHistoryDetail
+{
+    QVector<ActivityRecordPoint> records;
+    QVector<ActivityLap>         laps;
+    bool                         valid = false;
+
+    bool hasPower()     const { for (const auto &r : records) if (r.power     >= 0) return true; return false; }
+    bool hasHeartRate() const { for (const auto &r : records) if (r.heartRate >= 0) return true; return false; }
+    bool hasCadence()   const { for (const auto &r : records) if (r.cadence   >= 0) return true; return false; }
+};
+
+#endif // WORKOUTHISTORYDETAIL_H

--- a/src/persistence/file/file_io.pri
+++ b/src/persistence/file/file_io.pri
@@ -5,6 +5,7 @@ SOURCES += \
     $$PWD/xmlutil.cpp \
     $$PWD/fitactivitycreator.cpp \
     $$PWD/fitactivityreader.cpp \
+    $$PWD/fitactivitydetailreader.cpp \
     $$PWD/importerworkout.cpp \
     $$PWD/importerworkoutzwo.cpp
 
@@ -12,6 +13,7 @@ HEADERS += \
     $$PWD/xmlutil.h \
     $$PWD/fitactivitycreator.h \
     $$PWD/fitactivityreader.h \
+    $$PWD/fitactivitydetailreader.h \
     $$PWD/importerworkout.h \
     $$PWD/importerworkoutzwo.h
 

--- a/src/persistence/file/fitactivitydetailreader.cpp
+++ b/src/persistence/file/fitactivitydetailreader.cpp
@@ -1,0 +1,77 @@
+#include "fitactivitydetailreader.h"
+
+#include <fstream>
+
+#include <QDebug>
+
+#include "fit_decode.hpp"
+#include "fit_mesg_broadcaster.hpp"
+#include "fit_runtime_exception.hpp"
+
+WorkoutHistoryDetail FitActivityDetailReader::readFile(const QString &filePath)
+{
+    FitActivityDetailReader reader;
+
+    std::ifstream stream;
+#ifdef Q_OS_WIN32
+    stream.open(filePath.toStdWString(), std::ios::in | std::ios::binary);
+#else
+    stream.open(filePath.toStdString(), std::ios::in | std::ios::binary);
+#endif
+
+    if (!stream.is_open())
+        return reader.m_detail;
+
+    fit::Decode          decoder;
+    fit::MesgBroadcaster broadcaster;
+    broadcaster.AddListener(static_cast<fit::RecordMesgListener &>(reader));
+    broadcaster.AddListener(static_cast<fit::LapMesgListener &>(reader));
+
+    try {
+        decoder.Read(stream, broadcaster, broadcaster);
+    } catch (const fit::RuntimeException &) {
+        // partial decode — return whatever we extracted
+    } catch (...) {
+        qWarning() << "[FitActivityDetailReader] Unexpected exception decoding" << filePath;
+    }
+
+    reader.m_detail.valid = !reader.m_detail.records.isEmpty();
+    return reader.m_detail;
+}
+
+void FitActivityDetailReader::OnMesg(fit::RecordMesg &mesg)
+{
+    ActivityRecordPoint p;
+
+    if (mesg.IsTimestampValid()) {
+        const qint64 ts = static_cast<qint64>(mesg.GetTimestamp());
+        if (m_firstTimestamp < 0)
+            m_firstTimestamp = ts;
+        p.elapsedSec = static_cast<int>(ts - m_firstTimestamp);
+    } else {
+        p.elapsedSec = m_detail.records.size();  // fall back to sample index
+    }
+
+    if (mesg.IsPowerValid())     p.power      = static_cast<int>(mesg.GetPower());
+    if (mesg.IsHeartRateValid()) p.heartRate  = static_cast<int>(mesg.GetHeartRate());
+    if (mesg.IsCadenceValid())   p.cadence    = static_cast<int>(mesg.GetCadence());
+    if (mesg.IsDistanceValid())  p.distanceKm = static_cast<double>(mesg.GetDistance()) / 1000.0;
+
+    m_detail.records.append(p);
+}
+
+void FitActivityDetailReader::OnMesg(fit::LapMesg &mesg)
+{
+    ActivityLap lap;
+
+    if (mesg.IsTotalElapsedTimeValid()) lap.durationSec     = static_cast<int>(mesg.GetTotalElapsedTime());
+    if (mesg.IsAvgPowerValid())         lap.avgPowerW       = static_cast<int>(mesg.GetAvgPower());
+    if (mesg.IsMaxPowerValid())         lap.maxPowerW       = static_cast<int>(mesg.GetMaxPower());
+    if (mesg.IsNormalizedPowerValid())  lap.normalizedPower = static_cast<int>(mesg.GetNormalizedPower());
+    if (mesg.IsAvgHeartRateValid())     lap.avgHrBpm        = static_cast<int>(mesg.GetAvgHeartRate());
+    if (mesg.IsMaxHeartRateValid())     lap.maxHrBpm        = static_cast<int>(mesg.GetMaxHeartRate());
+    if (mesg.IsAvgCadenceValid())       lap.avgCadence      = static_cast<int>(mesg.GetAvgCadence());
+    if (mesg.IsTotalDistanceValid())    lap.distanceKm      = static_cast<double>(mesg.GetTotalDistance()) / 1000.0;
+
+    m_detail.laps.append(lap);
+}

--- a/src/persistence/file/fitactivitydetailreader.h
+++ b/src/persistence/file/fitactivitydetailreader.h
@@ -1,0 +1,27 @@
+#ifndef FITACTIVITYDETAILREADER_H
+#define FITACTIVITYDETAILREADER_H
+
+#include <QString>
+
+#include "workouthistorydetail.h"
+#include "fit_record_mesg_listener.hpp"
+#include "fit_lap_mesg_listener.hpp"
+
+/// Re-reads the full time-series (records) and per-lap summaries from a stored
+/// activity FIT file, for the History drill-down detail view. Distinct from
+/// FitActivityReader, which only extracts the single SessionMesg summary.
+class FitActivityDetailReader : public fit::RecordMesgListener,
+                                public fit::LapMesgListener
+{
+public:
+    static WorkoutHistoryDetail readFile(const QString &filePath);
+
+    void OnMesg(fit::RecordMesg &mesg) override;
+    void OnMesg(fit::LapMesg &mesg) override;
+
+private:
+    WorkoutHistoryDetail m_detail;
+    qint64               m_firstTimestamp = -1;  // FIT timestamp of first record
+};
+
+#endif // FITACTIVITYDETAILREADER_H

--- a/src/ui/activitydetaildialog.cpp
+++ b/src/ui/activitydetaildialog.cpp
@@ -8,13 +8,19 @@
 #include <QDialogButtonBox>
 #include <QPen>
 #include <QColor>
+#include <QSettings>
+#include <QCloseEvent>
 
 #include "qwt_plot.h"
 #include "qwt_plot_curve.h"
 #include "qwt_plot_grid.h"
 #include "qwt_legend.h"
 
+#include "util.h"
+
 namespace {
+
+const char *kGeometryKey = "activityDetailDialog/geometry";
 
 QString fmtDuration(int sec)
 {
@@ -60,8 +66,14 @@ ActivityDetailDialog::ActivityDetailDialog(const WorkoutHistorySummary &summary,
                                            QWidget *parent)
     : QDialog(parent)
 {
-    setWindowTitle(tr("Activity — %1").arg(summary.workoutName));
+    setWindowTitle(tr("Activity - %1").arg(summary.workoutName));
     setMinimumSize(860, 600);
+    // Use the plain top-level window type rather than the default Qt::Dialog
+    // type: window managers treat dialogs as fixed helper windows and won't give
+    // them a working maximise/restore toggle. This keeps the app-modal behaviour
+    // (set by the caller) while exposing the normal window controls.
+    setWindowFlags(Qt::Window | Qt::WindowMinimizeButtonHint |
+                   Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);
 
     auto *header = new QLabel(this);
     header->setTextFormat(Qt::RichText);
@@ -88,6 +100,33 @@ ActivityDetailDialog::ActivityDetailDialog(const WorkoutHistorySummary &summary,
     if (m_lapTable)
         layout->addWidget(m_lapTable, 2);
     layout->addWidget(buttons);
+
+    // Reopen in the same state the user last left (maximised or a given size).
+    // First ever open defaults to maximised.
+    const QByteArray geom = QSettings().value(kGeometryKey).toByteArray();
+    if (geom.isEmpty())
+        setWindowState(windowState() | Qt::WindowMaximized);
+    else
+        restoreGeometry(geom);
+}
+
+void ActivityDetailDialog::saveDialogGeometry()
+{
+    // saveGeometry() captures both the window state (maximised/normal) and the
+    // restored size, so restoreGeometry() round-trips the user's last choice.
+    QSettings().setValue(kGeometryKey, saveGeometry());
+}
+
+void ActivityDetailDialog::done(int result)
+{
+    saveDialogGeometry();
+    QDialog::done(result);
+}
+
+void ActivityDetailDialog::closeEvent(QCloseEvent *event)
+{
+    saveDialogGeometry();
+    QDialog::closeEvent(event);
 }
 
 void ActivityDetailDialog::buildGraph(const WorkoutHistoryDetail &detail)
@@ -101,9 +140,10 @@ void ActivityDetailDialog::buildGraph(const WorkoutHistoryDetail &detail)
     grid->setMajorPen(QPen(Qt::gray, 0, Qt::DashLine));
     grid->attach(m_plot);
 
-    attachChannel(m_plot, detail.records, &ActivityRecordPoint::power,     tr("Power"),   QColor(0xe0, 0x50, 0x50));
-    attachChannel(m_plot, detail.records, &ActivityRecordPoint::heartRate, tr("Heart Rate"), QColor(0x4a, 0x90, 0xd9));
-    attachChannel(m_plot, detail.records, &ActivityRecordPoint::cadence,   tr("Cadence"), QColor(0x2e, 0xa0, 0x55));
+    // Match the in-workout graph colours: power = yellow, HR = red, cadence = blue.
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::power,     tr("Power"),      Util::getColor(Util::LINE_POWER));
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::heartRate, tr("Heart Rate"), Util::getColor(Util::LINE_HEARTRATE));
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::cadence,   tr("Cadence"),    Util::getColor(Util::LINE_CADENCE));
 
     m_plot->replot();
 }

--- a/src/ui/activitydetaildialog.cpp
+++ b/src/ui/activitydetaildialog.cpp
@@ -1,0 +1,144 @@
+#include "activitydetaildialog.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QDialogButtonBox>
+#include <QPen>
+#include <QColor>
+
+#include "qwt_plot.h"
+#include "qwt_plot_curve.h"
+#include "qwt_plot_grid.h"
+#include "qwt_legend.h"
+
+namespace {
+
+QString fmtDuration(int sec)
+{
+    const int h = sec / 3600;
+    const int m = (sec % 3600) / 60;
+    const int s = sec % 60;
+    if (h > 0)
+        return QStringLiteral("%1:%2:%3").arg(h).arg(m, 2, 10, QLatin1Char('0')).arg(s, 2, 10, QLatin1Char('0'));
+    return QStringLiteral("%1:%2").arg(m).arg(s, 2, 10, QLatin1Char('0'));
+}
+
+// Attach a single channel as a curve, skipping samples where the value is the
+// "absent" sentinel (negative). Returns true if any point was plotted.
+bool attachChannel(QwtPlot *plot, const QVector<ActivityRecordPoint> &records,
+                   int ActivityRecordPoint::*field, const QString &title, const QColor &color)
+{
+    QVector<double> xs;
+    QVector<double> ys;
+    xs.reserve(records.size());
+    ys.reserve(records.size());
+    for (const ActivityRecordPoint &r : records) {
+        const int v = r.*field;
+        if (v < 0)
+            continue;
+        xs.append(r.elapsedSec / 60.0);  // minutes
+        ys.append(v);
+    }
+    if (xs.isEmpty())
+        return false;
+
+    auto *curve = new QwtPlotCurve(title);
+    curve->setPen(QPen(color, 1.5));
+    curve->setRenderHint(QwtPlotItem::RenderAntialiased, true);
+    curve->setSamples(xs, ys);
+    curve->attach(plot);
+    return true;
+}
+
+} // namespace
+
+ActivityDetailDialog::ActivityDetailDialog(const WorkoutHistorySummary &summary,
+                                           const WorkoutHistoryDetail &detail,
+                                           QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Activity — %1").arg(summary.workoutName));
+    setMinimumSize(860, 600);
+
+    auto *header = new QLabel(this);
+    header->setTextFormat(Qt::RichText);
+    header->setText(tr("<b>%1</b><br>%2 &nbsp;·&nbsp; %3 &nbsp;·&nbsp; %4 W avg &nbsp;·&nbsp; "
+                       "%5 W NP &nbsp;·&nbsp; %6 bpm &nbsp;·&nbsp; TSS %7")
+                        .arg(summary.workoutName,
+                             summary.startTime.toString(QStringLiteral("ddd d MMM yyyy, HH:mm")),
+                             fmtDuration(summary.durationSec))
+                        .arg(summary.avgPowerW)
+                        .arg(summary.normalizedPower)
+                        .arg(summary.avgHrBpm)
+                        .arg(summary.tss, 0, 'f', 0));
+
+    buildGraph(detail);
+    buildLapTable(detail);
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+
+    auto *layout = new QVBoxLayout(this);
+    layout->addWidget(header);
+    layout->addWidget(m_plot, 3);
+    if (m_lapTable)
+        layout->addWidget(m_lapTable, 2);
+    layout->addWidget(buttons);
+}
+
+void ActivityDetailDialog::buildGraph(const WorkoutHistoryDetail &detail)
+{
+    m_plot = new QwtPlot(this);
+    m_plot->setAxisTitle(QwtPlot::xBottom, tr("Elapsed (min)"));
+    m_plot->setAxisTitle(QwtPlot::yLeft, tr("Power (W) / HR (bpm) / Cadence (rpm)"));
+    m_plot->insertLegend(new QwtLegend(), QwtPlot::BottomLegend);
+
+    auto *grid = new QwtPlotGrid();
+    grid->setMajorPen(QPen(Qt::gray, 0, Qt::DashLine));
+    grid->attach(m_plot);
+
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::power,     tr("Power"),   QColor(0xe0, 0x50, 0x50));
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::heartRate, tr("Heart Rate"), QColor(0x4a, 0x90, 0xd9));
+    attachChannel(m_plot, detail.records, &ActivityRecordPoint::cadence,   tr("Cadence"), QColor(0x2e, 0xa0, 0x55));
+
+    m_plot->replot();
+}
+
+void ActivityDetailDialog::buildLapTable(const WorkoutHistoryDetail &detail)
+{
+    if (detail.laps.isEmpty())
+        return;
+
+    const QStringList headers = {tr("Lap"), tr("Duration"), tr("Avg W"), tr("NP"),
+                                 tr("Max W"), tr("Avg HR"), tr("Avg Cad"), tr("Distance")};
+
+    m_lapTable = new QTableWidget(detail.laps.size(), headers.size(), this);
+    m_lapTable->setHorizontalHeaderLabels(headers);
+    m_lapTable->verticalHeader()->hide();
+    m_lapTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_lapTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_lapTable->setAlternatingRowColors(true);
+    m_lapTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+
+    auto cell = [](const QString &text) {
+        auto *item = new QTableWidgetItem(text);
+        item->setTextAlignment(Qt::AlignCenter);
+        return item;
+    };
+
+    for (int i = 0; i < detail.laps.size(); ++i) {
+        const ActivityLap &lap = detail.laps.at(i);
+        m_lapTable->setItem(i, 0, cell(QString::number(i + 1)));
+        m_lapTable->setItem(i, 1, cell(fmtDuration(lap.durationSec)));
+        m_lapTable->setItem(i, 2, cell(QString::number(lap.avgPowerW)));
+        m_lapTable->setItem(i, 3, cell(lap.normalizedPower > 0 ? QString::number(lap.normalizedPower) : QStringLiteral("-")));
+        m_lapTable->setItem(i, 4, cell(QString::number(lap.maxPowerW)));
+        m_lapTable->setItem(i, 5, cell(lap.avgHrBpm > 0 ? QString::number(lap.avgHrBpm) : QStringLiteral("-")));
+        m_lapTable->setItem(i, 6, cell(lap.avgCadence > 0 ? QString::number(lap.avgCadence) : QStringLiteral("-")));
+        m_lapTable->setItem(i, 7, cell(QStringLiteral("%1 km").arg(lap.distanceKm, 0, 'f', 2)));
+    }
+}

--- a/src/ui/activitydetaildialog.h
+++ b/src/ui/activitydetaildialog.h
@@ -1,0 +1,32 @@
+#ifndef ACTIVITYDETAILDIALOG_H
+#define ACTIVITYDETAILDIALOG_H
+
+#include <QDialog>
+
+#include "workouthistorysummary.h"
+#include "workouthistorydetail.h"
+
+class QwtPlot;
+class QTableWidget;
+class QLabel;
+
+/// Drill-down view for a single stored activity: a power/HR/cadence graph
+/// re-rendered from the FIT record stream plus a per-lap stats table.
+class ActivityDetailDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    ActivityDetailDialog(const WorkoutHistorySummary &summary,
+                         const WorkoutHistoryDetail &detail,
+                         QWidget *parent = nullptr);
+
+private:
+    void buildGraph(const WorkoutHistoryDetail &detail);
+    void buildLapTable(const WorkoutHistoryDetail &detail);
+
+    QwtPlot      *m_plot     = nullptr;
+    QTableWidget *m_lapTable = nullptr;
+};
+
+#endif // ACTIVITYDETAILDIALOG_H

--- a/src/ui/activitydetaildialog.h
+++ b/src/ui/activitydetaildialog.h
@@ -21,9 +21,14 @@ public:
                          const WorkoutHistoryDetail &detail,
                          QWidget *parent = nullptr);
 
+protected:
+    void done(int result) override;
+    void closeEvent(QCloseEvent *event) override;
+
 private:
     void buildGraph(const WorkoutHistoryDetail &detail);
     void buildLapTable(const WorkoutHistoryDetail &detail);
+    void saveDialogGeometry();
 
     QwtPlot      *m_plot     = nullptr;
     QTableWidget *m_lapTable = nullptr;

--- a/src/ui/historyfilterproxymodel.cpp
+++ b/src/ui/historyfilterproxymodel.cpp
@@ -1,0 +1,49 @@
+#include "historyfilterproxymodel.h"
+
+#include <QDateTime>
+
+#include "workouthistorymodel.h"
+
+HistoryFilterProxyModel::HistoryFilterProxyModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+}
+
+void HistoryFilterProxyModel::setNameFilter(const QString &text)
+{
+    m_nameFilter = text.trimmed();
+    invalidateFilter();
+}
+
+void HistoryFilterProxyModel::setDateRange(const QDate &from, const QDate &to)
+{
+    m_from = from;
+    m_to   = to;
+    invalidateFilter();
+}
+
+bool HistoryFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    const QAbstractItemModel *src = sourceModel();
+    if (!src)
+        return true;
+
+    if (!m_nameFilter.isEmpty()) {
+        const QModelIndex nameIdx = src->index(sourceRow, WorkoutHistoryModel::ColWorkout, sourceParent);
+        const QString name = src->data(nameIdx, Qt::DisplayRole).toString();
+        if (!name.contains(m_nameFilter, Qt::CaseInsensitive))
+            return false;
+    }
+
+    if (m_from.isValid() || m_to.isValid()) {
+        const QModelIndex dateIdx = src->index(sourceRow, WorkoutHistoryModel::ColDate, sourceParent);
+        const qint64 secs = src->data(dateIdx, Qt::UserRole).toLongLong();
+        const QDate date = QDateTime::fromSecsSinceEpoch(secs).date();
+        if (m_from.isValid() && date < m_from)
+            return false;
+        if (m_to.isValid() && date > m_to)
+            return false;
+    }
+
+    return true;
+}

--- a/src/ui/historyfilterproxymodel.h
+++ b/src/ui/historyfilterproxymodel.h
@@ -1,0 +1,28 @@
+#ifndef HISTORYFILTERPROXYMODEL_H
+#define HISTORYFILTERPROXYMODEL_H
+
+#include <QSortFilterProxyModel>
+#include <QDate>
+
+/// Filters the workout history by workout-name substring and an inclusive
+/// start/end date range. An invalid (null) bound disables that side of the range.
+class HistoryFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit HistoryFilterProxyModel(QObject *parent = nullptr);
+
+    void setNameFilter(const QString &text);
+    void setDateRange(const QDate &from, const QDate &to);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    QString m_nameFilter;
+    QDate   m_from;
+    QDate   m_to;
+};
+
+#endif // HISTORYFILTERPROXYMODEL_H

--- a/src/ui/historywidget.cpp
+++ b/src/ui/historywidget.cpp
@@ -16,6 +16,8 @@
 #include <QPushButton>
 #include <QLineEdit>
 #include <QDateEdit>
+#include <QMenu>
+#include <QAction>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -57,11 +59,17 @@ void HistoryWidget::setupUi()
     m_tableView->horizontalHeader()->setStretchLastSection(true);
     m_tableView->verticalHeader()->hide();
     m_tableView->sortByColumn(0, Qt::DescendingOrder);
+    m_tableView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_tableView, &QTableView::doubleClicked, this, &HistoryWidget::openDetail);
+    connect(m_tableView, &QTableView::customContextMenuRequested,
+            this, &HistoryWidget::showHistoryContextMenu);
 
-    m_refreshBtn = new QPushButton(tr("Refresh"), histTab);
-    m_refreshBtn->setMaximumWidth(120);
-    connect(m_refreshBtn, &QPushButton::clicked, this, &HistoryWidget::loadHistory);
+    m_contextMenu = new QMenu(this);
+    QAction *refreshAction = m_contextMenu->addAction(QIcon(QStringLiteral(":/image/icon/refresh")), tr("Refresh"));
+    connect(refreshAction, &QAction::triggered, this, &HistoryWidget::loadHistory);
+    m_contextMenu->addSeparator();
+    m_deleteAction = m_contextMenu->addAction(QIcon(QStringLiteral(":/image/icon/delete")), tr("Delete"));
+    connect(m_deleteAction, &QAction::triggered, this, &HistoryWidget::deleteSelected);
 
     m_cpBtn = new QPushButton(tr("Critical Power Curve"), histTab);
     connect(m_cpBtn, &QPushButton::clicked, this, &HistoryWidget::openCriticalPowerDialog);
@@ -70,18 +78,11 @@ void HistoryWidget::setupUi()
     m_pmcBtn->setMaximumWidth(160);
     connect(m_pmcBtn, &QPushButton::clicked, this, &HistoryWidget::openPmcDialog);
 
-    m_deleteBtn = new QPushButton(tr("Delete"), histTab);
-    m_deleteBtn->setMaximumWidth(120);
-    m_deleteBtn->setEnabled(false);
-    connect(m_deleteBtn, &QPushButton::clicked, this, &HistoryWidget::deleteSelected);
-
     m_statusLabel = new QLabel(histTab);
 
     auto *toolBar = new QHBoxLayout();
-    toolBar->addWidget(m_refreshBtn);
     toolBar->addWidget(m_cpBtn);
     toolBar->addWidget(m_pmcBtn);
-    toolBar->addWidget(m_deleteBtn);
     toolBar->addWidget(m_statusLabel);
     toolBar->addStretch();
 
@@ -91,12 +92,11 @@ void HistoryWidget::setupUi()
     m_searchEdit->setClearButtonEnabled(true);
     connect(m_searchEdit, &QLineEdit::textChanged, this, &HistoryWidget::applyFilters);
 
-    // Defaults span everything (year 2000 .. today) so the date filter is a
-    // no-op until the user narrows it. clearFilters() restores these.
+    // Default range: the last year up to today. clearFilters() restores these.
     m_fromDate = new QDateEdit(histTab);
     m_fromDate->setCalendarPopup(true);
     m_fromDate->setDisplayFormat(QStringLiteral("yyyy-MM-dd"));
-    m_fromDate->setDate(QDate(2000, 1, 1));
+    m_fromDate->setDate(QDate::currentDate().addYears(-1));
     m_toDate = new QDateEdit(histTab);
     m_toDate->setCalendarPopup(true);
     m_toDate->setDisplayFormat(QStringLiteral("yyyy-MM-dd"));
@@ -115,17 +115,16 @@ void HistoryWidget::setupUi()
     filterBar->addWidget(m_toDate);
     filterBar->addWidget(clearBtn);
 
-    connect(m_tableView->selectionModel(), &QItemSelectionModel::selectionChanged,
-            this, [this]() {
-                m_deleteBtn->setEnabled(m_tableView->selectionModel()->hasSelection());
-            });
-
     auto *histLayout = new QVBoxLayout(histTab);
     histLayout->setContentsMargins(8, 8, 8, 8);
     histLayout->setSpacing(6);
     histLayout->addLayout(toolBar);
     histLayout->addLayout(filterBar);
     histLayout->addWidget(m_tableView);
+
+    // Push the initial date range into the proxy so the default filter is active
+    // before the first load (the date editors' signals only fire on user change).
+    applyFilters();
 
     m_tabs->addTab(histTab, tr("Activity History"));
 
@@ -179,7 +178,19 @@ void HistoryWidget::loadHistory()
     if (summaries.isEmpty())
         m_statusLabel->setText(tr("No activities found in %1").arg(historyPath));
     else
-        m_statusLabel->setText(tr("%n activity(ies)", "", summaries.size()));
+        updateStatus();
+}
+
+void HistoryWidget::updateStatus()
+{
+    const int total = m_model->history().size();
+    if (total == 0)
+        return;  // keep the load-time "no activities / folder not found" message
+    const int shown = m_proxy->rowCount();
+    if (shown == total)
+        m_statusLabel->setText(tr("%n activity(ies)", "", total));
+    else
+        m_statusLabel->setText(tr("Showing %1 of %2 activities").arg(shown).arg(total));
 }
 
 void HistoryWidget::openCriticalPowerDialog()
@@ -209,12 +220,13 @@ void HistoryWidget::applyFilters()
         return;
     m_proxy->setNameFilter(m_searchEdit->text());
     m_proxy->setDateRange(m_fromDate->date(), m_toDate->date());
+    updateStatus();
 }
 
 void HistoryWidget::clearFilters()
 {
     m_searchEdit->clear();
-    m_fromDate->setDate(QDate(2000, 1, 1));
+    m_fromDate->setDate(QDate::currentDate().addYears(-1));
     m_toDate->setDate(QDate::currentDate());
     applyFilters();
 }
@@ -248,8 +260,21 @@ void HistoryWidget::openDetail(const QModelIndex &proxyIndex)
     }
 
     auto *dlg = new ActivityDetailDialog(*summary, detail, this);
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-    dlg->exec();
+    dlg->setWindowModality(Qt::ApplicationModal);
+    connect(dlg, &QDialog::finished, dlg, &QObject::deleteLater);
+    dlg->show();  // the dialog restores its own last geometry/state
+}
+
+void HistoryWidget::showHistoryContextMenu(const QPoint &pos)
+{
+    const QModelIndex index = m_tableView->indexAt(pos);
+    if (index.isValid()) {
+        m_tableView->selectRow(index.row());  // operate on the right-clicked row
+        m_deleteAction->setEnabled(true);
+    } else {
+        m_deleteAction->setEnabled(false);     // Refresh still available on empty area
+    }
+    m_contextMenu->popup(m_tableView->viewport()->mapToGlobal(pos));
 }
 
 void HistoryWidget::deleteSelected()

--- a/src/ui/historywidget.cpp
+++ b/src/ui/historywidget.cpp
@@ -1,6 +1,9 @@
 #include "historywidget.h"
 #include "workouthistorymodel.h"
+#include "historyfilterproxymodel.h"
+#include "activitydetaildialog.h"
 #include "fitactivityreader.h"
+#include "fitactivitydetailreader.h"
 #include "planadherencewidget.h"
 #include "planadherencestore.h"
 #include "criticalpowerdialog.h"
@@ -11,12 +14,16 @@
 #include <QTableView>
 #include <QLabel>
 #include <QPushButton>
-#include <QSortFilterProxyModel>
+#include <QLineEdit>
+#include <QDateEdit>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QMessageBox>
 #include <QStringList>
 #include <QApplication>
 #include <QWidget>
@@ -35,7 +42,7 @@ void HistoryWidget::setupUi()
     auto *histTab = new QWidget(this);
     m_model = new WorkoutHistoryModel(this);
 
-    m_proxy = new QSortFilterProxyModel(this);
+    m_proxy = new HistoryFilterProxyModel(this);
     m_proxy->setSourceModel(m_model);
     m_proxy->setSortRole(Qt::UserRole);
 
@@ -50,6 +57,7 @@ void HistoryWidget::setupUi()
     m_tableView->horizontalHeader()->setStretchLastSection(true);
     m_tableView->verticalHeader()->hide();
     m_tableView->sortByColumn(0, Qt::DescendingOrder);
+    connect(m_tableView, &QTableView::doubleClicked, this, &HistoryWidget::openDetail);
 
     m_refreshBtn = new QPushButton(tr("Refresh"), histTab);
     m_refreshBtn->setMaximumWidth(120);
@@ -62,19 +70,61 @@ void HistoryWidget::setupUi()
     m_pmcBtn->setMaximumWidth(160);
     connect(m_pmcBtn, &QPushButton::clicked, this, &HistoryWidget::openPmcDialog);
 
+    m_deleteBtn = new QPushButton(tr("Delete"), histTab);
+    m_deleteBtn->setMaximumWidth(120);
+    m_deleteBtn->setEnabled(false);
+    connect(m_deleteBtn, &QPushButton::clicked, this, &HistoryWidget::deleteSelected);
+
     m_statusLabel = new QLabel(histTab);
 
     auto *toolBar = new QHBoxLayout();
     toolBar->addWidget(m_refreshBtn);
     toolBar->addWidget(m_cpBtn);
     toolBar->addWidget(m_pmcBtn);
+    toolBar->addWidget(m_deleteBtn);
     toolBar->addWidget(m_statusLabel);
     toolBar->addStretch();
+
+    // ── Search + date-range filter row ───────────────────────────────────────
+    m_searchEdit = new QLineEdit(histTab);
+    m_searchEdit->setPlaceholderText(tr("Search by workout name…"));
+    m_searchEdit->setClearButtonEnabled(true);
+    connect(m_searchEdit, &QLineEdit::textChanged, this, &HistoryWidget::applyFilters);
+
+    // Defaults span everything (year 2000 .. today) so the date filter is a
+    // no-op until the user narrows it. clearFilters() restores these.
+    m_fromDate = new QDateEdit(histTab);
+    m_fromDate->setCalendarPopup(true);
+    m_fromDate->setDisplayFormat(QStringLiteral("yyyy-MM-dd"));
+    m_fromDate->setDate(QDate(2000, 1, 1));
+    m_toDate = new QDateEdit(histTab);
+    m_toDate->setCalendarPopup(true);
+    m_toDate->setDisplayFormat(QStringLiteral("yyyy-MM-dd"));
+    m_toDate->setDate(QDate::currentDate());
+    connect(m_fromDate, &QDateEdit::dateChanged, this, &HistoryWidget::applyFilters);
+    connect(m_toDate,   &QDateEdit::dateChanged, this, &HistoryWidget::applyFilters);
+
+    auto *clearBtn = new QPushButton(tr("Clear filters"), histTab);
+    connect(clearBtn, &QPushButton::clicked, this, &HistoryWidget::clearFilters);
+
+    auto *filterBar = new QHBoxLayout();
+    filterBar->addWidget(m_searchEdit, 1);
+    filterBar->addWidget(new QLabel(tr("From:"), histTab));
+    filterBar->addWidget(m_fromDate);
+    filterBar->addWidget(new QLabel(tr("To:"), histTab));
+    filterBar->addWidget(m_toDate);
+    filterBar->addWidget(clearBtn);
+
+    connect(m_tableView->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, [this]() {
+                m_deleteBtn->setEnabled(m_tableView->selectionModel()->hasSelection());
+            });
 
     auto *histLayout = new QVBoxLayout(histTab);
     histLayout->setContentsMargins(8, 8, 8, 8);
     histLayout->setSpacing(6);
     histLayout->addLayout(toolBar);
+    histLayout->addLayout(filterBar);
     histLayout->addWidget(m_tableView);
 
     m_tabs->addTab(histTab, tr("Activity History"));
@@ -151,4 +201,84 @@ void HistoryWidget::openPmcDialog()
     auto *dlg = new PmcDialog(points, this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->exec();
+}
+
+void HistoryWidget::applyFilters()
+{
+    if (!m_proxy)
+        return;
+    m_proxy->setNameFilter(m_searchEdit->text());
+    m_proxy->setDateRange(m_fromDate->date(), m_toDate->date());
+}
+
+void HistoryWidget::clearFilters()
+{
+    m_searchEdit->clear();
+    m_fromDate->setDate(QDate(2000, 1, 1));
+    m_toDate->setDate(QDate::currentDate());
+    applyFilters();
+}
+
+const WorkoutHistorySummary *HistoryWidget::summaryForProxyRow(const QModelIndex &proxyIndex) const
+{
+    if (!proxyIndex.isValid())
+        return nullptr;
+    const QModelIndex src = m_proxy->mapToSource(proxyIndex);
+    const int row = src.row();
+    const QList<WorkoutHistorySummary> &history = m_model->history();
+    if (row < 0 || row >= history.size())
+        return nullptr;
+    return &history.at(row);
+}
+
+void HistoryWidget::openDetail(const QModelIndex &proxyIndex)
+{
+    const WorkoutHistorySummary *summary = summaryForProxyRow(proxyIndex);
+    if (!summary)
+        return;
+
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    const WorkoutHistoryDetail detail = FitActivityDetailReader::readFile(summary->filePath);
+    QApplication::restoreOverrideCursor();
+
+    if (!detail.valid) {
+        QMessageBox::information(this, tr("Activity Detail"),
+                                 tr("No detailed record data could be read from this activity."));
+        return;
+    }
+
+    auto *dlg = new ActivityDetailDialog(*summary, detail, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
+}
+
+void HistoryWidget::deleteSelected()
+{
+    const QModelIndexList selected = m_tableView->selectionModel()->selectedRows();
+    if (selected.isEmpty())
+        return;
+
+    const WorkoutHistorySummary *summary = summaryForProxyRow(selected.first());
+    if (!summary)
+        return;
+
+    const QString filePath = summary->filePath;
+    const QString name = summary->workoutName;
+
+    const auto answer = QMessageBox::question(
+        this, tr("Delete Activity"),
+        tr("Permanently delete this activity from disk?\n\n%1\n%2")
+            .arg(name, QFileInfo(filePath).fileName()),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+    if (answer != QMessageBox::Yes)
+        return;
+
+    if (!QFile::remove(filePath)) {
+        QMessageBox::warning(this, tr("Delete Activity"),
+                             tr("Could not delete the file:\n%1").arg(filePath));
+        return;
+    }
+
+    loadHistory();
 }

--- a/src/ui/historywidget.h
+++ b/src/ui/historywidget.h
@@ -13,6 +13,9 @@ class QLineEdit;
 class QDateEdit;
 class QTabWidget;
 class QModelIndex;
+class QMenu;
+class QAction;
+class QPoint;
 class WorkoutHistoryModel;
 class HistoryFilterProxyModel;
 class PlanAdherenceStore;
@@ -41,12 +44,16 @@ private slots:
     void clearFilters();
     void deleteSelected();
     void openDetail(const QModelIndex &proxyIndex);
+    void showHistoryContextMenu(const QPoint &pos);
 
 private:
     void setupUi();
 
     /// Map a proxy-model index to its WorkoutHistorySummary; returns nullptr if invalid.
     const WorkoutHistorySummary *summaryForProxyRow(const QModelIndex &proxyIndex) const;
+
+    /// Refresh the status label with the visible-vs-total activity count.
+    void updateStatus();
 
     QTabWidget              *m_tabs          = nullptr;
 
@@ -55,13 +62,13 @@ private:
     WorkoutHistoryModel     *m_model         = nullptr;
     HistoryFilterProxyModel *m_proxy         = nullptr;
     QLabel                  *m_statusLabel   = nullptr;
-    QPushButton             *m_refreshBtn    = nullptr;
     QPushButton             *m_cpBtn         = nullptr;
     QPushButton             *m_pmcBtn        = nullptr;
-    QPushButton             *m_deleteBtn     = nullptr;
     QLineEdit               *m_searchEdit    = nullptr;
     QDateEdit               *m_fromDate      = nullptr;
     QDateEdit               *m_toDate        = nullptr;
+    QMenu                   *m_contextMenu   = nullptr;
+    QAction                 *m_deleteAction  = nullptr;
 
     // Plan adherence tab (added when store is injected)
     PlanAdherenceWidget  *m_adherenceWidget = nullptr;

--- a/src/ui/historywidget.h
+++ b/src/ui/historywidget.h
@@ -9,9 +9,12 @@
 class QTableView;
 class QLabel;
 class QPushButton;
-class QSortFilterProxyModel;
+class QLineEdit;
+class QDateEdit;
 class QTabWidget;
+class QModelIndex;
 class WorkoutHistoryModel;
+class HistoryFilterProxyModel;
 class PlanAdherenceStore;
 class PlanAdherenceWidget;
 
@@ -34,20 +37,31 @@ protected:
 private slots:
     void openCriticalPowerDialog();
     void openPmcDialog();
+    void applyFilters();
+    void clearFilters();
+    void deleteSelected();
+    void openDetail(const QModelIndex &proxyIndex);
 
 private:
     void setupUi();
 
-    QTabWidget           *m_tabs          = nullptr;
+    /// Map a proxy-model index to its WorkoutHistorySummary; returns nullptr if invalid.
+    const WorkoutHistorySummary *summaryForProxyRow(const QModelIndex &proxyIndex) const;
+
+    QTabWidget              *m_tabs          = nullptr;
 
     // Workout history tab
-    QTableView           *m_tableView     = nullptr;
-    WorkoutHistoryModel  *m_model         = nullptr;
-    QSortFilterProxyModel*m_proxy         = nullptr;
-    QLabel               *m_statusLabel   = nullptr;
-    QPushButton          *m_refreshBtn    = nullptr;
-    QPushButton          *m_cpBtn         = nullptr;
-    QPushButton          *m_pmcBtn        = nullptr;
+    QTableView              *m_tableView     = nullptr;
+    WorkoutHistoryModel     *m_model         = nullptr;
+    HistoryFilterProxyModel *m_proxy         = nullptr;
+    QLabel                  *m_statusLabel   = nullptr;
+    QPushButton             *m_refreshBtn    = nullptr;
+    QPushButton             *m_cpBtn         = nullptr;
+    QPushButton             *m_pmcBtn        = nullptr;
+    QPushButton             *m_deleteBtn     = nullptr;
+    QLineEdit               *m_searchEdit    = nullptr;
+    QDateEdit               *m_fromDate      = nullptr;
+    QDateEdit               *m_toDate        = nullptr;
 
     // Plan adherence tab (added when store is injected)
     PlanAdherenceWidget  *m_adherenceWidget = nullptr;

--- a/src/ui/main_workoutpage.cpp
+++ b/src/ui/main_workoutpage.cpp
@@ -131,12 +131,15 @@ Main_WorkoutPage::Main_WorkoutPage(QWidget *parent) : QWidget(parent), ui(new Ui
     actionOpenFolder = contextMenu->addAction(QIcon(":/image/icon/folder"), tr("Open in folder"));
     contextMenu->addSeparator();
     actionAddToQueue = contextMenu->addAction(QIcon(":/image/icon/add"), tr("Add to Queue"));
+    contextMenu->addSeparator();
+    actionRefresh = contextMenu->addAction(QIcon(":/image/icon/refresh"), tr("Refresh"));
 
     connect(actionEdit, SIGNAL(triggered()), this, SLOT(editWorkout()) );
     connect(actionDelete, SIGNAL(triggered()), this, SLOT(deleteWorkout()) );
     connect(actionSetAsDone, SIGNAL(triggered()), this, SLOT(setAsDone()) );
     connect(actionOpenFolder, SIGNAL(triggered()), this, SLOT(openFolderWorkout()) );
     connect(actionAddToQueue, SIGNAL(triggered()), this, SLOT(addToQueue()));
+    connect(actionRefresh, SIGNAL(triggered()), this, SLOT(refreshUserWorkout()) );
     actionEdit->setEnabled(false);
     actionDelete->setEnabled(false);
     actionOpenFolder->setEnabled(false);
@@ -263,15 +266,19 @@ void Main_WorkoutPage::tableViewSelectionChanged(QItemSelection, QItemSelection)
     actionSetAsDone->setEnabled(true);
 
     if (workout.getWorkoutNameEnum() != Workout::USER_MADE) {
-        actionDelete->setEnabled(false);
-        actionOpenFolder->setEnabled(false);
+        // Included workouts live in the bundle, not the user folder, and can't be
+        // deleted — hide both actions entirely rather than showing them greyed out.
+        actionDelete->setVisible(false);
+        actionOpenFolder->setVisible(false);
         actionEdit->setEnabled(true); //let user edit, no copyright on a workout..
         //        if (workout.getWorkoutNameEnum() == Workout::MAP_TEST)
         //            actionEdit->setEnabled(false);
     }
     else {
         actionEdit->setEnabled(true);
+        actionDelete->setVisible(true);
         actionDelete->setEnabled(true);
+        actionOpenFolder->setVisible(true);
         actionOpenFolder->setEnabled(true);
     }
 
@@ -609,11 +616,6 @@ void Main_WorkoutPage::on_checkBox_clicked(bool checked)
 
 
 
-//-------------------------------------------------------------------------
-void Main_WorkoutPage::on_pushButton_refresh_clicked()
-{
-    refreshUserWorkout();
-}
 //-------------------------------------------------------------------------
 void Main_WorkoutPage::refreshUserWorkout() {
 

--- a/src/ui/main_workoutpage.h
+++ b/src/ui/main_workoutpage.h
@@ -86,8 +86,6 @@ private slots:
 
     void on_checkBox_clicked(bool checked);
 
-    void on_pushButton_refresh_clicked();
-
 
 
 
@@ -114,6 +112,7 @@ private:
     QAction *actionSetAsDone;
     QAction *actionOpenFolder;
     QAction *actionAddToQueue;
+    QAction *actionRefresh;
     QModelIndex indexSourceSelected;
 };
 

--- a/src/ui/main_workoutpage.ui
+++ b/src/ui/main_workoutpage.ui
@@ -207,23 +207,6 @@
       <number>3</number>
      </property>
      <item>
-      <widget class="QPushButton" name="pushButton_refresh">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Refresh</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../MyResources.qrc">
-         <normaloff>:/image/icon/refresh</normaloff>:/image/icon/refresh</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/ui/ui.pri
+++ b/src/ui/ui.pri
@@ -18,6 +18,8 @@ $$PWD/workoutdialog.cpp \
     $$PWD/tab_intervals_icu.cpp \
     $$PWD/workouthistorymodel.cpp \
     $$PWD/historywidget.cpp \
+    $$PWD/historyfilterproxymodel.cpp \
+    $$PWD/activitydetaildialog.cpp \
     $$PWD/dialogkeyboardshortcuts.cpp \
     $$PWD/planadherencewidget.cpp \
     $$PWD/criticalpowerdialog.cpp \
@@ -38,6 +40,8 @@ $$PWD/workoutdialog.h \
     $$PWD/tab_intervals_icu.h \
     $$PWD/workouthistorymodel.h \
     $$PWD/historywidget.h \
+    $$PWD/historyfilterproxymodel.h \
+    $$PWD/activitydetaildialog.h \
     $$PWD/dialogkeyboardshortcuts.h \
     $$PWD/criticalpowerdialog.h \
     $$PWD/pmcdialog.h \

--- a/tests/history/history_tests.pro
+++ b/tests/history/history_tests.pro
@@ -1,0 +1,46 @@
+###############################################################################
+# tests/history/history_tests.pro
+#
+# Standalone Qt Test project for the Workout History dashboard logic:
+#   - FIT activity indexing (FitActivityReader / FitActivityDetailReader)
+#   - TSS aggregation (PmcCalculator)
+#
+# Build:
+#   qmake6 history_tests.pro && make
+# Run:
+#   ./../../build/tests/history_tests -v2
+###############################################################################
+
+QT       += core testlib
+QT       -= gui
+
+CONFIG   += qt c++17 console
+CONFIG   -= app_bundle
+
+TARGET   = history_tests
+TEMPLATE = app
+
+DESTDIR  = ../../build/tests
+
+INCLUDEPATH += \
+    . \
+    ../../src/model \
+    ../../src/persistence/file \
+    ../../src/fitness \
+    ../../src/fitness/fit
+
+# FIT SDK (encode/decode + all message types)
+include(../../src/fitness/fit/fit.pri)
+
+SOURCES += \
+    ../../src/fitness/pmccalculator.cpp \
+    ../../src/persistence/file/fitactivityreader.cpp \
+    ../../src/persistence/file/fitactivitydetailreader.cpp \
+    tst_history.cpp
+
+HEADERS += \
+    ../../src/model/workouthistorysummary.h \
+    ../../src/model/workouthistorydetail.h \
+    ../../src/fitness/pmccalculator.h \
+    ../../src/persistence/file/fitactivityreader.h \
+    ../../src/persistence/file/fitactivitydetailreader.h

--- a/tests/history/tst_history.cpp
+++ b/tests/history/tst_history.cpp
@@ -179,6 +179,31 @@ private slots:
         QVERIFY(!pts.isEmpty());
         QCOMPARE(qRound(pts.last().tss), 100);  // 60 + 40 aggregated on the same day
     }
+
+    // Activities whose FIT file had no session data have an invalid startTime.
+    // These must be skipped, not crash/hang the day-by-day EMA loop.
+    void pmcSkipsInvalidDates()
+    {
+        const QDate day(2024, 3, 10);
+        WorkoutHistorySummary good;
+        good.startTime = QDateTime(day, QTime(8, 0), Qt::LocalTime);
+        good.tss = 100.0;
+        good.valid = true;
+        WorkoutHistorySummary junk;          // invalid startTime, no data
+        junk.workoutName = "broken";
+
+        const QList<PmcPoint> pts = PmcCalculator::compute({junk, good, junk}, day);
+        QVERIFY(!pts.isEmpty());
+        QCOMPARE(pts.last().date, day);
+        QCOMPARE(qRound(pts.last().tss), 100);
+    }
+
+    void pmcAllInvalidReturnsEmpty()
+    {
+        WorkoutHistorySummary junk;          // invalid startTime
+        junk.workoutName = "broken";
+        QVERIFY(PmcCalculator::compute({junk}).isEmpty());
+    }
 };
 
 QTEST_MAIN(TestHistory)

--- a/tests/history/tst_history.cpp
+++ b/tests/history/tst_history.cpp
@@ -1,0 +1,185 @@
+#include <QtTest>
+#include <QTemporaryDir>
+#include <QDateTime>
+
+#include <fstream>
+#include <cmath>
+
+#include "fit_encode.hpp"
+#include "fit_file_id_mesg.hpp"
+#include "fit_session_mesg.hpp"
+#include "fit_lap_mesg.hpp"
+#include "fit_record_mesg.hpp"
+
+#include "fitactivityreader.h"
+#include "fitactivitydetailreader.h"
+#include "pmccalculator.h"
+
+// Garmin FIT epoch (1989-12-31 UTC) offset from the Unix epoch, in seconds.
+static constexpr qint64 FIT_EPOCH_OFFSET = 631065600LL;
+
+class TestHistory : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Writes a synthetic but valid activity FIT file with a session summary,
+    // one lap, and `nRecords` per-second records. Returns the FIT start time
+    // (seconds since the FIT epoch) so callers can assert the decoded date.
+    static qint64 writeSampleFit(const QString &path, int nRecords)
+    {
+        const QDateTime start = QDateTime(QDate(2024, 1, 15), QTime(10, 0, 0), Qt::UTC);
+        const qint64 fitStart = start.toSecsSinceEpoch() - FIT_EPOCH_OFFSET;
+
+        std::fstream file;
+        file.open(path.toStdString(), std::ios::in | std::ios::out | std::ios::binary | std::ios::trunc);
+
+        fit::Encode encode;
+        encode.Open(file);
+
+        fit::FileIdMesg fileId;
+        fileId.SetTimeCreated(fitStart);
+        fileId.SetManufacturer(FIT_MANUFACTURER_DEVELOPMENT);
+        fileId.SetType(FIT_FILE_ACTIVITY);
+        encode.Write(fileId);
+
+        for (int i = 0; i < nRecords; ++i) {
+            fit::RecordMesg rec;
+            rec.SetTimestamp(fitStart + i);
+            rec.SetPower(200 + i);
+            rec.SetHeartRate(140 + i);
+            rec.SetCadence(90);
+            rec.SetDistance(static_cast<FIT_FLOAT32>(i * 10));  // metres
+            encode.Write(rec);
+        }
+
+        fit::LapMesg lap;
+        lap.SetTotalElapsedTime(static_cast<FIT_FLOAT32>(nRecords));
+        lap.SetAvgPower(205);
+        lap.SetMaxPower(260);
+        lap.SetNormalizedPower(215);
+        lap.SetAvgHeartRate(150);
+        lap.SetMaxHeartRate(175);
+        lap.SetAvgCadence(92);
+        lap.SetTotalDistance(static_cast<FIT_FLOAT32>(nRecords * 10));
+        encode.Write(lap);
+
+        fit::SessionMesg session;
+        session.SetStartTime(fitStart);
+        session.SetTimestamp(fitStart + nRecords);
+        session.SetTotalTimerTime(static_cast<FIT_FLOAT32>(nRecords));
+        session.SetSport(FIT_SPORT_CYCLING);
+        session.SetAvgPower(205);
+        session.SetNormalizedPower(215);
+        session.SetAvgHeartRate(150);
+        session.SetAvgCadence(92);
+        session.SetTrainingStressScore(85.0f);
+        session.SetTotalDistance(static_cast<FIT_FLOAT32>(nRecords * 10));  // metres
+        session.SetTotalCalories(450);
+        encode.Write(session);
+
+        encode.Close();
+        file.close();
+        return fitStart;
+    }
+
+private slots:
+
+    // ── FIT indexing: session summary ────────────────────────────────────────
+    void summaryReadsSessionFields()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath("activity.fit");
+        writeSampleFit(path, 60);
+
+        const WorkoutHistorySummary s = FitActivityReader::readFile(path);
+
+        QVERIFY(s.valid);
+        QCOMPARE(s.durationSec, 60);
+        QCOMPARE(s.avgPowerW, 205);
+        QCOMPARE(s.normalizedPower, 215);
+        QCOMPARE(s.avgHrBpm, 150);
+        QCOMPARE(s.avgCadence, 92);
+        QCOMPARE(s.calories, 450);
+        QCOMPARE(qRound(s.tss), 85);
+        QVERIFY(qAbs(s.totalDistanceKm - 0.6) < 1e-6);  // 600 m
+        QCOMPARE(s.startTime.toUTC(),
+                 QDateTime(QDate(2024, 1, 15), QTime(10, 0, 0), Qt::UTC));
+    }
+
+    void summaryHandlesMissingFile()
+    {
+        const WorkoutHistorySummary s = FitActivityReader::readFile("/no/such/file.fit");
+        QVERIFY(!s.valid);
+    }
+
+    // ── FIT indexing: detail records + laps ──────────────────────────────────
+    void detailReadsRecordsAndLaps()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath("activity.fit");
+        writeSampleFit(path, 60);
+
+        const WorkoutHistoryDetail d = FitActivityDetailReader::readFile(path);
+
+        QVERIFY(d.valid);
+        QCOMPARE(d.records.size(), 60);
+        QVERIFY(d.hasPower());
+        QVERIFY(d.hasHeartRate());
+        QVERIFY(d.hasCadence());
+
+        // Records are zero-based on elapsed time, with the values we wrote.
+        QCOMPARE(d.records.first().elapsedSec, 0);
+        QCOMPARE(d.records.first().power, 200);
+        QCOMPARE(d.records.last().elapsedSec, 59);
+        QCOMPARE(d.records.last().power, 259);
+
+        QCOMPARE(d.laps.size(), 1);
+        QCOMPARE(d.laps.first().avgPowerW, 205);
+        QCOMPARE(d.laps.first().maxPowerW, 260);
+        QCOMPARE(d.laps.first().normalizedPower, 215);
+    }
+
+    // ── TSS aggregation: PmcCalculator ───────────────────────────────────────
+    void pmcAggregatesSingleActivity()
+    {
+        const QDate day(2024, 3, 10);
+        WorkoutHistorySummary s;
+        s.startTime = QDateTime(day, QTime(8, 0), Qt::LocalTime);
+        s.tss = 100.0;
+        s.valid = true;
+
+        const QList<PmcPoint> pts = PmcCalculator::compute({s}, day);
+        QVERIFY(!pts.isEmpty());
+
+        const PmcPoint &last = pts.last();
+        QCOMPARE(last.date, day);
+        QCOMPARE(qRound(last.tss), 100);
+        // CTL/ATL on the activity day, all prior days TSS=0:
+        //   CTL = 100 * (1 - e^-1/42) ≈ 2.36 ; ATL = 100 * (1 - e^-1/7) ≈ 13.34
+        QVERIFY(qAbs(last.ctl - 100.0 * (1.0 - std::exp(-1.0 / 42.0))) < 0.01);
+        QVERIFY(qAbs(last.atl - 100.0 * (1.0 - std::exp(-1.0 / 7.0)))  < 0.01);
+    }
+
+    void pmcSumsSameDayActivities()
+    {
+        const QDate day(2024, 3, 10);
+        WorkoutHistorySummary a;
+        a.startTime = QDateTime(day, QTime(8, 0), Qt::LocalTime);
+        a.tss = 60.0;
+        a.valid = true;
+        WorkoutHistorySummary b;
+        b.startTime = QDateTime(day, QTime(18, 0), Qt::LocalTime);
+        b.tss = 40.0;
+        b.valid = true;
+
+        const QList<PmcPoint> pts = PmcCalculator::compute({a, b}, day);
+        QVERIFY(!pts.isEmpty());
+        QCOMPARE(qRound(pts.last().tss), 100);  // 60 + 40 aggregated on the same day
+    }
+};
+
+QTEST_MAIN(TestHistory)
+#include "tst_history.moc"


### PR DESCRIPTION
## Summary

Completes the **Workout History Dashboard** (#144). The core dashboard (History tab with a local-FIT activity table, Critical Power Curve, and Performance Management Chart) already existed; this PR adds the remaining acceptance-criteria functionality and polish.

### What's added
- **Row drill-down** — double-click an activity to open a detail view that re-reads the FIT record stream (new `FitActivityDetailReader`) and renders a power/HR/cadence graph plus a per-lap stats table. The graph reuses the in-workout plot colours (power = yellow, HR = red, cadence = blue). Opens as a proper top-level window with working maximise/restore, and remembers its last geometry/state.
- **Search + date-range filter** — search by workout name and a From/To date range (default: last year → today), backed by `HistoryFilterProxyModel`. The filter is applied on startup, and the status shows "Showing X of Y activities".
- **Delete with confirmation** — right-click an activity → Delete, with a confirm prompt before the FIT file is removed from disk. Right-click also offers Refresh.
- **Unit tests** (`tests/history/`) — synthesize a FIT file with the encoder and read it back through `FitActivityReader` (session summary) and `FitActivityDetailReader` (records + laps); plus `PmcCalculator` TSS-aggregation cases including invalid-date robustness. Wired into a `test_history` CI job.

### Fixes / polish picked up during validation
- **Performance Chart crash fixed**: `PmcCalculator::compute` could hang/crash on activities whose FIT file had no session data (invalid `startTime` → null `QDate` → non-terminating day loop). Now skips invalid-date entries; covered by regression tests.
- Workout list: right-click **Refresh** action added and the redundant bottom-left Refresh button removed; **Delete** and **Open in folder** are now hidden (not greyed) for included/bundled workouts.

### Acceptance criteria (#144)
- [x] History tab in the main window
- [x] Lists all FIT files in the history folder, sorted by date descending
- [x] Each row shows date, name, duration, TSS, NP, avg power, avg HR, calories, distance (+ cadence)
- [x] Click a row → detail view with per-lap stats and the power/HR/cadence graph re-rendered from FIT data
- [x] Search and filter by workout name and date range
- [x] Delete with confirmation before removing the FIT file
- [x] Unit tests for FIT indexing and TSS aggregation
- [x] Uses locally stored activities, not remote
- [x] **30-day rolling TSS view** — considered covered by the **Performance Management Chart** (CTL/ATL/TSB from daily TSS over time), which supersedes a raw 30-day TSS bar chart. *(needs validation)*
- [~] Consistent across platforms incl. WASM in-memory VFS — uses standard file APIs that work on WASM's MEMFS, but **not yet verified in-browser** *(needs validation)*

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
