### PR TITLE
fix(wasm): eliminate fatal nested-event-loop dialogs (Log Out, Preferences, workout start, ...)

### DIFF
--- a/src/ui/asyncdialogs.h
+++ b/src/ui/asyncdialogs.h
@@ -1,0 +1,60 @@
+#ifndef ASYNCDIALOGS_H
+#define ASYNCDIALOGS_H
+
+#include <QAbstractButton>
+#include <QMessageBox>
+#include <functional>
+
+/*
+ * Non-blocking replacements for the static QMessageBox convenience functions.
+ *
+ * Those statics run QDialog::exec(), which spins a nested event loop — a
+ * qFatal on Qt for WebAssembly without asyncify ("Calling exec() is not
+ * supported..."), aborting the whole WASM runtime.  Every message box that can
+ * be reached in the WASM build must therefore go through QDialog::open().
+ * Used on all platforms so there is a single code path; on desktop the only
+ * difference is that the call returns immediately instead of blocking.
+ */
+namespace AsyncDialogs {
+
+inline QMessageBox *makeBox(QMessageBox::Icon icon, QWidget *parent,
+                            const QString &title, const QString &text,
+                            QMessageBox::StandardButtons buttons)
+{
+    auto *box = new QMessageBox(icon, title, text, buttons, parent);
+    box->setAttribute(Qt::WA_DeleteOnClose);
+    return box;
+}
+
+inline void information(QWidget *parent, const QString &title, const QString &text)
+{
+    makeBox(QMessageBox::Information, parent, title, text, QMessageBox::Ok)->open();
+}
+
+inline void warning(QWidget *parent, const QString &title, const QString &text)
+{
+    makeBox(QMessageBox::Warning, parent, title, text, QMessageBox::Ok)->open();
+}
+
+/// Yes/No confirmation. onYes runs only when Yes is clicked; No, Esc and
+/// closing the box all decline (No is the default button).
+inline void question(QWidget *parent, const QString &title, const QString &text,
+                     std::function<void()> onYes,
+                     const QString &informativeText = QString())
+{
+    auto *box = makeBox(QMessageBox::Question, parent, title, text,
+                        QMessageBox::Yes | QMessageBox::No);
+    box->setDefaultButton(QMessageBox::No);
+    if (!informativeText.isEmpty())
+        box->setInformativeText(informativeText);
+    QObject::connect(box, &QMessageBox::buttonClicked, box,
+                     [box, onYes = std::move(onYes)](QAbstractButton *button) {
+        if (box->standardButton(button) == QMessageBox::Yes)
+            onYes();
+    });
+    box->open();
+}
+
+} // namespace AsyncDialogs
+
+#endif // ASYNCDIALOGS_H

--- a/src/ui/dialogconfig.cpp
+++ b/src/ui/dialogconfig.cpp
@@ -1136,24 +1136,29 @@ void DialogConfig::saveIntervalSummary()
 #include <QLineEdit>
 #include <QSpinBox>
 #include "util.h"
