### PR TITLE
fix(ci): pin macOS runners to macos-15 (Qt 6.7.3 qyieldcpu.h vs new Xcode -Werror)

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -18,7 +18,7 @@ on:
 jobs:
 
   build_mac:
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 
@@ -261,7 +261,7 @@ jobs:
   #   • A labelled 1280×720 screenshot is captured as visual build evidence
   # ──────────────────────────────────────────────────────────────────────────
   test_runtime_validation:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -305,7 +305,7 @@ jobs:
   # gracefully.  No display required (headless Qt Test binary).
   # ──────────────────────────────────────────────────────────────────────────
   test_btle_api:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -348,7 +348,7 @@ jobs:
   #     confirming offline data persistence.
   # ──────────────────────────────────────────────────────────────────────────
   test_offline_mode:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -397,7 +397,7 @@ jobs:
   # development without credentials).
   # ──────────────────────────────────────────────────────────────────────────
   test_intervals_icu_integration:
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
     env:
@@ -470,7 +470,7 @@ jobs:
   # local development without credentials).
   # ──────────────────────────────────────────────────────────────────────────
   test_online_mode:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -527,7 +527,7 @@ jobs:
   #   • A labelled 1280×720 screenshot is captured as visual build evidence.
   # ──────────────────────────────────────────────────────────────────────────
   test_login_screen:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -589,7 +589,7 @@ jobs:
   #     as visual build evidence
   # ──────────────────────────────────────────────────────────────────────────
   test_workout_ui:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -634,7 +634,7 @@ jobs:
   # Workout Parsing Tests – macOS
   # ──────────────────────────────────────────────────────────────────────────
   test_workout_parsing:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -669,7 +669,7 @@ jobs:
   # UI Navigation Tests – macOS
   # ──────────────────────────────────────────────────────────────────────────
   test_ui_navigation:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -718,7 +718,7 @@ jobs:
   # UI Screens Tests – macOS
   # ──────────────────────────────────────────────────────────────────────────
   test_ui_screens:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -757,7 +757,7 @@ jobs:
   # Workout I/O Tests – macOS
   # ──────────────────────────────────────────────────────────────────────────
   test_workout_io:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read
@@ -789,7 +789,7 @@ jobs:
   # Workout Creator Tests – macOS
   # ──────────────────────────────────────────────────────────────────────────
   test_workout_creator:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build_mac
     permissions:
       contents: read

--- a/tests/intervals_icu_integration/intervals_icu_integration_tests.pro
+++ b/tests/intervals_icu_integration/intervals_icu_integration_tests.pro
@@ -48,13 +48,3 @@ SOURCES += \
 HEADERS += \
     tst_intervals_icu_integration.h \
     ../../src/persistence/db/intervals_icu_api.h
-
-# Qt 6.7.3's <QtCore> qyieldcpu.h calls the ARM intrinsic __yield() without
-# including <arm_acle.h>; newer Xcode (macos-latest runner image) promotes
-# -Wimplicit-function-declaration to a hard error. This is a core-only test
-# (QT = core network testlib), so unlike the gui/widgets test targets nothing
-# transitively pulls in <arm_acle.h> first. __yield is a clang builtin and
-# still lowers correctly, so keep it a warning rather than a hard error.
-macx {
-    QMAKE_CXXFLAGS += -Wno-error=implicit-function-declaration
-}


### PR DESCRIPTION
## Problem

The `macos-latest` runner image rolled to **Xcode 26.x** (no Xcode <26 is installed on it anymore), which promotes `-Wimplicit-function-declaration` to a hard error. Qt 6.7.3's `<QtCore>` `qyieldcpu.h` calls the ARM intrinsic `__yield()` without including `<arm_acle.h>`, so compilation fails:

```
qyieldcpu.h:35:5: error: implicitly declaring library function '__yield'
 with type 'void ()' [-Werror,-Wimplicit-function-declaration]
```

First surfaces while **building QWT 6.3.0 from source**, so it breaks `build_mac` for every PR/branch. (#329 only patched one core-only test target; it doesn't cover the QWT build or the app/other test targets.)

## Fix

Pin the macOS jobs to the **`macos-15`** image, whose default toolchain is **Xcode 16.x** and builds Qt 6.7.3 cleanly. One label change per job, applied uniformly to QWT + the app + every test target, and trivially reversible.

> Note: pinning a specific Xcode *version* via `setup-xcode` is unreliable here — the new `macos-latest` image only ships Xcode 26.x, so `xcode-version: '16'` errors with "Could not find Xcode version that satisfied version spec: '16'". Pinning the image label is the robust fix.

Also removes the now-redundant `macx { QMAKE_CXXFLAGS += -Wno-error=implicit-function-declaration }` block that #329 added to `intervals_icu_integration_tests.pro` — the image pin supersedes it, leaving a single mechanism.

## Follow-up

Tracked in **#332**: move CI to a Qt version whose `qyieldcpu.h` includes `<arm_acle.h>`, then drop the pin and return to `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
