### PR TITLE
feat(race): standings leaderboard with Zwift-style time-behind

### DIFF
--- a/src/game/qml/RetroRace.qml
+++ b/src/game/qml/RetroRace.qml
@@ -915,6 +915,52 @@ Item {
 
     // (No top-right gap cluster: position and gap live in the avatar bubble.)
 
+    // ---------------------------------------------------------------- LEADERBOARD
+    // Shared standings panel (right edge). Solo = you vs the ghost; the same
+    // panel will list every Studio rider once multi-rider is wired in. Each row:
+    // rank · name · time behind the leader ("Leader" / "+12s" / "+1:05").
+    Rectangle {
+        id: leaderboard
+        visible: race.started && lbRepeater.count > 1
+        anchors.right: parent.right; anchors.rightMargin: 14
+        anchors.verticalCenter: parent.verticalCenter
+        width: 176
+        height: lbCol.implicitHeight + 16
+        radius: 8
+        color: "#000000"; opacity: 0.52
+        border.color: "#ffffff"; border.width: 1
+
+        Column {
+            id: lbCol
+            anchors.fill: parent; anchors.margins: 8
+            spacing: 5
+            Text { anchors.horizontalCenter: parent.horizontalCenter
+                   text: "STANDINGS"; color: "#bcd"
+                   font.family: "monospace"; font.pixelSize: 11; font.bold: true }
+            Repeater {
+                id: lbRepeater
+                model: race.standings
+                Item {
+                    width: lbCol.width; height: 18
+                    readonly property bool me: modelData.isPlayer
+                    Text { id: rk; anchors.left: parent.left; anchors.verticalCenter: parent.verticalCenter
+                           text: modelData.rank + "."; color: me ? "#ffe24a" : "#dfe7ef"
+                           font.family: "monospace"; font.pixelSize: 13; font.bold: true }
+                    Text { anchors.left: rk.right; anchors.leftMargin: 5
+                           anchors.right: gp.left; anchors.rightMargin: 6
+                           anchors.verticalCenter: parent.verticalCenter
+                           text: root.shortName(modelData.name, 12); elide: Text.ElideRight
+                           color: me ? "#ffe24a" : "#ffffff"
+                           font.family: "monospace"; font.pixelSize: 13; font.bold: me }
+                    Text { id: gp; anchors.right: parent.right; anchors.verticalCenter: parent.verticalCenter
+                           text: modelData.gapText
+                           color: modelData.rank === 1 ? "#5dff5d" : "#ff9d6b"
+                           font.family: "monospace"; font.pixelSize: 13; font.bold: true }
+                }
+            }
+        }
+    }
+
     // NEXT-interval target card (right side).
     Rectangle {
         visible: race.started && !race.finished && race.nextTargetW > 0 && race.nextSecs >= 0

--- a/src/game/retroracecontroller.cpp
+++ b/src/game/retroracecontroller.cpp
@@ -13,6 +13,10 @@ namespace {
 // so a near-stopped leader doesn't blow the "time behind" up to nonsense.
 constexpr double kStandingsMinMS = 1.5;
 
+// Only store a new trace sample once the rider has moved this far, to keep the
+// history compact over a long ride (the gap interpolates between samples).
+constexpr double kTraceStepM = 3.0;
+
 // "+12s" under a minute, "+1:05" beyond.
 QString fmtGapSec(double sec) {
     if (sec < 60.0)
@@ -183,6 +187,8 @@ void RetroRaceController::start()
     m_finishSecs     = -1.0;
     m_started  = false;
     m_finished = false;
+    m_playerTrace.clear();
+    m_oppTrace.clear();
     m_intervalMarks.clear();
     emit intervalMarksChanged();
     m_clock.restart();
@@ -363,11 +369,47 @@ void RetroRaceController::tick()
         m_playerCadence = m_oppCadence;
     m_playerCrankRev += (m_playerCadence / 60.0) * dt;
 
+    // Record each rider's position-over-time for the time-gap lookup.
+    recordTrace(m_playerTrace, m_playerDistM, m_elapsedSec);
+    recordTrace(m_oppTrace,    m_oppDistM,    m_elapsedSec);
+
     emit updated();
 
     const double total = m_opponent->totalTimeSec();
     if (total > 1.0 && m_elapsedSec >= total)
         finishRace();   // ghost route completed → celebrate
+}
+
+// Append a (distance, time) sample once the rider has advanced kTraceStepM, so
+// the trace stays compact. Distance is monotonic, so the trace is sorted by x.
+void RetroRaceController::recordTrace(QVector<QPointF> &trace, double distanceM, double timeSec)
+{
+    if (trace.isEmpty() || distanceM - trace.last().x() >= kTraceStepM)
+        trace.append(QPointF(distanceM, timeSec));
+}
+
+// The elapsed time at which this rider passed `distanceM` (linear-interpolated
+// between samples). Returns -1 if the trace doesn't reach back that far.
+double RetroRaceController::timeAtDistance(const QVector<QPointF> &trace, double distanceM)
+{
+    if (trace.isEmpty())
+        return -1.0;
+    if (distanceM <= trace.first().x())
+        return trace.first().y();
+    if (distanceM >= trace.last().x())
+        return trace.last().y();
+    // Binary search for the first sample at/after distanceM, then interpolate.
+    int lo = 0, hi = trace.size() - 1;
+    while (lo < hi) {
+        const int mid = (lo + hi) / 2;
+        if (trace.at(mid).x() < distanceM) lo = mid + 1;
+        else                               hi = mid;
+    }
+    const QPointF &b = trace.at(lo);
+    const QPointF &a = trace.at(lo - 1);
+    const double span = b.x() - a.x();
+    const double f = span > 1e-6 ? (distanceM - a.x()) / span : 0.0;
+    return a.y() + f * (b.y() - a.y());
 }
 
 // Leaderboard rows (leader-first) for the shared race panel. Solo = the live
@@ -386,12 +428,23 @@ QVariantList RetroRaceController::standings() const
 
     const double leaderDist = rows.isEmpty() ? 0.0 : rows.first().dist;
     const double leaderMS   = rows.isEmpty() ? 0.0 : qMax(rows.first().speedMS, 0.0);
+    // The leader's position trace — used to find when the leader passed each
+    // trailing rider's current spot (Zwift-style true time gap).
+    const QVector<QPointF> &leaderTrace =
+        (!rows.isEmpty() && rows.first().isPlayer) ? m_playerTrace : m_oppTrace;
 
     QVariantList out;
     for (int i = 0; i < rows.size(); ++i) {
         const Row &r = rows.at(i);
-        const double gapM   = qMax(0.0, leaderDist - r.dist);
-        const double gapSec = (i == 0) ? 0.0 : gapM / qMax(leaderMS, kStandingsMinMS);
+        double gapSec = 0.0;
+        if (i > 0) {
+            // True time gap: how long ago was the leader at this rider's distance?
+            const double tLeaderHere = timeAtDistance(leaderTrace, r.dist);
+            if (tLeaderHere >= 0.0)
+                gapSec = qMax(0.0, m_elapsedSec - tLeaderHere);
+            else  // no history yet — fall back to gap distance / leader speed
+                gapSec = qMax(0.0, leaderDist - r.dist) / qMax(leaderMS, kStandingsMinMS);
+        }
         QVariantMap m;
         m.insert(QStringLiteral("name"),     r.name);
         m.insert(QStringLiteral("rank"),     i + 1);

--- a/src/game/retroracecontroller.cpp
+++ b/src/game/retroracecontroller.cpp
@@ -3,9 +3,25 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
+#include <QVariantMap>
 #include <QtGlobal>
 
+#include <algorithm>
+
 namespace {
+// Floor for the leader's speed when converting a distance gap into a time gap,
+// so a near-stopped leader doesn't blow the "time behind" up to nonsense.
+constexpr double kStandingsMinMS = 1.5;
+
+// "+12s" under a minute, "+1:05" beyond.
+QString fmtGapSec(double sec) {
+    if (sec < 60.0)
+        return QStringLiteral("+%1s").arg(qRound(sec));
+    const int m = int(sec) / 60;
+    const int s = int(sec) % 60;
+    return QStringLiteral("+%1:%2").arg(m).arg(s, 2, 10, QLatin1Char('0'));
+}
+
 // ERG team-race tuning. In ERG the rider can't out-power the target, so catching
 // back relies on drafting; the partner is leashed so it never drops you.
 constexpr double kDraftRangeM     = 12.0;  // slipstream reaches this far back
@@ -352,4 +368,38 @@ void RetroRaceController::tick()
     const double total = m_opponent->totalTimeSec();
     if (total > 1.0 && m_elapsedSec >= total)
         finishRace();   // ghost route completed → celebrate
+}
+
+// Leaderboard rows (leader-first) for the shared race panel. Solo = the live
+// rider plus the chosen opponent; the same shape will carry N Studio riders.
+QVariantList RetroRaceController::standings() const
+{
+    struct Row { QString name; double dist; double speedMS; bool isPlayer; };
+    QVector<Row> rows;
+    rows.append({ m_playerName, m_playerDistM, m_playerV, true });
+    if (m_opponent)
+        rows.append({ m_oppName.isEmpty() ? QStringLiteral("Ghost") : m_oppName,
+                      m_oppDistM, m_oppV, false });
+
+    std::sort(rows.begin(), rows.end(),
+              [](const Row &a, const Row &b) { return a.dist > b.dist; });
+
+    const double leaderDist = rows.isEmpty() ? 0.0 : rows.first().dist;
+    const double leaderMS   = rows.isEmpty() ? 0.0 : qMax(rows.first().speedMS, 0.0);
+
+    QVariantList out;
+    for (int i = 0; i < rows.size(); ++i) {
+        const Row &r = rows.at(i);
+        const double gapM   = qMax(0.0, leaderDist - r.dist);
+        const double gapSec = (i == 0) ? 0.0 : gapM / qMax(leaderMS, kStandingsMinMS);
+        QVariantMap m;
+        m.insert(QStringLiteral("name"),     r.name);
+        m.insert(QStringLiteral("rank"),     i + 1);
+        m.insert(QStringLiteral("isPlayer"), r.isPlayer);
+        m.insert(QStringLiteral("gapSec"),   gapSec);
+        m.insert(QStringLiteral("gapText"),  (i == 0) ? QStringLiteral("Leader")
+                                                      : fmtGapSec(gapSec));
+        out.append(m);
+    }
+    return out;
 }

--- a/src/game/retroracecontroller.h
+++ b/src/game/retroracecontroller.h
@@ -6,6 +6,8 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QVariantList>
+#include <QVector>
+#include <QPointF>
 
 #include <memory>
 
@@ -278,6 +280,14 @@ private:
     // player a touch stronger than the opponent. Both go away with live power.
     double m_timeScale  = 10.0;
     double m_playerForm = 1.08;
+
+    // Position-over-time traces (x = distance m, y = elapsed sec), one per rider,
+    // for the Zwift-style "time behind": the gap is how many seconds ago the
+    // rider ahead passed the point the trailing rider is at now. Monotonic in x.
+    QVector<QPointF> m_playerTrace;
+    QVector<QPointF> m_oppTrace;
+    void recordTrace(QVector<QPointF> &trace, double distanceM, double timeSec);
+    static double timeAtDistance(const QVector<QPointF> &trace, double distanceM);
 
     double m_elapsedSec  = 0.0;
     double m_playerV     = 0.0;   // m/s

--- a/src/game/retroracecontroller.h
+++ b/src/game/retroracecontroller.h
@@ -35,6 +35,10 @@ class RetroRaceController : public QObject
     Q_PROPERTY(double  displayDistanceM READ displayDistanceM NOTIFY updated)
     Q_PROPERTY(double  oppDistanceM    READ oppDistanceM    NOTIFY updated)
     Q_PROPERTY(double  gapMeters       READ gapMeters       NOTIFY updated)
+    // Leaderboard rows, leader-first. Each is a map: name, rank, gapSec, gapText
+    // ("Leader" / "+12s" / "+1:05"), isPlayer. Built from the player + opponent;
+    // the same shape will carry N Studio riders later (one scene, one panel).
+    Q_PROPERTY(QVariantList standings  READ standings       NOTIFY updated)
     Q_PROPERTY(double  playerSpeedKmh  READ playerSpeedKmh  NOTIFY updated)
     Q_PROPERTY(double  oppSpeedKmh     READ oppSpeedKmh     NOTIFY updated)
     Q_PROPERTY(double  playerPowerW    READ playerPowerW    NOTIFY updated)
@@ -133,6 +137,9 @@ public:
     void    setDisplayDistanceM(double m) { m_displayDistM = m; }
     double  oppDistanceM() const    { return m_oppDistM; }
     double  gapMeters() const       { return m_playerDistM - m_oppDistM; }
+    QVariantList standings() const;
+    /// Name shown for the live rider in the leaderboard (defaults to "You").
+    void    setPlayerName(const QString &n) { m_playerName = n.isEmpty() ? QStringLiteral("You") : n; }
     double  playerSpeedKmh() const  { return m_playerV * 3.6; }
     double  oppSpeedKmh() const     { return m_oppV * 3.6; }
     double  playerPowerW() const    { return m_playerPowerW; }
@@ -248,6 +255,7 @@ private:
     std::unique_ptr<PowerSource> m_opponent;
     LivePowerSource *m_pacerLive = nullptr;   // non-owning; valid only for the workout pacer
     QString m_oppName;
+    QString m_playerName = QStringLiteral("You");
     QString m_workoutName;
     bool    m_oppIsBot     = false;
     bool    m_oppChosen    = false;


### PR DESCRIPTION
Adds a **standings leaderboard** to the solo retro ghost race — rank · name · time behind — reusing the existing `RetroRace.qml` scene (no new QML file, no duplicated graphics).

## What it does
A small **STANDINGS** panel on the right edge of the race view:

```
        STANDINGS
1. You          Leader
2. Pace Partner   +8s
```

- `RetroRaceController` gains a computed `standings` QVariantList (leader-first; each row: `name` / `rank` / `gapSec` / `gapText` / `isPlayer`), built from the existing player + opponent state. Player name via `setPlayerName()` (defaults "You"); the opponent row appears whenever an opponent exists.
- `RetroRace.qml`: a right-edge panel bound to `race.standings`.

## Time behind = Zwift-style true time gap
Instead of an instantaneous `gap ÷ speed` (which jitters and can read backwards when the leader eases off), the gap is the **real elapsed-time difference**: *how many seconds ago the rider ahead passed the point the trailing rider is at now*.

- Each rider records a compact `(distance, time)` trace in the tick (one sample per ~3 m; distance is monotonic so the trace stays sorted).
- `standings()` binary-searches + interpolates the leader's trace for the time it was at the trailing rider's current distance; gap = `now − that time`. Falls back to the old speed-based estimate only before any history exists.

This is **gradient-aware** (a gap on a climb is worth more seconds than on a descent) and **stable** (no jitter on pace changes) — matching how Zwift shows time gaps.

## Not included (by design)
A multi-rider **Studio** race was explored and dropped: in Studio every rider is in ERG on the same FTP-relative target, so power is pinned and a head-to-head would only reflect FTP/weight, not effort. The leaderboard was kept generic so it could carry N riders if that ever changes, but Studio stays race-free.

## Validation
- Clean build.
- Headless via `--retrorace --bot`: panel renders correctly ("1. You — Leader / 2. Pacer Bot — +Ns").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