+#include "asyncdialogs.h"
+#include <functional>
 
 namespace {
-/// Tiny modal that edits a single Radio. Returns the edited copy on accept.
+/// Tiny editor for a single Radio, shown via open() (exec() is fatal on WASM).
+/// onAccepted receives the edited copy once the input passed validation.
 /// Lives here (not in its own .h/.cpp pair) because it is only used by the
 /// three Add/Edit/Delete handlers below.
-bool runRadioEditDialog(QWidget *parent, Radio& inOut) {
-    QDialog dlg(parent);
-    dlg.setWindowTitle(QObject::tr("Radio Station"));
+void runRadioEditDialog(QWidget *parent, const Radio &initial,
+                        std::function<void(const Radio &)> onAccepted) {
+    auto *dlg = new QDialog(parent);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->setWindowTitle(QObject::tr("Radio Station"));
 
-    auto *nameEdit    = new QLineEdit(inOut.getName());
-    auto *genreEdit   = new QLineEdit(inOut.getGenre());
-    auto *langEdit    = new QLineEdit(inOut.getLanguage());
-    auto *urlEdit     = new QLineEdit(inOut.getUrl());
+    auto *nameEdit    = new QLineEdit(initial.getName());
+    auto *genreEdit   = new QLineEdit(initial.getGenre());
+    auto *langEdit    = new QLineEdit(initial.getLanguage());
+    auto *urlEdit     = new QLineEdit(initial.getUrl());
     urlEdit->setPlaceholderText(QStringLiteral("https://stream.example.com/stream.mp3"));
     auto *bitrateSpin = new QSpinBox();
     bitrateSpin->setRange(0, 1000);
     bitrateSpin->setSuffix(QStringLiteral(" kbps"));
-    bitrateSpin->setValue(inOut.getBitrate());
+    bitrateSpin->setValue(initial.getBitrate());
 
     auto *form = new QFormLayout();
     form->addRow(QObject::tr("Name"),     nameEdit);
@@ -1163,33 +1168,34 @@ bool runRadioEditDialog(QWidget *parent, Radio& inOut) {
     form->addRow(QObject::tr("URL"),      urlEdit);
 
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    QObject::connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
-    QObject::connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    /// Minimal validation, checked before accepting so the dialog stays open
+    /// on bad input: name and url are required. We don't try to validate the
+    /// URL itself — the player will reject anything unparseable on Play.
+    QObject::connect(buttons, &QDialogButtonBox::accepted, dlg, [dlg, nameEdit, urlEdit]() {
+        if (nameEdit->text().trimmed().isEmpty() || urlEdit->text().trimmed().isEmpty()) {
+            AsyncDialogs::warning(dlg, QObject::tr("Radio Station"),
+                QObject::tr("Name and URL are required."));
+            return;
+        }
+        dlg->accept();
+    });
+    QObject::connect(buttons, &QDialogButtonBox::rejected, dlg, &QDialog::reject);
+    QObject::connect(dlg, &QDialog::accepted, dlg,
+                     [nameEdit, genreEdit, langEdit, urlEdit, bitrateSpin,
+                      onAccepted = std::move(onAccepted)]() {
+        onAccepted(Radio(nameEdit->text().trimmed(),
+                         genreEdit->text().trimmed(),
+                         /*gotAds=*/false,
+                         bitrateSpin->value(),
+                         langEdit->text().trimmed(),
+                         urlEdit->text().trimmed()));
+    });
 
-    auto *layout = new QVBoxLayout(&dlg);
+    auto *layout = new QVBoxLayout(dlg);
     layout->addLayout(form);
     layout->addWidget(buttons);
-    dlg.resize(420, dlg.sizeHint().height());
-
-    if (dlg.exec() != QDialog::Accepted)
-        return false;
-
-    /// Minimal validation: name and url are required. We don't try to validate
-    /// the URL itself — libvlc will reject anything unparseable when the user
-    /// hits Play.
-    if (nameEdit->text().trimmed().isEmpty() || urlEdit->text().trimmed().isEmpty()) {
-        QMessageBox::warning(parent, QObject::tr("Radio Station"),
-            QObject::tr("Name and URL are required."));
-        return false;
-    }
-
-    inOut = Radio(nameEdit->text().trimmed(),
-                  genreEdit->text().trimmed(),
-                  /*gotAds=*/false,
-                  bitrateSpin->value(),
-                  langEdit->text().trimmed(),
-                  urlEdit->text().trimmed());
-    return true;
+    dlg->resize(420, dlg->sizeHint().height());
+    dlg->open();
 }
 }
 
@@ -1198,11 +1204,10 @@ bool runRadioEditDialog(QWidget *parent, Radio& inOut) {
 void DialogConfig::on_pushButton_addRadio_clicked() {
 
     Radio newRadio(QString(), QString(), false, 128, QString(), QString());
-    if (!runRadioEditDialog(this, newRadio))
-        return;
-
-    tableModel->addRadio(newRadio);
-    Util::saveLocalRadioList(tableModel->getAllRadios());
+    runRadioEditDialog(this, newRadio, [this](const Radio &edited) {
+        tableModel->addRadio(edited);
+        Util::saveLocalRadioList(tableModel->getAllRadios());
+    });
 }
 
 
@@ -1213,18 +1218,17 @@ void DialogConfig::on_pushButton_editRadio_clicked() {
     if (!idx.isValid())
         idx = currentRadioIndex;
     if (!idx.isValid()) {
-        QMessageBox::information(this, tr("Edit Radio"),
+        AsyncDialogs::information(this, tr("Edit Radio"),
             tr("Select a radio station to edit."));
         return;
     }
 
     const int row = idx.row();
-    Radio existing = tableModel->getRadioAtRow(idx);
-    if (!runRadioEditDialog(this, existing))
-        return;
-
-    tableModel->replaceRadioAtRow(row, existing);
-    Util::saveLocalRadioList(tableModel->getAllRadios());
+    const Radio existing = tableModel->getRadioAtRow(idx);
+    runRadioEditDialog(this, existing, [this, row](const Radio &edited) {
+        tableModel->replaceRadioAtRow(row, edited);
+        Util::saveLocalRadioList(tableModel->getAllRadios());
+    });
 }
 
 
@@ -1235,7 +1239,7 @@ void DialogConfig::on_pushButton_deleteRadio_clicked() {
     if (!idx.isValid())
         idx = currentRadioIndex;
     if (!idx.isValid()) {
-        QMessageBox::information(this, tr("Delete Radio"),
+        AsyncDialogs::information(this, tr("Delete Radio"),
             tr("Select a radio station to delete."));
         return;
     }
@@ -1243,15 +1247,12 @@ void DialogConfig::on_pushButton_deleteRadio_clicked() {
     const int row = idx.row();
     const Radio radio = tableModel->getRadioAtRow(idx);
 
-    if (QMessageBox::question(this, tr("Delete Radio"),
-            tr("Delete \"%1\"?").arg(radio.getName()),
-            QMessageBox::Yes | QMessageBox::No,
-            QMessageBox::No) != QMessageBox::Yes) {
-        return;
-    }
-
-    tableModel->removeRadioAtRow(row);
-    if (currentRadioIndex.row() == row)
-        currentRadioIndex = QModelIndex();
-    Util::saveLocalRadioList(tableModel->getAllRadios());
+    AsyncDialogs::question(this, tr("Delete Radio"),
+                           tr("Delete \"%1\"?").arg(radio.getName()),
+                           [this, row]() {
+        tableModel->removeRadioAtRow(row);
+        if (currentRadioIndex.row() == row)
+            currentRadioIndex = QModelIndex();
+        Util::saveLocalRadioList(tableModel->getAllRadios());
+    });
 }

--- a/src/ui/dialoglogin.cpp
+++ b/src/ui/dialoglogin.cpp
@@ -21,6 +21,7 @@
 #include "extrequest.h"
 #include "credential_store.h"
 #include "intervals_icu_oauth_flow.h"
+#include "asyncdialogs.h"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // WASM: Emscripten bridge for the OAuth popup flow.
@@ -354,14 +355,18 @@ void DialogLogin::slotFinishedGetVersion() {
         } else if (!latestVersion.isEmpty() && Util::isVersionNewer(Environnement::getVersion(), latestVersion)) {
             LOG_INFO("DialogLogin", QStringLiteral("Update available – showing dialog"));
             m_updateDialogOpen = true;
-            UpdateDialog up(latestVersion, this);
-            const int updateChoice = up.exec();   // nested event loop
-            m_updateDialogOpen = false;
-            if (updateChoice == QDialog::Accepted) {
-                gotUpdateDialog = true;
-            } else {
-                LOG_INFO("DialogLogin", QStringLiteral("User declined update – proceeding to login"));
-            }
+            // open(), not exec(): a nested event loop is fatal on WASM.
+            auto *up = new UpdateDialog(latestVersion, this);
+            up->setAttribute(Qt::WA_DeleteOnClose);
+            connect(up, &QDialog::finished, this, [this](int updateChoice) {
+                m_updateDialogOpen = false;
+                if (updateChoice == QDialog::Accepted) {
+                    gotUpdateDialog = true;
+                } else {
+                    LOG_INFO("DialogLogin", QStringLiteral("User declined update – proceeding to login"));
+                }
+            });
+            up->open();
         }
     } else {
         LOG_WARN("DialogLogin", QStringLiteral("Version check failed – ") + replyVersion->errorString());
@@ -561,7 +566,7 @@ void DialogLogin::onLoginWithIntervalsIcuClicked()
     if (!m_oauthFlow->start()) {
         m_oauthFlow->deleteLater();
         m_oauthFlow = nullptr;
-        QMessageBox::warning(
+        AsyncDialogs::warning(
             this,
             tr("Intervals.icu Login Failed"),
             tr("Could not start the local sign-in listener. Please try again."));

--- a/src/ui/dialogmainwindowconfig.cpp
+++ b/src/ui/dialogmainwindowconfig.cpp
@@ -1,5 +1,6 @@
 #include "dialogmainwindowconfig.h"
 #include "ui_dialogmainwindowconfig.h"
+#include "asyncdialogs.h"
 
 #include <QDebug>
 #include <QFileDialog>
@@ -211,16 +212,16 @@ void DialogMainWindowConfig::stravaLabelClicked() {
         if (linked) {
             stravaLinked(true);
         } else {
-            QMessageBox::warning(this, tr("Strava"),
-                                 tr("Could not connect to Strava. Please try again."));
+            AsyncDialogs::warning(this, tr("Strava"),
+                                  tr("Could not connect to Strava. Please try again."));
         }
     });
 
     if (!flow->start()) {
         flow->deleteLater();
-        QMessageBox::warning(this, tr("Strava"),
-                             tr("Could not start the local login listener. "
-                                "Please try again."));
+        AsyncDialogs::warning(this, tr("Strava"),
+                              tr("Could not start the local login listener. "
+                                 "Please try again."));
     }
 }
 
@@ -374,10 +375,10 @@ void DialogMainWindowConfig::accept() {
     account->intervals_icu_auto_upload = ui->checkBox_intervalsAutoUpload->isChecked();
     account->saveIntervalsIcuCredentials();  // persist to QSettings (fast, no-fail path)
     if (!XmlUtil::saveLocalSaveFile(account)) {
-        QMessageBox::warning(this,
-                             tr("Save Failed"),
-                             tr("Could not save Intervals.icu credentials to the local file.\n"
-                                "Your settings may not be remembered after the next restart."));
+        AsyncDialogs::warning(this,
+                              tr("Save Failed"),
+                              tr("Could not save Intervals.icu credentials to the local file.\n"
+                                 "Your settings may not be remembered after the next restart."));
         // Do not close the dialog — let the user correct the situation (e.g.
         // free disk space) or explicitly dismiss.
         return;
@@ -404,8 +405,10 @@ void DialogMainWindowConfig::accept() {
     QDialog::accept();
 
     if (themeChanged) {
-        QMessageBox::information(
-            this,
+        // Parented to the main window: this dialog just accept()ed (hidden),
+        // and the box outlives it on screen.
+        AsyncDialogs::information(
+            parentWidget(),
             tr("Theme Changed"),
             tr("The new theme will be applied the next time you restart MaximumTrainer."));
     }
@@ -535,6 +538,11 @@ QWidget *DialogMainWindowConfig::createLoggingPage()
     m_editLogFilePath->setPlaceholderText(tr("(default path)"));
     m_btnBrowseLog = new QPushButton(tr("Browse…"), fileGroup);
     m_btnBrowseLog->setFixedWidth(90);
+#ifdef GC_WASM_BUILD
+    // QFileDialog::getSaveFileName spins a fatal nested event loop on WASM,
+    // and a browsable log path is meaningless in the in-memory browser FS.
+    m_btnBrowseLog->setVisible(false);
+#endif
     pathRow->addWidget(m_editLogFilePath);
     pathRow->addWidget(m_btnBrowseLog);
     fileLayout->addLayout(pathRow);

--- a/src/ui/historywidget.cpp
+++ b/src/ui/historywidget.cpp
@@ -1,4 +1,5 @@
 #include "historywidget.h"
+#include "asyncdialogs.h"
 #include "workouthistorymodel.h"
 #include "historyfilterproxymodel.h"
 #include "activitydetaildialog.h"
@@ -199,8 +200,10 @@ void HistoryWidget::openCriticalPowerDialog()
         loadHistory();
 
     const QList<WorkoutHistorySummary> &history = m_model->history();
-    CriticalPowerDialog dlg(history, this);
-    dlg.exec();
+    // Shown non-modally via open() — exec() is fatal on WASM.
+    auto *dlg = new CriticalPowerDialog(history, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->open();
 }
 
 void HistoryWidget::openPmcDialog()
@@ -211,7 +214,7 @@ void HistoryWidget::openPmcDialog()
     const QList<PmcPoint> points = PmcCalculator::compute(m_model->history());
     auto *dlg = new PmcDialog(points, this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
-    dlg->exec();
+    dlg->open();
 }
 
 void HistoryWidget::applyFilters()
@@ -254,8 +257,8 @@ void HistoryWidget::openDetail(const QModelIndex &proxyIndex)
     QApplication::restoreOverrideCursor();
 
     if (!detail.valid) {
-        QMessageBox::information(this, tr("Activity Detail"),
-                                 tr("No detailed record data could be read from this activity."));
+        AsyncDialogs::information(this, tr("Activity Detail"),
+                                  tr("No detailed record data could be read from this activity."));
         return;
     }
 
@@ -290,20 +293,17 @@ void HistoryWidget::deleteSelected()
     const QString filePath = summary->filePath;
     const QString name = summary->workoutName;
 
-    const auto answer = QMessageBox::question(
+    AsyncDialogs::question(
         this, tr("Delete Activity"),
         tr("Permanently delete this activity from disk?\n\n%1\n%2")
             .arg(name, QFileInfo(filePath).fileName()),
-        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        [this, filePath]() {
+        if (!QFile::remove(filePath)) {
+            AsyncDialogs::warning(this, tr("Delete Activity"),
+                                  tr("Could not delete the file:\n%1").arg(filePath));
+            return;
+        }
 
-    if (answer != QMessageBox::Yes)
-        return;
-
-    if (!QFile::remove(filePath)) {
-        QMessageBox::warning(this, tr("Delete Activity"),
-                             tr("Could not delete the file:\n%1").arg(filePath));
-        return;
-    }
-
-    loadHistory();
+        loadHistory();
+    });
 }

--- a/src/ui/main_workoutpage.cpp
+++ b/src/ui/main_workoutpage.cpp
@@ -1,4 +1,5 @@
 #include "main_workoutpage.h"
+#include "asyncdialogs.h"
 #include "ui_main_workoutpage.h"
 
 #include <QPainter>
@@ -392,25 +393,22 @@ void Main_WorkoutPage::deleteWorkout() {
 
     Workout workout = tableModel->getWorkoutAtRow(indexSourceSelected);
 
-    /// Ask confirmation
-    QMessageBox msgBox(this);
-    msgBox.setIcon(QMessageBox::Question);
-    QString textToShow = tr("Are you sure you want to delete <b>%1</b>?").arg(workout.getName());
-    msgBox.setText(textToShow);
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox.setDefaultButton(QMessageBox::No);
-    if (msgBox.exec() == QMessageBox::Yes) {
-        qDebug() << "Yes was clicked";
+    /// Ask confirmation (async — exec() is fatal on WASM)
+    const int rowToDelete = indexSourceSelected.row();
+    AsyncDialogs::question(this, tr("Delete Workout"),
+                           tr("Are you sure you want to delete <b>%1</b>?").arg(workout.getName()),
+                           [this, workout, rowToDelete]() {
         /// Delete from model
-        tableModel->removeRows(indexSourceSelected.row(), 1, QModelIndex());
+        tableModel->removeRows(rowToDelete, 1, QModelIndex());
 
         /// Delete local file xml
         Util::deleteLocalFile(workout.getFilePath());
 
         //  remove from lst done
         account->hashWorkoutDone.remove(workout.getName());
-    }
-    tableViewSelectionChanged(QItemSelection(), QItemSelection());
+
+        tableViewSelectionChanged(QItemSelection(), QItemSelection());
+    });
 
 
 
@@ -442,12 +440,8 @@ void Main_WorkoutPage::on_tableView_workout_doubleClicked(const QModelIndex &ind
     Workout workoutToDo = tableModel->getWorkoutAtRow(sourceIndex);
 
     if(account->enable_studio_mode && workoutToDo.getWorkoutNameEnum() == Workout::MAP_TEST) {
-        QMessageBox msgBox;
-        msgBox.setTextFormat(Qt::RichText);
-        msgBox.setIcon(QMessageBox::Information);
-        msgBox.setText(tr("MAP Test can only be done alone. Please disable studio mode to continue"));
-        msgBox.setStandardButtons(QMessageBox::Close);
-        msgBox.exec();
+        AsyncDialogs::information(this, QString(),
+            tr("MAP Test can only be done alone. Please disable studio mode to continue"));
     }
     else {
         emit executeWorkout(workoutToDo);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -63,6 +63,7 @@
 #endif
 #include "sensorswidget.h"
 #include "studiowidget.h"
+#include "asyncdialogs.h"
 
 #ifdef GC_WASM_BUILD
 #include <emscripten.h>
@@ -110,6 +111,17 @@ void mt_trigger_logout_impl()
                               Qt::QueuedConnection);
 }
 
+// Open the Preferences dialog. Exposed as window.mt_openPreferences() so
+// Playwright can assert it opens without killing the runtime (it used to run
+// dconfig->exec(), a fatal nested event loop on WASM — #344 follow-up).
+EMSCRIPTEN_KEEPALIVE
+void mt_open_preferences_impl()
+{
+    if (!g_mainWindow) return;
+    QMetaObject::invokeMethod(g_mainWindow.data(), "on_actionPreferences_triggered",
+                              Qt::QueuedConnection);
+}
+
 } // extern "C"
 
 EM_JS(void, js_exposeWasmDemoWorkout, (), {
@@ -121,6 +133,9 @@ EM_JS(void, js_exposeWasmDemoWorkout, (), {
     };
     window.mt_triggerLogout = function() {
         Module._mt_trigger_logout_impl();
+    };
+    window.mt_openPreferences = function() {
+        Module._mt_open_preferences_impl();
     };
 });
 #endif // GC_WASM_BUILD
@@ -380,7 +395,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
             });
     connect(ui->tab_intervals_icu, &TabIntervalsIcu::syncFailed,
             this, [this](const QString &err) {
-                QMessageBox::warning(this, tr("Intervals.icu Sync Failed"), err);
+                AsyncDialogs::warning(this, tr("Intervals.icu Sync Failed"), err);
             });
 
     // ── Plan Adherence (#157) ─────────────────────────────────────────────────
@@ -410,6 +425,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     // the metric-dashboard view and verify QML rendering in the browser.
     g_mainWindow = this;
     js_exposeWasmDemoWorkout();
+
+    // No local file system in the browser: the Import actions run
+    // QFileDialog::getOpenFileName/getExistingDirectory (a fatal nested event
+    // loop on WASM) and the Folder menu opens local paths that don't exist.
+    ui->menuImport->menuAction()->setVisible(false);
+    ui->menuFolder->menuAction()->setVisible(false);
 #endif
 }
 
@@ -544,8 +565,9 @@ void MainWindow::showPlanContextMenu(const QPoint &pos) {
 
     QMenu *menu = new QMenu(ui->webView_plan);
     menu->addAction(tr("Refresh"), this, SLOT(reloadPlanWebView()));
-    menu->exec(ui->webView_plan->mapToGlobal(pos));
-    menu->deleteLater();
+    // popup() instead of exec(): a nested event loop is fatal on WASM.
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    menu->popup(ui->webView_plan->mapToGlobal(pos));
 }
 
 // trigger after a .zwo file downloaded from Intervals.icu is saved
@@ -735,9 +757,9 @@ void MainWindow::startWorkoutQueue()
     if (!first.getName().isEmpty()) {
         executeWorkout(first);
     } else {
-        QMessageBox::warning(this,
-                             tr("Queue Error"),
-                             tr("Could not load the queued workout:\n%1\n(%2)").arg(name, path));
+        AsyncDialogs::warning(this,
+                              tr("Queue Error"),
+                              tr("Could not load the queued workout:\n%1\n(%2)").arg(name, path));
         tryAdvanceWorkoutQueue();
     }
 }
@@ -745,10 +767,10 @@ void MainWindow::startWorkoutQueue()
 void MainWindow::tryAdvanceWorkoutQueue()
 {
     // Take the next item NOW (atomically), skipping any blank entries. The
-    // countdown below spins a nested event loop, so if we only read here and
-    // deferred the dequeue, a re-entrant advance could read the same item again
-    // or observe a half-updated queue — that produced the empty-path "Could not
-    // load the next queued workout" error.
+    // event loop keeps running while the countdown below is open, so if we only
+    // read here and deferred the dequeue, a re-entrant advance could read the
+    // same item again or observe a half-updated queue — that produced the
+    // empty-path "Could not load the next queued workout" error.
     QString nextName;
     QString nextPath;
     while (!m_workoutQueue->isEmpty()) {
@@ -760,31 +782,37 @@ void MainWindow::tryAdvanceWorkoutQueue()
     if (nextPath.isEmpty())
         return;
 
-    WorkoutCountdownDialog countdown(nextName, 60, this);
-    if (countdown.exec() != QDialog::Accepted) {
-        // User chose "Cancel Queue" — clear the remaining queue so it doesn't
-        // auto-advance after subsequent workouts.
-        if (countdown.dialogResult() == WorkoutCountdownDialog::Result::Cancelled)
-            m_workoutQueue->clear();
-        return;
-    }
-
-    // Defer via singleShot so this stack frame fully unwinds before
-    // the next workout begins — avoids unbounded recursion with long queues.
-    QTimer::singleShot(0, this, [this, nextName, nextPath]() {
-        XmlUtil xmlNext;
-        Workout next = xmlNext.parseSingleWorkoutXml(nextPath);
-        if (!next.getName().isEmpty()) {
-            executeWorkout(next);
-        } else {
-            QMessageBox::warning(this,
-                                 tr("Queue Error"),
-                                 tr("Could not load the next queued workout:\n%1\n(%2)")
-                                     .arg(nextName, nextPath));
-            // The bad entry is already removed; keep the queue moving.
-            tryAdvanceWorkoutQueue();
+    // Countdown runs via open() + finished — exec() is fatal on WASM.
+    auto *countdown = new WorkoutCountdownDialog(nextName, 60, this);
+    countdown->setAttribute(Qt::WA_DeleteOnClose);
+    connect(countdown, &QDialog::finished, this,
+            [this, countdown, nextName, nextPath](int result) {
+        if (result != QDialog::Accepted) {
+            // User chose "Cancel Queue" — clear the remaining queue so it
+            // doesn't auto-advance after subsequent workouts.
+            if (countdown->dialogResult() == WorkoutCountdownDialog::Result::Cancelled)
+                m_workoutQueue->clear();
+            return;
         }
+
+        // Defer via singleShot so the dialog teardown fully unwinds before
+        // the next workout begins — avoids unbounded recursion with long queues.
+        QTimer::singleShot(0, this, [this, nextName, nextPath]() {
+            XmlUtil xmlNext;
+            Workout next = xmlNext.parseSingleWorkoutXml(nextPath);
+            if (!next.getName().isEmpty()) {
+                executeWorkout(next);
+            } else {
+                AsyncDialogs::warning(this,
+                                      tr("Queue Error"),
+                                      tr("Could not load the next queued workout:\n%1\n(%2)")
+                                          .arg(nextName, nextPath));
+                // The bad entry is already removed; keep the queue moving.
+                tryAdvanceWorkoutQueue();
+            }
+        });
     });
+    countdown->open();
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -1225,20 +1253,13 @@ void MainWindow::on_actionExit_triggered()
 /////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::on_actionLogout_triggered()
 {
-    // Confirm asynchronously via open(): QMessageBox::question() spins a
-    // nested event loop (QDialog::exec), which is a qFatal on Qt WASM
-    // without asyncify — the whole runtime aborted on Log Out (#344).
-    auto *confirm = new QMessageBox(
-        QMessageBox::Question, tr("Log Out"),
+    // Confirm asynchronously: QMessageBox::question() spins a nested event
+    // loop (QDialog::exec), which is a qFatal on Qt WASM without asyncify —
+    // the whole runtime aborted on Log Out (#344).
+    AsyncDialogs::question(
+        this, tr("Log Out"),
         tr("Log out of Intervals.icu and return to the login screen?"),
-        QMessageBox::Yes | QMessageBox::No, this);
-    confirm->setAttribute(Qt::WA_DeleteOnClose);
-    connect(confirm, &QMessageBox::buttonClicked, this,
-            [this, confirm](QAbstractButton *button) {
-        if (confirm->standardButton(button) == QMessageBox::Yes)
-            performLogout();
-    });
-    confirm->open();
+        [this]() { performLogout(); });
 }
 
 void MainWindow::performLogout()
@@ -1295,15 +1316,15 @@ void MainWindow::on_actionRequest_Help_triggered()
 //-----------------------------------------------
 void MainWindow::on_actionKeyboard_Shortcuts_triggered()
 {
-    DialogKeyboardShortcuts dlg(this);
-    dlg.exec();
+    // open(), not exec(): a nested event loop is fatal on WASM.
+    auto *dlg = new DialogKeyboardShortcuts(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->open();
 }
 //-----------------------------------------------
 void MainWindow::on_actionPreferences_triggered()
 {
-
-    dconfig->exec();
-
+    dconfig->open();
 }
 //-----------------------------------------------
 void MainWindow::on_actionWorkout_triggered()
@@ -1376,6 +1397,26 @@ void MainWindow::executeWorkout(Workout workout) {
     if (m_launchingWorkout || isInsideWorkout)
         return;
     m_launchingWorkout = true;
+
+#ifdef GC_WASM_BUILD
+    // WASM: fully async chain — any nested event loop (QDialog::exec /
+    // QEventLoop::exec) is a qFatal on Qt WASM without asyncify. The
+    // m_launchingWorkout guard is released by each terminal continuation.
+    auto *connDlg = new DialogConnectionMethod(this);
+    connDlg->setAttribute(Qt::WA_DeleteOnClose);
+    connect(connDlg, &QDialog::finished, this, [this, workout, connDlg](int result) {
+        if (result != QDialog::Accepted) {
+            m_launchingWorkout = false;
+            return;
+        }
+        if (connDlg->selectedMethod() == DialogConnectionMethod::Simulation)
+            startSimulatedWorkout(workout);
+        else
+            startWasmBleWorkout(workout);
+    });
+    connDlg->open();
+    return;
+#else
     auto launchGuard = qScopeGuard([this]() { m_launchingWorkout = false; });
 
     DialogConnectionMethod connDlg(this);
@@ -1385,69 +1426,11 @@ void MainWindow::executeWorkout(Workout workout) {
 
     // ── Simulation path ───────────────────────────────────────────────────
     if (connDlg.selectedMethod() == DialogConnectionMethod::Simulation) {
-        // In Studio mode simulate every selected rider; otherwise a single rider.
-        const bool studio = account->enable_studio_mode;
-        const int nbRiders = studio ? qBound(1, account->nb_user_studio, constants::nbMaxUserStudio) : 1;
-        const QVector<UserStudio> riders = studio ? prepareStudioRiders(true) : vecUserStudio;
-
-        // Show WorkoutDialog NON-MODALLY (window-modal via setWindowModality,
-        // run on the main event loop instead of QDialog::exec()). The embedded
-        // QWebEngine video player reparents widgets when it initialises, which
-        // destroys and recreates the dialog's native window; inside a nested
-        // exec() loop that window-destroy calls QEventLoop::exit() and tears the
-        // dialog down. Running on the main loop removes that hazard. Post-workout
-        // cleanup moves to the finished() handler below.
-        WorkoutDialog *w = new WorkoutDialog(workout, lstRadio, riders);
-        w->setAttribute(Qt::WA_DeleteOnClose);
-        w->setWindowModality(Qt::ApplicationModal);
-
-        // One simulator hub per rider, each emitting its own 1-based userID so
-        // WorkoutDialog routes the data to the matching rider box.
-        QList<SimulatorHub*> simHubs;
-        for (int i = 0; i < nbRiders; ++i) {
-            SimulatorHub *simHub = new SimulatorHub(this);
-            simHub->setUserID(i + 1);
-
-            connect(simHub, SIGNAL(signal_hr(int,int)),               w, SLOT(HrDataReceived(int,int)));
-            connect(simHub, SIGNAL(signal_cadence(int,int)),          w, SLOT(CadenceDataReceived(int,int)));
-            connect(simHub, SIGNAL(signal_speed(int,double)),         w, SLOT(TrainerSpeedDataReceived(int,double)));
-            connect(simHub, SIGNAL(signal_power(int,int)),            w, SLOT(PowerDataReceived(int,int)));
-            connect(simHub, SIGNAL(signal_balance(int,int)),          w, SLOT(PowerBalanceDataReceived(int,int)));
-            connect(simHub, SIGNAL(signal_pedal(int,double,double,double,double,double)), w, SLOT(pedalMetricReceived(int,double,double,double,double,double)));
-            connect(simHub, SIGNAL(signal_oxygen(int,double,double)), w, SLOT(OxygenValueChanged(int,double,double)));
-
-            connect(w, SIGNAL(setLoad(int,double)),  simHub, SLOT(setLoad(int,double)));
-            connect(w, SIGNAL(setSlope(int,double)), simHub, SLOT(setSlope(int,double)));
-            connect(w, SIGNAL(stopDecodingMsgHub()), simHub, SLOT(stopDecodingMsg()));
-
-            simHubs.append(simHub);
-        }
-        w->enableTrainerControl();
-
-        connect(w, SIGNAL(fitFileReady(QString, QString, QString)), this, SLOT(checkToUploadFile(QString,QString,QString)));
-        connect(w, SIGNAL(ftp_lthr_changed()), ui->tab_workout1, SLOT(updateTableViewMetrics()));
-        connect(w, SIGNAL(ftpUserStudioChanged(QVector<UserStudio>)), this, SLOT(updateVecStudio(QVector<UserStudio>)));
-
-        connect(w, &QDialog::finished, this, [this, simHubs]() {
-            workoutOver();
-            for (SimulatorHub *simHub : simHubs) {
-                simHub->stopDecodingMsg();
-                delete simHub;
-            }
-            // Auto-advance to next queued workout if one exists
-            tryAdvanceWorkoutQueue();
-        });
-
-        for (SimulatorHub *simHub : simHubs)
-            simHub->start();
-        workoutExecuting();
-        QApplication::restoreOverrideCursor();
-        w->show();
+        startSimulatedWorkout(workout);
         return;
     }
 
     // ── BTLE Device path ─────────────────────────────────────────────────
-#ifndef GC_WASM_BUILD
     // Studio mode: connect each rider's own saved sensor package in turn, tag
     // every hub with that rider's id, then run the workout with all of them.
     if (account->enable_studio_mode) {
@@ -1517,7 +1500,6 @@ void MainWindow::executeWorkout(Workout workout) {
             // Empty result = "Skip": drop through to the legacy manual scanner.
         }
     }
-#endif
 
     BtleScannerDialog scanner(this);
     if (scanner.exec() != QDialog::Accepted || !scanner.hasSelection())
@@ -1541,14 +1523,131 @@ void MainWindow::executeWorkout(Workout workout) {
     }
 
     if (!btleHub->isConnected()) {
-        QMessageBox::warning(this,
-                             tr("Connection Failed"),
-                             tr("Could not connect to the selected Bluetooth device.\n"
-                                "Please check the device is powered on and try again."));
+        AsyncDialogs::warning(this,
+                              tr("Connection Failed"),
+                              tr("Could not connect to the selected Bluetooth device.\n"
+                                 "Please check the device is powered on and try again."));
         delete btleHub;
         return;
     }
 
+    startWorkoutWithConnectedHub(workout, btleHub);
+#endif // GC_WASM_BUILD
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void MainWindow::startSimulatedWorkout(const Workout &workout)
+{
+    // In Studio mode simulate every selected rider; otherwise a single rider.
+    const bool studio = account->enable_studio_mode;
+    const int nbRiders = studio ? qBound(1, account->nb_user_studio, constants::nbMaxUserStudio) : 1;
+    const QVector<UserStudio> riders = studio ? prepareStudioRiders(true) : vecUserStudio;
+
+    // Show WorkoutDialog NON-MODALLY (window-modal via setWindowModality,
+    // run on the main event loop instead of QDialog::exec()). The embedded
+    // QWebEngine video player reparents widgets when it initialises, which
+    // destroys and recreates the dialog's native window; inside a nested
+    // exec() loop that window-destroy calls QEventLoop::exit() and tears the
+    // dialog down. Running on the main loop removes that hazard. Post-workout
+    // cleanup moves to the finished() handler below.
+    WorkoutDialog *w = new WorkoutDialog(workout, lstRadio, riders);
+    w->setAttribute(Qt::WA_DeleteOnClose);
+    w->setWindowModality(Qt::ApplicationModal);
+
+    // One simulator hub per rider, each emitting its own 1-based userID so
+    // WorkoutDialog routes the data to the matching rider box.
+    QList<SimulatorHub*> simHubs;
+    for (int i = 0; i < nbRiders; ++i) {
+        SimulatorHub *simHub = new SimulatorHub(this);
+        simHub->setUserID(i + 1);
+
+        connect(simHub, SIGNAL(signal_hr(int,int)),               w, SLOT(HrDataReceived(int,int)));
+        connect(simHub, SIGNAL(signal_cadence(int,int)),          w, SLOT(CadenceDataReceived(int,int)));
+        connect(simHub, SIGNAL(signal_speed(int,double)),         w, SLOT(TrainerSpeedDataReceived(int,double)));
+        connect(simHub, SIGNAL(signal_power(int,int)),            w, SLOT(PowerDataReceived(int,int)));
+        connect(simHub, SIGNAL(signal_balance(int,int)),          w, SLOT(PowerBalanceDataReceived(int,int)));
+        connect(simHub, SIGNAL(signal_pedal(int,double,double,double,double,double)), w, SLOT(pedalMetricReceived(int,double,double,double,double,double)));
+        connect(simHub, SIGNAL(signal_oxygen(int,double,double)), w, SLOT(OxygenValueChanged(int,double,double)));
+
+        connect(w, SIGNAL(setLoad(int,double)),  simHub, SLOT(setLoad(int,double)));
+        connect(w, SIGNAL(setSlope(int,double)), simHub, SLOT(setSlope(int,double)));
+        connect(w, SIGNAL(stopDecodingMsgHub()), simHub, SLOT(stopDecodingMsg()));
+
+        simHubs.append(simHub);
+    }
+    w->enableTrainerControl();
+
+    connect(w, SIGNAL(fitFileReady(QString, QString, QString)), this, SLOT(checkToUploadFile(QString,QString,QString)));
+    connect(w, SIGNAL(ftp_lthr_changed()), ui->tab_workout1, SLOT(updateTableViewMetrics()));
+    connect(w, SIGNAL(ftpUserStudioChanged(QVector<UserStudio>)), this, SLOT(updateVecStudio(QVector<UserStudio>)));
+
+    connect(w, &QDialog::finished, this, [this, simHubs]() {
+        workoutOver();
+        for (SimulatorHub *simHub : simHubs) {
+            simHub->stopDecodingMsg();
+            delete simHub;
+        }
+        // Auto-advance to next queued workout if one exists
+        tryAdvanceWorkoutQueue();
+    });
+
+    for (SimulatorHub *simHub : simHubs)
+        simHub->start();
+    workoutExecuting();
+    QApplication::restoreOverrideCursor();
+    w->show();
+    m_launchingWorkout = false;
+}
+
+
+#ifdef GC_WASM_BUILD
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void MainWindow::startWasmBleWorkout(const Workout &workout)
+{
+    // Browser BLE picker via open(); the connect wait is signal-driven (the
+    // desktop QEventLoop wait would be a fatal nested loop here).
+    auto *scanner = new BtleScannerDialog(this);
+    scanner->setAttribute(Qt::WA_DeleteOnClose);
+    connect(scanner, &QDialog::finished, this, [this, workout, scanner](int result) {
+        if (result != QDialog::Accepted || !scanner->hasSelection()) {
+            m_launchingWorkout = false;
+            return;
+        }
+
+        BtleHub *btleHub = new BtleHub(this);
+
+        // Context object: deleting it disconnects all three outcome handlers,
+        // so exactly one continuation runs per connection attempt.
+        QObject *attempt = new QObject(this);
+        connect(btleHub, &BtleHub::deviceConnected, attempt,
+                [this, workout, btleHub, attempt]() {
+            attempt->deleteLater();
+            startWorkoutWithConnectedHub(workout, btleHub);
+        });
+        const auto onFailed = [this, btleHub, attempt]() {
+            attempt->deleteLater();
+            AsyncDialogs::warning(this,
+                                  tr("Connection Failed"),
+                                  tr("Could not connect to the selected Bluetooth device.\n"
+                                     "Please check the device is powered on and try again."));
+            btleHub->deleteLater();
+            m_launchingWorkout = false;
+        };
+        connect(btleHub, &BtleHub::deviceDisconnected, attempt, onFailed);
+        connect(btleHub, &BtleHub::connectionError, attempt,
+                [onFailed](const QString &) { onFailed(); });
+
+        btleHub->connectToDevice(scanner->selectedDevice());
+    });
+    scanner->open();
+}
+#endif // GC_WASM_BUILD
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void MainWindow::startWorkoutWithConnectedHub(const Workout &workout, BtleHub *btleHub)
+{
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
     // Show WorkoutDialog NON-MODALLY (window-modal, run on the main event loop
@@ -1609,6 +1708,7 @@ void MainWindow::executeWorkout(Workout workout) {
     workoutExecuting();
     QApplication::restoreOverrideCursor();
     w->show();
+    m_launchingWorkout = false;
 }
 
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -99,6 +99,17 @@ void mt_show_demo_race_impl()
                               Qt::QueuedConnection);
 }
 
+// Run the confirmed Log Out path (skipping the confirmation box). Exposed as
+// window.mt_triggerLogout() so Playwright can assert the full logout →
+// login-screen cycle survives on WASM (#344).
+EMSCRIPTEN_KEEPALIVE
+void mt_trigger_logout_impl()
+{
+    if (!g_mainWindow) return;
+    QMetaObject::invokeMethod(g_mainWindow.data(), "performLogout",
+                              Qt::QueuedConnection);
+}
+
 } // extern "C"
 
 EM_JS(void, js_exposeWasmDemoWorkout, (), {
@@ -107,6 +118,9 @@ EM_JS(void, js_exposeWasmDemoWorkout, (), {
     };
     window.mt_showRace = function() {
         Module._mt_show_demo_race_impl();
+    };
+    window.mt_triggerLogout = function() {
+        Module._mt_trigger_logout_impl();
     };
 });
 #endif // GC_WASM_BUILD
@@ -1123,14 +1137,17 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
 
     if (isInsideWorkout) {
-        QMessageBox msgBox;
-        msgBox.setWindowFlags(msgBox.windowFlags() | Qt::WindowStaysOnTopHint);
-        msgBox.setIcon(QMessageBox::Question);
-        msgBox.setText(tr("A workout is still active."));
-        msgBox.setInformativeText(tr("Please close any active workout before leaving MaximumTrainer."));
-        msgBox.setStandardButtons(QMessageBox::Ok);
-        msgBox.setDefaultButton(QMessageBox::Ok);
-        msgBox.exec();
+        // Shown non-blocking: exec() is a qFatal on Qt WASM without asyncify,
+        // and the close is refused regardless of when the box is dismissed.
+        auto *msgBox = new QMessageBox(this);
+        msgBox->setAttribute(Qt::WA_DeleteOnClose);
+        msgBox->setWindowFlags(msgBox->windowFlags() | Qt::WindowStaysOnTopHint);
+        msgBox->setIcon(QMessageBox::Question);
+        msgBox->setText(tr("A workout is still active."));
+        msgBox->setInformativeText(tr("Please close any active workout before leaving MaximumTrainer."));
+        msgBox->setStandardButtons(QMessageBox::Ok);
+        msgBox->setDefaultButton(QMessageBox::Ok);
+        msgBox->open();
         event->ignore();
         return;
     }
@@ -1208,12 +1225,24 @@ void MainWindow::on_actionExit_triggered()
 /////////////////////////////////////////////////////////////////////////////////////////
 void MainWindow::on_actionLogout_triggered()
 {
-    if (QMessageBox::question(
-            this, tr("Log Out"),
-            tr("Log out of Intervals.icu and return to the login screen?"))
-        != QMessageBox::Yes)
-        return;
+    // Confirm asynchronously via open(): QMessageBox::question() spins a
+    // nested event loop (QDialog::exec), which is a qFatal on Qt WASM
+    // without asyncify — the whole runtime aborted on Log Out (#344).
+    auto *confirm = new QMessageBox(
+        QMessageBox::Question, tr("Log Out"),
+        tr("Log out of Intervals.icu and return to the login screen?"),
+        QMessageBox::Yes | QMessageBox::No, this);
+    confirm->setAttribute(Qt::WA_DeleteOnClose);
+    connect(confirm, &QMessageBox::buttonClicked, this,
+            [this, confirm](QAbstractButton *button) {
+        if (confirm->standardButton(button) == QMessageBox::Yes)
+            performLogout();
+    });
+    confirm->open();
+}
 
+void MainWindow::performLogout()
+{
     if (account)
         account->logout();
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -104,6 +104,22 @@ private:
 public slots:
 #endif
 
+private:
+    /// Simulator-fed workout launch (the "Simulation" connection method).
+    /// Shared by the desktop synchronous flow and the WASM async chain.
+    void startSimulatedWorkout(const Workout &workout);
+
+    /// Wire a single already-connected hub to a new WorkoutDialog and show it
+    /// (the legacy single-device tail of executeWorkout, shared by both flows).
+    void startWorkoutWithConnectedHub(const Workout &workout, BtleHub *btleHub);
+
+#ifdef GC_WASM_BUILD
+    /// Browser BLE launch: scanner prompt via open(), then a signal-driven
+    /// wait for the connection (no nested event loop — fatal on WASM).
+    void startWasmBleWorkout(const Workout &workout);
+#endif
+public slots:
+
     //Coming from Studio QWebView ----------
     void enableStudioMode(bool enable);
     void setNumberUserStudio(int numberUser);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -154,6 +154,9 @@ private slots:
     void on_actionOpen_Ride_triggered();
     void on_actionExit_triggered();
     void on_actionLogout_triggered();
+    // The confirmed half of Log Out (clear credentials + close). Split out of
+    // on_actionLogout_triggered so the WASM test hook can drive it directly.
+    void performLogout();
 
 
     void on_actionSingle_Workout_triggered();

--- a/src/ui/studiowidget.cpp
+++ b/src/ui/studiowidget.cpp
@@ -1,4 +1,5 @@
 #include "studiowidget.h"
+#include "asyncdialogs.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -497,6 +498,7 @@ void StudioWidget::saveErg(int riderIndex, bool control, int ramp)
 
 void StudioWidget::onExportClicked()
 {
+#ifndef GC_WASM_BUILD
     QString path = QFileDialog::getSaveFileName(
         this, tr("Export Studio Configuration"),
         QStringLiteral("studio_config.json"), tr("Studio configuration (*.json)"));
@@ -504,6 +506,7 @@ void StudioWidget::onExportClicked()
         return;
     if (!path.endsWith(QLatin1String(".json"), Qt::CaseInsensitive))
         path += QLatin1String(".json");
+#endif
 
     QJsonObject root;
     root[QStringLiteral("version")]  = 1;
@@ -547,18 +550,36 @@ void StudioWidget::onExportClicked()
     }
     root[QStringLiteral("riders")] = ridersArr;
 
+    const QByteArray json = QJsonDocument(root).toJson(QJsonDocument::Indented);
+#ifdef GC_WASM_BUILD
+    // Browser download: getSaveFileName would spin a fatal nested event loop
+    // on WASM, and the browser exposes no local paths anyway.
+    QFileDialog::saveFileContent(json, QStringLiteral("studio_config.json"));
+#else
     QFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox::warning(this, tr("Export failed"),
-                             tr("Could not write to %1").arg(path));
+        AsyncDialogs::warning(this, tr("Export failed"),
+                              tr("Could not write to %1").arg(path));
         return;
     }
-    file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    file.write(json);
     file.close();
+#endif
 }
 
 void StudioWidget::onImportClicked()
 {
+#ifdef GC_WASM_BUILD
+    // Browser file picker with async callback: getOpenFileName would spin a
+    // fatal nested event loop on WASM.
+    QFileDialog::getOpenFileContent(
+        tr("Studio configuration (*.json)"),
+        [this](const QString &fileName, const QByteArray &content) {
+            if (fileName.isEmpty())
+                return;   // picker cancelled
+            applyImportedStudioJson(content);
+        });
+#else
     const QString path = QFileDialog::getOpenFileName(
         this, tr("Import Studio Configuration"),
         QString(), tr("Studio configuration (*.json)"));
@@ -567,16 +588,21 @@ void StudioWidget::onImportClicked()
 
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, tr("Import failed"),
-                             tr("Could not read %1").arg(path));
+        AsyncDialogs::warning(this, tr("Import failed"),
+                              tr("Could not read %1").arg(path));
         return;
     }
+    applyImportedStudioJson(file.readAll());
+#endif
+}
+
+void StudioWidget::applyImportedStudioJson(const QByteArray &json)
+{
     QJsonParseError parseError;
-    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &parseError);
-    file.close();
+    const QJsonDocument doc = QJsonDocument::fromJson(json, &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
-        QMessageBox::warning(this, tr("Import failed"),
-                             tr("This is not a valid studio configuration file."));
+        AsyncDialogs::warning(this, tr("Import failed"),
+                              tr("This is not a valid studio configuration file."));
         return;
     }
 

--- a/src/ui/studiowidget.h
+++ b/src/ui/studiowidget.h
@@ -63,6 +63,9 @@ private slots:
     void onRiderCountChanged(int index);
     void onExportClicked();
     void onImportClicked();
+    // Parse + apply an imported studio-config JSON payload (shared by the
+    // desktop path dialog and the WASM getOpenFileContent callback).
+    void applyImportedStudioJson(const QByteArray &json);
 
 private:
     static constexpr int kMaxRiders = 8;

--- a/src/ui/ui.pri
+++ b/src/ui/ui.pri
@@ -28,6 +28,7 @@ $$PWD/workoutdialog.cpp \
     $$PWD/queuepanelwidget.cpp
 
 HEADERS += $$PWD/mainwindow.h\
+    $$PWD/asyncdialogs.h \
 $$PWD/workoutdialog.h \
     $$PWD/main_workoutpage.h \
     $$PWD/dialogconfig.h \

--- a/src/ui/workout_editor/workoutcreator.cpp
+++ b/src/ui/workout_editor/workoutcreator.cpp
@@ -1,5 +1,6 @@
 
 #include "workoutcreator.h"
+#include "asyncdialogs.h"
 #include "ui_workoutcreator.h"
 
 
@@ -809,37 +810,27 @@ void WorkoutCreator::createWorkout(const QString& name, const QString& plan, con
 
     if (exist)
     {
-        QMessageBox msgBox(this);
-        msgBox.setIcon(QMessageBox::Question);
-        msgBox.setText(tr("A workout already exists with that name."));
-        msgBox.setInformativeText(tr("Overwrite it?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::No);
-        if (msgBox.exec() == QMessageBox::Yes) {
-            qDebug() << "Yes was clicked";
+        // Confirm asynchronously (exec() is fatal on WASM).
+        AsyncDialogs::question(this, tr("Overwrite Workout"),
+                               tr("A workout already exists with that name."),
+                               [this, workoutToSave = workout]() {
             /// Delete local file xml
-            Util::deleteLocalFile(workout.getFilePath());
+            Util::deleteLocalFile(workoutToSave.getFilePath());
 
-
-            fileCreated = XmlUtil::createWorkoutXml(workout, "");
+            const bool overwritten = XmlUtil::createWorkoutXml(workoutToSave, "");
             qDebug() << "Emit workoutOverwrited";
-            emit workoutOverwrited(workout);
-        }
+            emit workoutOverwrited(workoutToSave);
+            if (overwritten)
+                emit showStatusBarMessage(tr("Workout  \"%1\" overwrited").arg(workoutToSave.getFilePath()), 7000);
+        }, tr("Overwrite it?"));
     }
     else {
         fileCreated = XmlUtil::createWorkoutXml(workout, "");
         qDebug() << "Emit workoutCreated";
         emit workoutCreated(workout);
-    }
 
-    if (fileCreated) {
-
-        QString textToShow;
-        if (!exist)
-            textToShow = tr("Workout  \"%1\" created").arg(workout.getFilePath());
-        else
-            textToShow = tr("Workout  \"%1\" overwrited").arg(workout.getFilePath());
-        emit showStatusBarMessage(textToShow, 7000);
+        if (fileCreated)
+            emit showStatusBarMessage(tr("Workout  \"%1\" created").arg(workout.getFilePath()), 7000);
     }
 }
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -1,4 +1,5 @@
 #include "workoutdialog.h"
+#include "asyncdialogs.h"
 #include "virtual_gear.h"
 #include "ui_workoutdialog.h"
 
@@ -1396,21 +1397,30 @@ void WorkoutDialog::moveToInterval(int nbInterval, double secWorkout, double sta
 
     QString timeStartInterval = Util::showQTimeAsString(Util::convertMinutesToQTime(startIntervalSec/60.0));
 
-    //ask confirmation
+    //ask confirmation (async: exec() is fatal on WASM)
     if (showConfirmation) {
         isAskingUserQuestion = true;
-        QMessageBox msgBox(this);
-        msgBox.setIcon(QMessageBox::Question);
-        msgBox.setText(tr("Move to the interval starting at: ") + timeStartInterval + "?");
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::No);
-        if (msgBox.exec() == QMessageBox::No) {
-            isAskingUserQuestion = false;
-            return;
-        }
-        isAskingUserQuestion = false;
+        auto *msgBox = new QMessageBox(QMessageBox::Question, QString(),
+                                       tr("Move to the interval starting at: ") + timeStartInterval + "?",
+                                       QMessageBox::Yes | QMessageBox::No, this);
+        msgBox->setDefaultButton(QMessageBox::No);
+        msgBox->setAttribute(Qt::WA_DeleteOnClose);
+        connect(msgBox, &QDialog::finished, this, [this](int) { isAskingUserQuestion = false; });
+        connect(msgBox, &QMessageBox::buttonClicked, this,
+                [this, msgBox, nbIntervalToDelete](QAbstractButton *button) {
+            if (msgBox->standardButton(button) == QMessageBox::Yes)
+                applyMoveToInterval(nbIntervalToDelete);
+        });
+        msgBox->open();
+        return;
     }
 
+    applyMoveToInterval(nbIntervalToDelete);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void WorkoutDialog::applyMoveToInterval(int nbIntervalToDelete) {
 
     //Calculate timeDone in currentInterval
     double currentIntervalTimeDone =  timeElapsed_sec - lastIntervalEndTime_sec;
@@ -3243,8 +3253,9 @@ void WorkoutDialog::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Question:
     case Qt::Key_F1:
         if (!event->isAutoRepeat()) {
-            DialogKeyboardShortcuts dlg(this);
-            dlg.exec();
+            auto *dlg = new DialogKeyboardShortcuts(this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->open();
         }
         return;
     case Qt::Key_Return:
@@ -3324,34 +3335,38 @@ void WorkoutDialog::sureYouWantToQuit() {
     if (isWorkoutStarted && !isWorkoutOver) {
 
         isAskingUserQuestion = true;
-        QMessageBox msgBox(this);
-        msgBox.setIcon(QMessageBox::Question);
-        msgBox.setText(tr("Workout is not completed."));
-        msgBox.setInformativeText(tr("Save your progress?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-        msgBox.setDefaultButton(QMessageBox::Save);
+        // Async 3-way confirm (exec() is fatal on WASM); accept() runs from
+        // the button callback instead of after a blocking return.
+        auto *msgBox = new QMessageBox(QMessageBox::Question, QString(),
+                                       tr("Workout is not completed."),
+                                       QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, this);
+        msgBox->setInformativeText(tr("Save your progress?"));
+        msgBox->setAttribute(Qt::WA_DeleteOnClose);
+        connect(msgBox, &QDialog::finished, this, [this](int) { isAskingUserQuestion = false; });
+        connect(msgBox, &QMessageBox::buttonClicked, this,
+                [this, msgBox](QAbstractButton *button) {
+            const QMessageBox::StandardButton reply = msgBox->standardButton(button);
+            if (reply == QMessageBox::Yes) {
 
-        int reply = msgBox.exec();
-        if (reply == QMessageBox::Yes) {
+                // Save FIT FILE
+                if (Util::getSystemPathHistory() != "invalid_writable_path") {
+                    int intervalPausedTime_msec = totalTimePausedWorkout_msec - lastIntervalTotalTimePausedWorkout_msec;
+                    changeIntervalsDataWorkout(lastIntervalEndTime_msec, timeElapsed_sec, intervalPausedTime_msec, true, false);
+                    m_quitAfterSave = true;  // skip post-workout panel — dialog closes immediately after
+                    closeFitFiles(timeElapsed_sec);
+                }
 
-            // Save FIT FILE
-            if (Util::getSystemPathHistory() != "invalid_writable_path") {
-                int intervalPausedTime_msec = totalTimePausedWorkout_msec - lastIntervalTotalTimePausedWorkout_msec;
-                changeIntervalsDataWorkout(lastIntervalEndTime_msec, timeElapsed_sec, intervalPausedTime_msec, true, false);
-                m_quitAfterSave = true;  // skip post-workout panel — dialog closes immediately after
-                closeFitFiles(timeElapsed_sec);
+                QDialog::accept();
             }
-
-            QDialog::accept();
-        }
-        else if (reply == QMessageBox::No) {
-            closeAndDeleteFitFile();
-            QDialog::accept();
-        }
-        else {
-            qDebug() << "Cancel was clicked";
-        }
-        isAskingUserQuestion = false;
+            else if (reply == QMessageBox::No) {
+                closeAndDeleteFitFile();
+                QDialog::accept();
+            }
+            else {
+                qDebug() << "Cancel was clicked";
+            }
+        });
+        msgBox->open();
     }
     /// Not started or workout completed, no warning to show
     else {

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -222,6 +222,8 @@ private slots:
 
     void insertInterval();
     void moveToInterval(int nb, double secWorkout, double startIntervalSec, bool showConfirmation);
+    // Confirmed half of moveToInterval (runs after the async confirmation).
+    void applyMoveToInterval(int nbIntervalToDelete);
     void adjustWorkoutDifficulty(int percentage);
 
     // Post-workout upload slots

--- a/tests/playwright/wasm_logout.spec.ts
+++ b/tests/playwright/wasm_logout.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Log Out survival – WASM (regression for #344)
+ *
+ * Log Out used to abort the whole WASM runtime ("uncaught RuntimeError")
+ * because the confirmation box ran QDialog::exec(), which is a qFatal on
+ * Qt for WebAssembly without asyncify. The fix confirms via QDialog::open()
+ * and this suite proves the full cycle survives in-browser:
+ *
+ *   1. Mocked OAuth login → MainWindow (same setup as wasm_workout_render).
+ *   2. window.mt_triggerLogout() runs the confirmed logout path: credentials
+ *      cleared, MainWindow saved + torn down, DialogLogin re-shown in-process.
+ *   3. The login dialog re-appearing (mt_wasmOAuthReady re-set by its
+ *      constructor) and a second successful login prove the runtime is alive.
+ *
+ * The round-1 JS hooks are explicitly cleared before logout so their
+ * reappearance can only come from the second DialogLogin / MainWindow
+ * construction, not from stale registrations.
+ */
+
+import { test, expect, type BrowserContext } from '@playwright/test';
+import { WasmAppPage } from './pages/WasmAppPage';
+
+const SCREENSHOT_DIR = 'test-results/wasm-screenshots';
+
+test.describe('WASM Log Out returns to the login screen without crashing', () => {
+  test.describe.configure({ timeout: 420_000 });
+
+  let ctx: BrowserContext;
+  let wasmApp: WasmAppPage;
+  const pageErrors: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(420_000);
+    ctx = await browser.newContext();
+    wasmApp = new WasmAppPage(await ctx.newPage());
+    wasmApp.page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await wasmApp.stubBluetooth();
+    await wasmApp.disableIcuProxyInterceptor();
+    await wasmApp.mockIntervalsIcuApi();
+    // setupOAuthMock must follow mockIntervalsIcuApi so its specific routes
+    // take priority (Playwright tries routes last-first).
+    await wasmApp.setupOAuthMock();
+
+    await wasmApp.goto();
+    await wasmApp.waitForFullyLoaded(300_000);
+
+    // Round 1: fully-mocked OAuth login → MainWindow.
+    await wasmApp.completeOAuthLogin(180_000);
+    await wasmApp.waitForDemoWorkoutHook(60_000);
+  });
+
+  test.afterAll(async () => {
+    await ctx.close();
+  });
+
+  test('logout tears down MainWindow and re-shows the login dialog', async () => {
+    // Clear the round-1 bridge flags so their reappearance below can only be
+    // caused by the login dialog / main window being constructed again.
+    await wasmApp.page.evaluate(() => {
+      (window as any).mt_wasmOAuthReady = false;
+      delete (window as any).mt_setIntervalsCredentials;
+      delete (window as any).mt_intervalsRefresh;
+    });
+
+    await wasmApp.page.evaluate(() => (window as any).mt_triggerLogout());
+
+    // DialogLogin's constructor re-sets mt_wasmOAuthReady — the signal that
+    // the teardown survived and the app is back at the login screen.
+    await wasmApp.page.waitForFunction(
+      () => (window as any).mt_wasmOAuthReady === true,
+      null,
+      { timeout: 120_000 },
+    );
+    await wasmApp.page.screenshot({ path: `${SCREENSHOT_DIR}/logout-login-screen.png` });
+  });
+
+  test('a second OAuth login reaches MainWindow again', async () => {
+    await wasmApp.completeOAuthLogin(180_000);
+    await wasmApp.page.screenshot({ path: `${SCREENSHOT_DIR}/logout-relogin.png` });
+  });
+
+  test('no uncaught runtime errors or fatal log lines across the cycle', async () => {
+    expect(
+      pageErrors,
+      `Uncaught page errors during logout/login cycle:\n${pageErrors.join('\n')}`,
+    ).toHaveLength(0);
+
+    const fatalLines = await wasmApp.logOverlay.getFatalErrorLines();
+    expect(
+      fatalLines,
+      `Fatal log-overlay lines during logout/login cycle:\n${fatalLines.join('\n')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/tests/playwright/wasm_logout.spec.ts
+++ b/tests/playwright/wasm_logout.spec.ts
@@ -54,6 +54,23 @@ test.describe('WASM Log Out returns to the login screen without crashing', () =>
     await ctx.close();
   });
 
+  test('Preferences opens without killing the runtime', async () => {
+    // dconfig->exec() used to be a fatal nested event loop on WASM — opening
+    // Preferences aborted the app just like Log Out did (#344).
+    await wasmApp.page.evaluate(() => (window as any).mt_openPreferences());
+    await wasmApp.page.waitForTimeout(3_000);
+    await wasmApp.page.screenshot({ path: `${SCREENSHOT_DIR}/preferences-open.png` });
+
+    expect(
+      pageErrors,
+      `Uncaught page errors after opening Preferences:\n${pageErrors.join('\n')}`,
+    ).toHaveLength(0);
+
+    // Close it again (Esc) so the logout test below starts from MainWindow.
+    await wasmApp.page.keyboard.press('Escape');
+    await wasmApp.page.waitForTimeout(1_000);
+  });
+
   test('logout tears down MainWindow and re-shows the login dialog', async () => {
     // Clear the round-1 bridge flags so their reappearance below can only be
     // caused by the login dialog / main window being constructed again.


### PR DESCRIPTION
Fixes #344 — on the WASM build, clicking **MaximumTrainer → Log Out** killed the whole app with an uncaught `RuntimeError: memory access out of bounds`. Windows/Linux were unaffected.

Per Maxime's request this PR now also **sweeps every other dialog with the same defect** in the WASM build (second commit) — the Log Out crash was one instance of a whole class.

## Root cause (reproduced)

Driving the **deployed v0.0.206 build** with Playwright (mocked OAuth login, then clicking MaximumTrainer → Log Out on the canvas) reproduces the report exactly:

```
[ERROR] [Qt] Calling exec() is not supported on Qt for WebAssembly in this
configuration. Please build with asyncify support, or use an asynchronous
API like QDialog::open()
[error] Aborted()
pageerror: memory access out of bounds     <- what the issue reported
```

Any nested event loop (`QDialog::exec()`, the static `QMessageBox`/`QFileDialog`/`QInputDialog` helpers, `QMenu::exec()`, `QEventLoop::exec()`) is a `qFatal` on Qt for WebAssembly without asyncify (we do not link `-sASYNCIFY`). Desktop platforms have real nested event loops, so the same code was fine there.

## What was broken on WASM (full audit)

Beyond Log Out, these all aborted the runtime the same way:

- **Preferences** and **Keyboard Shortcuts** — crash straight from the menu
- **Starting any real (non-demo) workout** — crash at the connection-method dialog; the BLE path additionally ran a scanner `exec()` and a blocking `QEventLoop` connect-wait
- **Closing an unfinished workout** (save/discard confirm) and **skip-to-interval** confirm
- History: **Critical Power / PMC dialogs**, **delete activity**, info boxes
- Workout list **delete** confirm; editor **overwrite** confirm; **queue countdown** + queue warnings
- Preferences internals: radio **add/edit/delete**, Strava link warnings, save-failed / theme-changed boxes, log-path **Browse…**
- Studio **JSON import/export** (QFileDialog statics)
- Login screen **update prompt** (UpdateDialog), sync-failed warning, connection-failed warning

Sites already compiled out or guarded on WASM (sensor/studio scanner dialogs, plan-adherence context menu, Intervals connection test, media player) were verified safe and left unchanged.

## Fix

- New **`src/ui/asyncdialogs.h`**: `information` / `warning` / `question` helpers built on a heap `QMessageBox` + `open()` (`WA_DeleteOnClose`), used on **all platforms** so there is one code path; desktop UX is unchanged.
- **`executeWorkout` split**: `startSimulatedWorkout` + `startWorkoutWithConnectedHub` are shared; desktop keeps its synchronous `exec()` flow verbatim, WASM gets an async chain (connection dialog via `open()` → browser BLE picker → signal-driven connect wait) in `startWasmBleWorkout`.
- Confirmations restructured onto callbacks (workout close/skip, deletes, overwrite); plain dialogs switched to `open()`; the plan context menu uses `popup()`.
- The radio editor now validates **before** accepting, so the dialog stays open on bad input (previously it closed and threw your edits away with a warning).
- Studio export/import uses `QFileDialog::saveFileContent` / `getOpenFileContent` on WASM (browser download / file picker — there are no local paths in-browser).
- WASM hides the **Import** and **Folder** menus (they need a local file system) and the log-path Browse button.

## Test coverage

`tests/playwright/wasm_logout.spec.ts`, running in CI's `test_playwright` job against the **freshly built** wasm artifact:

1. Mocked-OAuth login → MainWindow.
2. **Preferences smoke test** via the new `window.mt_openPreferences()` hook (crashed exactly like Log Out before this PR).
3. `window.mt_triggerLogout()` runs the confirmed logout path: credentials cleared, MainWindow saved and torn down, login dialog re-shown in-process.
4. Asserts the login dialog comes back, a **second** login reaches MainWindow again, and zero uncaught runtime errors / fatal log-overlay lines across the whole cycle.

## Validation

- Root cause reproduced against the live deployment (console output above) before writing the fix.
- Desktop (Linux, Qt 6.10): clean build; app launch + full headless screenshot pass verified. Desktop flows keep their synchronous structure — the only behavioral change is dialogs being shown via `open()`.
- WASM: logout + preferences covered by the CI Playwright spec; the rest of the converted dialogs share the same `open()` mechanism. A human pass on real hardware is requested below.

### How to test manually (@MaximumTrainer)

Either wait for this PR's `build.yml` run to go green (the `test_playwright` job exercises login → preferences → logout → re-login in Chromium), or check by hand:

1. Download the `wasm` artifact from this PR's build run and unzip the three files over `docs/app/` on this branch.
2. `python3 -m http.server 8080 --directory docs`
3. Open `http://localhost:8080/app/` in Chrome and try the flows that used to die: **Log Out → Yes** (should land back on the login screen and allow logging in again), **Preferences**, **Keyboard Shortcuts**, starting a **Simulation workout** and closing it mid-way (save/discard prompt), History → delete an activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
