### PR TITLE
Remove vestigial speed-sensor cruft (PowerCurve/physio remnants, wheel_circ) + always use virtual speed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,11 @@ Validation checklist:
 ## Known dormant features (don't extend; slated for removal)
 
 Per `agents.md §7`:
-- **PowerCurve** — removed from the product. The dead UI/page was deleted in
-  #242, but ~9 files still carry remnant references (`settings.h`,
-  `userstudio.{h,cpp}`, `dialogconfig.{h,cpp,ui}`, `mainwindow.cpp`,
-  `workoutplot.{h,cpp}`) — safe to strip when you're nearby.
+- **PowerCurve** — fully removed (UI/page in #242; last remnants — the
+  `UserStudio::usingPowerCurve` field and dead `Account` physio fields — stripped
+  afterwards). **Do not confuse** with the live `show_power_curve` /
+  `checkBox_PowerCurve` / `workoutplot::powerCurve`: those toggle the power line
+  on the workout graph (alongside cadence/HR/speed) and are not dormant.
 - **Course** — feature fully removed end to end (Group 1 / #230: `course.*`,
   `main_coursepage.*`, `googlemapwidget.*`, etc.). Only the **FIT-SDK** course
   message headers (`src/fitness/fit/fit_course_*.hpp`) and the `.workout`

--- a/agents.md
+++ b/agents.md
@@ -672,12 +672,19 @@ the `displayPrefs` QSettings group via `Account::save/loadDisplayPrefs()` (with
 encrypted credential stores for third-party tokens). **When adding a new user
 setting, persist it there — do not rely on the server.**
 
-**Profile physio fields.** The truly-dead `Account` fields that only ever came
-from the defunct server JSON with no remaining reader — `height_cm`,
-`bike_type`, `minutes_rode`, and the `powerCurve` data field — have been
-**removed**. Two fields from the old list were kept because they are now live:
-`wheel_circ` feeds the BLE speed-sensor circumference (`BtleHub`), and
-`bike_weight_kg` is added to rider weight for the race-physics rider params.
+**Profile physio fields.** The dead `Account` fields that only ever came from
+the defunct server JSON with no remaining reader — `height_cm`, `bike_type`,
+`minutes_rode`, the `powerCurve` data field, and `wheel_circ` — have been
+**removed**. `wheel_circ` was always the constructor default (no UI to change
+it), so the wheel circumference is now a fixed constant (`BtleHub::DEFAULT_WHEEL_CIRC_MM`,
+700c) feeding the CSC speed calc. `bike_weight_kg` was kept — it's added to
+rider weight for the race-physics / virtual-speed rider params.
+
+**Speed is always virtual.** Indoor speed is derived from power via
+`CyclingPhysics` for both solo and Studio riders (`Clock` emits per-rider
+`virtualSpeed`). The old "Speed Source" (Virtual/Trainer) setting and
+`Account::use_virtual_speed` were removed; a paired sensor's speed only shows
+as the optional "Show Trainer Speed" readout.
 
 (`FTP`, `LTHR`, and `weight_kg` *are* persisted — still user-editable via
 **Preferences → Profile**.)

--- a/agents.md
+++ b/agents.md
@@ -647,17 +647,13 @@ from the code alone.
 
 ### 7.1 Deferred Tasks
 
-**Remove the PowerCurve feature entirely.** PowerCurve was removed from the
-product but still exists throughout the code (~20 files, 100+ references).
-Scrape it out as its own dedicated PR (large; touches plotting, studio users,
-and persistence):
-
-- `src/model/powercurve.{cpp,h}` (delete)
-- References across `account.{cpp,h}`, `userstudio.{cpp,h}`,
-  `workoutplot.{cpp,h}`, `mainwindow.{cpp,h}`, `dialogconfig.{cpp,h}`,
-  `workoutdialog.{cpp,h}`, `util.cpp`, `globalvars.cpp`, `zoneobject.cpp`,
-  `xmlutil.cpp`, `userdao.cpp`, `settings.h`
-- While at it, remove the orphaned profile-physio fields listed in §7.2.
+**PowerCurve removal — DONE.** The mean-maximal-power-curve feature has been
+fully stripped: `powercurve.{cpp,h}` and the bulk of references went in #242,
+and the last remnants (the `UserStudio::usingPowerCurve` field/accessors and the
+dead `Account` physio fields from §7.2) were removed afterwards. Note the
+*live* `show_power_curve` / `checkBox_PowerCurve` / `showHideCurvePower` /
+`workoutplot`'s `powerCurve` are unrelated — they toggle the power line on the
+workout graph (alongside the cadence/HR/speed curves) and must be kept.
 
 **Offline achievement tracking.** Achievements were a sub-tab of the
 (now-removed) main-page Profile tab, rendered by a server-hosted
@@ -676,12 +672,12 @@ the `displayPrefs` QSettings group via `Account::save/loadDisplayPrefs()` (with
 encrypted credential stores for third-party tokens). **When adding a new user
 setting, persist it there — do not rely on the server.**
 
-**Profile physio fields are intentionally NOT persisted.** These `Account`
-fields only ever came from the server JSON and have no remaining UI, so
-persisting them would just store hardcoded defaults. They are left unpersisted
-and should be **removed with the PowerCurve cleanup** (§7.1):
-`height_cm`, `bike_weight_kg`, `wheel_circ`, `bike_type`, `minutes_rode`,
-`powerCurve`.
+**Profile physio fields.** The truly-dead `Account` fields that only ever came
+from the defunct server JSON with no remaining reader — `height_cm`,
+`bike_type`, `minutes_rode`, and the `powerCurve` data field — have been
+**removed**. Two fields from the old list were kept because they are now live:
+`wheel_circ` feeds the BLE speed-sensor circumference (`BtleHub`), and
+`bike_weight_kg` is added to rider weight for the race-physics rider params.
 
 (`FTP`, `LTHR`, and `weight_kg` *are* persisted — still user-editable via
 **Preferences → Profile**.)

--- a/src/btle/btle_hub.cpp
+++ b/src/btle/btle_hub.cpp
@@ -73,12 +73,6 @@ BtleHub::~BtleHub()
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
-void BtleHub::setWheelCircumferenceMm(int mm)
-{
-    if (mm > 0)
-        m_wheelCircMm = mm;
-}
-
 void BtleHub::connectToDevice(const QBluetoothDeviceInfo &device)
 {
     // Fresh, user-initiated connect: remember the target and reset the retry

--- a/src/btle/btle_hub.h
+++ b/src/btle/btle_hub.h
@@ -38,10 +38,6 @@ public:
 
     bool isConnected() const;
 
-    // Wheel circumference in mm – used to convert wheel revolutions to speed.
-    // Should be set from account->wheel_circ before connecting.
-    void setWheelCircumferenceMm(int mm);
-
     // 1-based rider id emitted in every data signal. Defaults to 1 (solo); in
     // Studio mode each rider's hub is given a distinct id so WorkoutDialog
     // routes the data to the correct rider box. Mirrors SimulatorHub::setUserID.
@@ -189,7 +185,9 @@ private:
     static constexpr int MAX_RECONNECT_ATTEMPTS = 3;
     static constexpr int RECONNECT_INTERVAL_MS  = 5000;
 
-    static constexpr int DEFAULT_WHEEL_CIRC_MM  = 2100; // ~700c / 29" wheel
+    // Fixed wheel circumference (700c / 29") used to convert CSC wheel
+    // revolutions to speed. There is no UI to change it, so it's a constant.
+    static constexpr int DEFAULT_WHEEL_CIRC_MM  = 2100;
 
     // WorkoutDialog indexes its per-user data arrays as arrDataWorkout[userID-1],
     // so a single rider must be userID 1 (matching SimulatorHub). Emitting 0 here

--- a/src/btle/btle_hub_wasm.cpp
+++ b/src/btle/btle_hub_wasm.cpp
@@ -75,8 +75,6 @@ void BtleHubWasm::disconnectFromDevice()
 
 bool BtleHubWasm::isConnected() const { return m_connected; }
 
-void BtleHubWasm::setWheelCircumferenceMm(int mm) { m_wheelCircMm = mm; }
-
 void BtleHubWasm::setLoad(int /*deviceId*/, double watts)
 {
     WebBluetoothBridge::sendFtmsSetTargetPower(static_cast<int>(watts));

--- a/src/btle/btle_hub_wasm.h
+++ b/src/btle/btle_hub_wasm.h
@@ -29,8 +29,6 @@ public:
 
     bool isConnected() const;
 
-    void setWheelCircumferenceMm(int mm);
-
     // Keep API compatible with BtleHub so callers can use either hub
     // via connectToDevice(const QBluetoothDeviceInfo&) on native.
     // On Wasm, device selection is done by the browser; this is a no-op.

--- a/src/btle/sensor_connect_dialog.cpp
+++ b/src/btle/sensor_connect_dialog.cpp
@@ -22,10 +22,8 @@ QString deviceKey(const BtleSavedSensor &s)
 
 SensorConnectDialog::SensorConnectDialog(
         const QMap<BtleSensorRole, BtleSavedSensor> &savedSensors,
-        int wheelCircMm,
         QWidget *parent)
     : QDialog(parent)
-    , m_wheelCircMm(wheelCircMm)
 {
     setWindowTitle(tr("Connecting Sensors"));
 
@@ -175,8 +173,6 @@ void SensorConnectDialog::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
         BtleHub *hub = m_hubByDevice.value(key, nullptr);
         if (!hub) {
             hub = new BtleHub(this);
-            if (m_wheelCircMm > 0)
-                hub->setWheelCircumferenceMm(m_wheelCircMm);
             connect(hub, &BtleHub::deviceConnected, this, [this, hub]() {
                 markSlotConnected(hub);
             });

--- a/src/btle/sensor_connect_dialog.h
+++ b/src/btle/sensor_connect_dialog.h
@@ -35,7 +35,6 @@ class SensorConnectDialog : public QDialog
 
 public:
     SensorConnectDialog(const QMap<BtleSensorRole, BtleSavedSensor> &savedSensors,
-                        int wheelCircMm,
                         QWidget *parent = nullptr);
     ~SensorConnectDialog() override;
 
@@ -85,7 +84,6 @@ private:
     // One hub per physical device, keyed by its saved identifier (address/UUID).
     QMap<QString, BtleHub*>         m_hubByDevice;
 
-    int   m_wheelCircMm  = 0;
     bool  m_hubsDetached = false;
 
     QPushButton *m_btnContinue = nullptr;

--- a/src/fitness/achievements/managerachievement.cpp
+++ b/src/fitness/achievements/managerachievement.cpp
@@ -52,12 +52,6 @@ void ManagerAchievement::checkMAPAchievement(int lastStepCompleted) {
 
 
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void ManagerAchievement::updateMinuteRode(int minutes) {
-
-    account->minutes_rode += minutes;
-}
-
 
 
 

--- a/src/fitness/achievements/managerachievement.h
+++ b/src/fitness/achievements/managerachievement.h
@@ -21,9 +21,6 @@ public:
 
 public slots:
 
-    /// Check for Level achievement
-    void updateMinuteRode(int minutes);
-
     /// Check for 1h Workout, 2h Workout, 3h Workout, Target Maniac
     void workoutCompleted(Workout workout);
 

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -26,14 +26,11 @@ Account::Account(QObject *parent) : QObject(parent)  {
 
     FTP = 150;
     LTHR = 150;
-    minutes_rode = 0;
     weight_kg = 70;
     weight_in_kg = true;
-    height_cm = 170;
 
     wheel_circ = 2100;
     bike_weight_kg = 9;
-    bike_type = 2;
 
 
     userCda = 0.35;

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -29,7 +29,6 @@ Account::Account(QObject *parent) : QObject(parent)  {
     weight_kg = 70;
     weight_in_kg = true;
 
-    wheel_circ = 2100;
     bike_weight_kg = 9;
 
 

--- a/src/model/account.cpp
+++ b/src/model/account.cpp
@@ -129,7 +129,6 @@ Account::Account(QObject *parent) : QObject(parent)  {
     show_speed_widget = true;
     show_calories_widget = true;
     show_oxygen_widget = true;
-    use_virtual_speed = true;
     show_trainer_speed = true;
 
     display_hr = 1;
@@ -317,7 +316,6 @@ void Account::loadDisplayPrefs() {
     nb_user_studio        = settings.value("nb_user_studio",        nb_user_studio).toInt();
     use_pm_for_cadence    = settings.value("use_pm_for_cadence",    use_pm_for_cadence).toBool();
     use_pm_for_speed      = settings.value("use_pm_for_speed",      use_pm_for_speed).toBool();
-    use_virtual_speed     = settings.value("use_virtual_speed",     use_virtual_speed).toBool();
     show_included_workout = settings.value("show_included_workout", show_included_workout).toBool();
 
     // Timer display
@@ -403,7 +401,6 @@ void Account::saveDisplayPrefs() {
     settings.setValue("nb_user_studio",        nb_user_studio);
     settings.setValue("use_pm_for_cadence",    use_pm_for_cadence);
     settings.setValue("use_pm_for_speed",      use_pm_for_speed);
-    settings.setValue("use_virtual_speed",     use_virtual_speed);
     settings.setValue("show_included_workout", show_included_workout);
 
     settings.setValue("show_timer_on_top",       show_timer_on_top);

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -166,7 +166,6 @@ public:
     bool show_speed_widget;
     bool show_calories_widget;
     bool show_oxygen_widget;
-    bool use_virtual_speed;
     bool show_trainer_speed;
 
     int display_hr;

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -62,7 +62,6 @@ public:
     double weight_kg;
     bool weight_in_kg;
 
-    int wheel_circ;
     double bike_weight_kg;
 
 

--- a/src/model/account.h
+++ b/src/model/account.h
@@ -59,14 +59,11 @@ public:
 
     int FTP;
     int LTHR;
-    int minutes_rode;
     double weight_kg;
     bool weight_in_kg;
-    int height_cm;
 
     int wheel_circ;
     double bike_weight_kg;
-    int bike_type;
 
 
     //-------------------------- not in DB ----------------------

--- a/src/model/userstudio.cpp
+++ b/src/model/userstudio.cpp
@@ -19,7 +19,7 @@ QVector<UserStudio> UserStudio::loadStudioConfig()
         const QString name = settings.value(g + QStringLiteral("/name")).toString();
         const int ftp      = settings.value(g + QStringLiteral("/ftp"),  -1).toInt();
         const int lthr     = settings.value(g + QStringLiteral("/lthr"), -1).toInt();
-        riders.append(UserStudio(name, ftp, lthr, -1, -1, -1, -1, -1, 2100, false, 0, 0));
+        riders.append(UserStudio(name, ftp, lthr, -1, -1, -1, -1, -1, 2100, 0, 0));
     }
     return riders;
 }
@@ -47,7 +47,7 @@ void UserStudio::saveStudioConfig(const QVector<UserStudio> &riders)
 
 
 UserStudio::UserStudio(QString displayName, int FTP, int LTHR, int hrID, int powerID, int cadenceID, int speedID, int fecID,
-                       int wheelCircMM, bool usingPowerCurve, int companyID, int brandID) {
+                       int wheelCircMM, int companyID, int brandID) {
 
     this->displayName = displayName;
     this->FTP = FTP;
@@ -61,32 +61,6 @@ UserStudio::UserStudio(QString displayName, int FTP, int LTHR, int hrID, int pow
 
     this->wheelCircMM = wheelCircMM;
 
-    this->usingPowerCurve = usingPowerCurve;
     this->companyID = companyID;
     this->brandID = brandID;
 }
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-//UserStudio::UserStudio( const UserStudio& other ) {
-
-//    this->displayName = other.displayName;
-//    this->FTP = other.FTP;
-//    this->LTHR = other.LTHR;
-
-//    this->hrID = other.hrID;
-//    this->powerID = other.powerID;
-//    this->cadenceID = other.cadenceID;
-//    this->speedID = other.speedID;
-//    this->fecID = other.fecID;
-
-//    this->wheelCircMM = other.wheelCircMM;
-
-//    this->usingPowerCurve = other.usingPowerCurve;
-//    this->companyID = other.companyID;
-//    this->brandID = other.brandID;
-
-//    this->powerCurve = other.powerCurve;
-
-
-//}
-

--- a/src/model/userstudio.h
+++ b/src/model/userstudio.h
@@ -11,7 +11,7 @@ class UserStudio
 public:
     UserStudio() {}
     UserStudio(QString displayName, int FTP, int LTHR, int hrID, int powerID, int cadenceID, int speedID, int fecID,
-               int wheelCircMM, bool usingPowerCurve, int companyID, int brandID);
+               int wheelCircMM, int companyID, int brandID);
 
     /// Studio rider identity (name / FTP / LTHR) persistence in QSettings, group
     /// "studioRiders/riderN". Returns a fixed-size vector (constants::nbMaxUserStudio),
@@ -52,9 +52,6 @@ public:
 
     int getWheelCircMM() const {
         return this->wheelCircMM;
-    }
-    bool getUsingPowerCurve() const {
-        return this->usingPowerCurve;
     }
     int getCompanyID() const {
         return this->companyID;
@@ -103,9 +100,6 @@ public:
         this->wheelCircMM = wheelCircMM;
     }
 
-    void setUsingPowerCurve(bool val) {
-        this->usingPowerCurve = val;
-    }
     void setCompanyID(int id) {
         this->companyID = id;
     }
@@ -128,7 +122,6 @@ private :
 
     int wheelCircMM;
 
-    bool usingPowerCurve;
     int companyID;
     int brandID;
 

--- a/src/ui/components/clock.cpp
+++ b/src/ui/components/clock.cpp
@@ -174,30 +174,14 @@ void Clock::timerSpeedTimeout() {
 
         double fractionSecond = diffTime / 1000.0;
 
-        //        for (int i=0; i<nbUser; i++) {
-        for (int i=0; i<1; i++) {
-
-            //            qDebug() << "Calculating speed for user:" << i;
-
-            // Flat-road power→speed via the shared CyclingPhysics model (the same
-            // one the retro race integrates), so virtual speed and the race agree.
-            // Uses rider+bike mass (weightKG) and the rider's CdA.
+        // One pass per rider (1 solo, up to nbMaxUserStudio in Studio): integrate
+        // each rider's flat-road power→speed via the shared CyclingPhysics model
+        // (the same one the retro race uses, so virtual speed and the race agree),
+        // then emit it. Uses rider+bike mass (weightKG) and the rider's CdA.
+        for (int i=0; i<nbUser; i++) {
             currentSpeedMS[i] = CyclingPhysics::stepSpeed(
                 currentSpeedMS[i], currentPowerWatts[i], weightKG[i], cda[i], fractionSecond);
 
-
-            //        qDebug() << "fractionSecond:" << fractionSecond << "diffTime" << diffTime;
-
-            //        qDebug() << "Virtual Speed Debug::" << "currentPowerWatts" << currentPowerWatts <<
-            //                    "powerRequiredRolling" << powerRequiredRolling << "powerRequiredWind" << powerRequiredWind << "powerRequiredGravity" <<
-            //                    powerRequiredGravity << "accelerationMs" << accelerationMs << "currentSpeedMS" <<  currentSpeedMS << "diffTime" << diffTime;
-
-
-        }
-
-        //        for (int i=0; i<nbUser; i++) {
-        for (int i=0; i<1; i++) {
-            //            qDebug() << "emiting speed for user:" << i+1 << "is" << currentSpeedMS[i];
             emit virtualSpeed(i+1, currentSpeedMS[i], fractionSecond);
         }
 

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -477,14 +477,6 @@ void DialogConfig::initUi() {
     ///Speed widget
     ui->checkBox_enableSpeed->setChecked(account->show_speed_widget);
 
-    ///virtual speed
-    if (account->use_virtual_speed) {
-        ui->comboBox_virtualSpeed->setCurrentIndex(0);
-    }
-    else {
-        ui->comboBox_virtualSpeed->setCurrentIndex(1);
-    }
-
     ///Speed widget
     ui->checkBox_showTrainerSpeed->setChecked(account->show_trainer_speed);
 
@@ -661,25 +653,6 @@ void DialogConfig::on_comboBox_displayHR_currentIndexChanged(int index) {
     if (ui->checkBox_enableHR->isChecked())
         parentDialog->showHeartRateDisplayWidget(index + 1);
 }
-//----------------
-void DialogConfig::on_comboBox_virtualSpeed_currentIndexChanged(int index)
-{
-    qDebug() << "OK CLICKED!" << index;
-
-
-    if (index == 0) { //Virtual Speed
-        account->use_virtual_speed = true;
-        parentDialog->useVirtualSpeedData(true);
-        ui->checkBox_showTrainerSpeed->setVisible(true);
-    }
-    else {
-        account->use_virtual_speed = false;
-        parentDialog->useVirtualSpeedData(false);     // Trainer Speed
-        ui->checkBox_showTrainerSpeed->setVisible(false);
-    }
-
-}
-
 
 //-----------------------------------------------------------------------------------
 void DialogConfig::on_checkBox_showTrainerSpeed_clicked(bool checked)

--- a/src/ui/dialogconfig.h
+++ b/src/ui/dialogconfig.h
@@ -84,7 +84,6 @@ private slots:
     void on_checkBox_enablePowerBalance_clicked(bool checked);
 
     void on_comboBox_displayHR_currentIndexChanged(int index);
-    void on_comboBox_virtualSpeed_currentIndexChanged(int index);
 
     void on_comboBox_displayCadence_currentIndexChanged(int index);
     void on_comboBox_displayPower_currentIndexChanged(int index);

--- a/src/ui/dialogconfig.ui
+++ b/src/ui/dialogconfig.ui
@@ -1230,50 +1230,6 @@ QLabel#label_imageCalories {
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Speed Source:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="comboBox_virtualSpeed">
-               <property name="minimumSize">
-                <size>
-                 <width>90</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Virtual Speed</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Trainer Speed</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item>
             <widget class="QCheckBox" name="checkBox_showTrainerSpeed">
              <property name="text">
               <string>Show Trainer Speed</string>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -970,8 +970,6 @@ void MainWindow::updateFieldForUser(int riderID, int fieldNumber, QVariant value
 
     qDebug() << "updateDisplayNameForUser" << riderID << "fieldNumber" << fieldNumber << "value" << value;
 
-
-    qDebug() << "disablePowerCurveForUser" << riderID;
     if (riderID >= vecUserStudio.size())
         return;
     UserStudio myUserStudio = vecUserStudio.at(riderID-1);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1430,7 +1430,7 @@ void MainWindow::executeWorkout(Workout workout) {
             if (saved.isEmpty())
                 continue;   // rider configured no sensors — their box stays empty
 
-            SensorConnectDialog connectDlg(saved, account->wheel_circ, this);
+            SensorConnectDialog connectDlg(saved, this);
             const QString riderName = (rider - 1 < vecUserStudio.size()
                                        && !vecUserStudio.at(rider - 1).getDisplayName().trimmed().isEmpty())
                                           ? vecUserStudio.at(rider - 1).getDisplayName().trimmed()
@@ -1467,7 +1467,7 @@ void MainWindow::executeWorkout(Workout workout) {
     {
         const QMap<BtleSensorRole, BtleSavedSensor> savedSensors = BtleSensorStore::loadAll();
         if (!savedSensors.isEmpty()) {
-            SensorConnectDialog connectDlg(savedSensors, account->wheel_circ, this);
+            SensorConnectDialog connectDlg(savedSensors, this);
             connect(&connectDlg, &SensorConnectDialog::openSensorPreferences,
                     this, [this, &connectDlg]() {
                         // "Manage Sensors" – cancel the connect flow and switch
@@ -1498,8 +1498,6 @@ void MainWindow::executeWorkout(Workout workout) {
 
 
     BtleHub *btleHub = new BtleHub(this);
-    if (account->wheel_circ > 0)
-        btleHub->setWheelCircumferenceMm(account->wheel_circ);
 
     {
         QEventLoop loop;

--- a/src/ui/studiowidget.cpp
+++ b/src/ui/studiowidget.cpp
@@ -256,7 +256,7 @@ void StudioWidget::reload()
     m_riders = UserStudio::loadStudioConfig();
     // Guarantee enough entries to back every card.
     while (m_riders.size() < kMaxRiders)
-        m_riders.append(UserStudio("", -1, -1, -1, -1, -1, -1, -1, 2100, false, 0, 0));
+        m_riders.append(UserStudio("", -1, -1, -1, -1, -1, -1, -1, 2100, 0, 0));
 
     if (m_enableSwitch) {
         QSignalBlocker b(m_enableSwitch);

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -844,7 +844,8 @@ void WorkoutDialog::initUI() {
     showCadenceDisplayWidget(account->display_cadence);
     showSpeedDisplayWidget();
     showTrainerSpeed(account->show_trainer_speed);
-    useVirtualSpeedData(account->use_virtual_speed);
+    // Speed is always virtual (derived from power), for solo and Studio riders.
+    useVirtualSpeedData(true);
     showOxygenDisplayWidget();
     showCaloriesDisplayWidget();
     showPowerBalanceWidget(account->display_power_balance);
@@ -2007,12 +2008,9 @@ void WorkoutDialog::TrainerSpeedDataReceived(int userID, double value) {
         checkPairingCompleted();
     }
 
+    // The displayed speed is always virtual (see VirtualSpeedDataReceived);
+    // a paired sensor's reading is only shown as the optional "trainer speed".
     ui->wid_4_infoBoxSpeed->setTrainerSpeed(value);
-
-    // if user want trainer data to represent his speed
-    if ( !account->use_virtual_speed || account->enable_studio_mode) {
-        speedDataChosen(userID, value);
-    }
 
 }
 
@@ -2036,14 +2034,11 @@ void WorkoutDialog::VirtualSpeedDataReceived(int userID, double valueMS, double 
 
 
 
-    if ( account->use_virtual_speed && !account->enable_studio_mode ) {
-        speedDataChosen(userID, valueKMH);
+    speedDataChosen(userID, valueKMH);
 
-        //Update Distance Counter
-        if (!isWorkoutPaused && !isWorkoutOver) {
-//            qDebug() << "valueMS" << valueMS << "valueKMH" << valueKMH << "timeAtThisSpeedSec" << timeAtThisSpeedSec;
-            arrDataWorkout[userID-1]->updateDistance(valueMS*timeAtThisSpeedSec);
-        }
+    //Update Distance Counter
+    if (!isWorkoutPaused && !isWorkoutOver) {
+        arrDataWorkout[userID-1]->updateDistance(valueMS*timeAtThisSpeedSec);
     }
 
 }

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -586,7 +586,6 @@ WorkoutDialog::WorkoutDialog(Workout workout,  QList<Radio> lstRadio, QVector<Us
 
 
     timeElapsedTotal = QTime(0,0,0,0);
-    nbUpdate1Sec = 0;
 
     trainerControlUserId = -1;
     currentTargetPower = -1;
@@ -1106,13 +1105,6 @@ void WorkoutDialog::update1sec(double totalTimeElapsed_sec) {
     // Update the graph 'dark' area
     ui->widget_workoutPlot->updateMarkerTimeNow(totalTimeElapsed_sec);
 
-    // Update minutes rode after 60secs
-    nbUpdate1Sec++ ;
-    if (nbUpdate1Sec == 60) {
-        achievementManager->updateMinuteRode(1);
-        nbUpdate1Sec = 0;
-    }
-
     // Update Timers
     timeElapsedTotal = timeElapsedTotal.addSecs(1);
     ui->widget_time->setWorkoutTime(timeElapsedTotal);
@@ -1618,7 +1610,6 @@ void WorkoutDialog::workoutOver() {
     setWidgetsStopped(true);
 
     qDebug() << "OK CHECKING IF WORKOUT ACHIEVEMENT WITH LENGTH:" << QString::number(Util::convertQTimeToSecD(workout.getDurationQTime()) );
-    achievementManager->updateMinuteRode(1);
     achievementManager->workoutCompleted(workout);
 
 

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -509,7 +509,6 @@ private:
     static constexpr double kMiniGraphRefreshMs = 50.0; // ~20 fps
     double lastMiniGraphReplot_msec = -kMiniGraphRefreshMs;
 
-    int nbUpdate1Sec;
     QTime timeWorkoutRemaining;
     QTime timeElapsedTotal;
     QTime timeInterval;

--- a/tests/btle/tst_btle_hub.cpp
+++ b/tests/btle/tst_btle_hub.cpp
@@ -214,8 +214,6 @@ void TstBtleHub::testCsc_wheelOnly()
 {
     // 2100 mm wheel (default), 1 rev in 512 ticks (0.5 s) → speed
     // speed_ms = (2.1 m × 1 rev × 1024) / 512 = 4.2 m/s = 15.12 km/h
-    hub->setWheelCircumferenceMm(2100);
-
     QSignalSpy spy(hub, &BtleHub::signal_speed);
 
     hub->simulateNotification(BTLE_UUID_CSC_MEASUREMENT,
@@ -236,8 +234,6 @@ void TstBtleHub::testCsc_combined()
     // 30 km/h speed with 2100 mm wheel:
     //   speed_ms = 30/3.6 = 8.333 m/s
     //   ticks_per_rev = 2100/1000 × 1024 / 8.333 = 258 ticks
-    hub->setWheelCircumferenceMm(2100);
-
     QSignalSpy spyCad(hub, &BtleHub::signal_cadence);
     QSignalSpy spySpd(hub, &BtleHub::signal_speed);
 
@@ -519,7 +515,6 @@ void TstBtleHub::testEliteTrainer_sequence()
  */
 void TstBtleHub::testWahooKickr_powerAndCsc()
 {
-    hub->setWheelCircumferenceMm(2100);
     QSignalSpy spyPwr(hub, &BtleHub::signal_power);
     QSignalSpy spyCad(hub, &BtleHub::signal_cadence);
 
@@ -572,7 +567,6 @@ void TstBtleHub::testWahooKickr_cscRollover()
  */
 void TstBtleHub::testGarminTacx_ftmsPlusCsc()
 {
-    hub->setWheelCircumferenceMm(2100);
     QSignalSpy spySpd(hub, &BtleHub::signal_speed);
     QSignalSpy spyCad(hub, &BtleHub::signal_cadence);
     QSignalSpy spyPwr(hub, &BtleHub::signal_power);


### PR DESCRIPTION
A cleanup pass around the (now-vestigial) dedicated speed/cadence sensor path. Three commits:

## 1. Strip the last dead PowerCurve / orphaned physio remnants
PowerCurve was removed in #242; this clears the final remnants `agents.md §7.1/§7.2` still flagged:
- `UserStudio::usingPowerCurve` field + accessors + ctor param (never read, not serialized) and the dead commented copy-ctor
- `Account` fields with no reader: `height_cm`, `bike_type`, write-only `minutes_rode` (+ `ManagerAchievement::updateMinuteRode` and the `WorkoutDialog::nbUpdate1Sec` counter that only fed it)
- a stray `disablePowerCurveForUser` qDebug

## 2. Drop unused `wheel_circ` indirection
`Account::wheel_circ` was only ever the constructor default (`2100` mm) - never persisted, loaded, or editable from any UI - so threading it through `SensorConnectDialog` into `setWheelCircumferenceMm` just re-set the hub to the constant it already defaults to. Removed the field, the dialog plumbing, and `setWheelCircumferenceMm` from both hubs. The live CSC speed calc keeps reading the fixed `DEFAULT_WHEEL_CIRC_MM` (700c).

## 3. Always use virtual speed; remove the "Speed Source" toggle (behaviour change)
Indoor speed is now always derived from power via `CyclingPhysics`, for solo **and** Studio riders.
- removed the **Settings → Display → Speed → "Speed Source"** (Virtual/Trainer) dropdown - the default was already Virtual, and sensor speed is redundant now (smart trainers/power meters cover it; the power-from-speed PowerCurve path is gone)
- dropped `Account::use_virtual_speed` (field + persistence)
- `Clock` now computes & emits per-rider virtual speed for all riders (it was hardcoded to rider 1, which is exactly why Studio previously fell back to trainer speed); merged the redundant compute/emit passes into one loop
- the separate **"Show Trainer Speed"** secondary-readout option is unaffected

## Kept on purpose (NOT dead)
The live `show_power_curve` / `checkBox_PowerCurve` / `workoutplot::powerCurve` (power line on the workout graph) and `bike_weight_kg` (race physics). `agents.md §7.2` wrongly listed `wheel_circ`/`bike_weight_kg` as orphaned; both docs corrected.

## Validation
- Clean app build; headless `--screenshots` demo (incl. Studio) runs, no crash markers
- **BLE unit suite: 56 passed, 0 failed** (incl. the Wahoo/Garmin CSC + speed/cadence tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
