### PR TITLE
chore(security): never compile the Intervals.icu client_secret into the app

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -92,8 +92,7 @@ jobs:
       run: |
         qmake MaximumTrainer.pro "QWT_INSTALL=$QWT_DIR"
       env:
-        INTERVALS_OAUTH_CLIENT_ID:     ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}
-        INTERVALS_OAUTH_CLIENT_SECRET: ${{ secrets.INTERVALS_OAUTH_CLIENT_SECRET }}
+        INTERVALS_OAUTH_CLIENT_ID: ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}
 
     - name: Build
       run: make -j$(nproc)

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -99,8 +99,7 @@ jobs:
         qmake MaximumTrainer.pro \
           "QWT_INSTALL=/usr/local/qwt-6.3.0"
       env:
-        INTERVALS_OAUTH_CLIENT_ID:     ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}
-        INTERVALS_OAUTH_CLIENT_SECRET: ${{ secrets.INTERVALS_OAUTH_CLIENT_SECRET }}
+        INTERVALS_OAUTH_CLIENT_ID: ${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}
 
     - name: Diagnose QWT installation
       run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -156,7 +156,6 @@ jobs:
       run: |
         $qwtInstallDirFwd = $env:QWT_INSTALL_DIR -replace '\\','/'
         $env:INTERVALS_OAUTH_CLIENT_ID = "${{ secrets.INTERVALS_OAUTH_CLIENT_ID }}"
-        $env:INTERVALS_OAUTH_CLIENT_SECRET = "${{ secrets.INTERVALS_OAUTH_CLIENT_SECRET }}"
         qmake MaximumTrainer.pro `
           "QWT_INSTALL=$qwtInstallDirFwd"
       shell: powershell

--- a/.github/workflows/deploy-intervals-proxy.yml
+++ b/.github/workflows/deploy-intervals-proxy.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           if [ -z "$INTERVALS_OAUTH_CLIENT_SECRET" ]; then
             echo "INTERVALS_OAUTH_CLIENT_SECRET secret not configured — the worker"
-            echo "cannot inject it; token exchange then only works for builds with"
-            echo "a baked-in secret (qmake INTERVALS_OAUTH_CLIENT_SECRET)."
+            echo "cannot inject it and token exchange will fail (the app never"
+            echo "carries the secret)."
             exit 0
           fi
           # KV path: store secret keyed by client_id ("259").

--- a/MaximumTrainer.pro
+++ b/MaximumTrainer.pro
@@ -36,25 +36,16 @@ isEmpty(GIT_VERSION) {
 }
 DEFINES += APP_VERSION=\\\"$$GIT_VERSION\\\"
 
-# Intervals.icu OAuth2 client credentials — supplied at build time via env vars.
-# In GitHub Actions CI, add INTERVALS_OAUTH_CLIENT_ID and INTERVALS_OAUTH_CLIENT_SECRET
-# as repository secrets and expose them on the qmake step.  For local development,
-# export the variables before running qmake.
-# Fallback: client_id=259 (existing public client registration), client_secret=""
-# (public client — no secret required).  The fallbacks preserve existing behaviour
-# when the secrets are absent.
+# Intervals.icu OAuth2 client_id — supplied at build time via the
+# INTERVALS_OAUTH_CLIENT_ID env var, defaulting to the public client 259.
+# The client_secret is deliberately NOT compiled in: the app is a public
+# client, and the token Worker (workers/intervals-cors-proxy) injects the
+# secret server-side on every token request.
 ICV_CLIENT_ID_VAL = $$(INTERVALS_OAUTH_CLIENT_ID)
 !isEmpty(ICV_CLIENT_ID_VAL) {
     DEFINES += INTERVALS_OAUTH_CLIENT_ID=\\\"$$ICV_CLIENT_ID_VAL\\\"
 } else {
     DEFINES += INTERVALS_OAUTH_CLIENT_ID=\\\"259\\\"
-}
-
-ICV_CLIENT_SECRET_VAL = $$(INTERVALS_OAUTH_CLIENT_SECRET)
-!isEmpty(ICV_CLIENT_SECRET_VAL) {
-    DEFINES += INTERVALS_OAUTH_CLIENT_SECRET=\\\"$$ICV_CLIENT_SECRET_VAL\\\"
-} else {
-    DEFINES += INTERVALS_OAUTH_CLIENT_SECRET=\\\"\\\"
 }
 
 # Derive qmake's VERSION variable from GIT_VERSION.  This is used by qmake to

--- a/src/persistence/db/environnement.cpp
+++ b/src/persistence/db/environnement.cpp
@@ -100,12 +100,6 @@ QString Environnement::getIntervalsIcuClientId() {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-QString Environnement::getIntervalsIcuClientSecret() {
-    const QString stored = CredentialStore::load("intervals_icu_app", "client_secret");
-    return stored.isEmpty() ? CLIENT_SECRET_ICV : stored;
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 QString Environnement::getUrlIntervalsIcuRegister() {
     return urlIntervalsIcuRegister;
 }

--- a/src/persistence/db/environnement.h
+++ b/src/persistence/db/environnement.h
@@ -45,19 +45,15 @@ const static QString urlIntervalsIcuOAuthAuthorize =
 const static QString intervalsIcuOAuthScope =
     QStringLiteral("ACTIVITY:WRITE,WELLNESS:READ,SETTINGS:WRITE,CALENDAR:WRITE,LIBRARY:READ");
 
-/// Intervals.icu OAuth2 client credentials.
-/// client_id and client_secret are injected at build time via environment variables
-/// INTERVALS_OAUTH_CLIENT_ID and INTERVALS_OAUTH_CLIENT_SECRET (see MaximumTrainer.pro).
-/// The macros default to "259" (existing public client) and "" (no secret) when
-/// the environment variables are not set.
+/// Intervals.icu OAuth2 client_id, injected at build time via the
+/// INTERVALS_OAUTH_CLIENT_ID environment variable (see MaximumTrainer.pro);
+/// defaults to "259" (existing public client).  The client_secret is
+/// deliberately NOT in the app: the token Worker injects it server-side
+/// (see URL_TOKEN_ICV).
 #ifndef INTERVALS_OAUTH_CLIENT_ID
 #define INTERVALS_OAUTH_CLIENT_ID "259"
 #endif
-#ifndef INTERVALS_OAUTH_CLIENT_SECRET
-#define INTERVALS_OAUTH_CLIENT_SECRET ""
-#endif
-const static QString CLIENT_ID_ICV     = QStringLiteral(INTERVALS_OAUTH_CLIENT_ID);
-const static QString CLIENT_SECRET_ICV = QStringLiteral(INTERVALS_OAUTH_CLIENT_SECRET);
+const static QString CLIENT_ID_ICV = QStringLiteral(INTERVALS_OAUTH_CLIENT_ID);
 
 /// Cloudflare CORS proxy that fronts intervals.icu for both desktop and WASM
 /// builds.  All OAuth token exchange / refresh POSTs (and, in WASM, all API
@@ -89,10 +85,8 @@ const static QString INTERVALS_PROXY_DESKTOP_CLIENT_VALUE =
 ///
 /// intervals.icu REQUIRES the client_secret on token requests (422 without
 /// it); client 259 is confidential.  The Worker injects the secret
-/// server-side (wrangler secret INTERVALS_CLIENT_SECRET), so no app binary
-/// has to carry it.  If a secret IS configured locally (self-registered
-/// OAuth client, see getIntervalsIcuClientSecret()) it is sent along and the
-/// Worker forwards it untouched.
+/// server-side (CLIENT_SECRETS KV keyed by client_id), so no app binary
+/// carries it.
 const static QString URL_TOKEN_ICV = INTERVALS_PROXY_BASE + "/proxy/api/oauth/token";
 
 /// Sentinel athlete ID meaning "the currently authenticated OAuth2 user".
@@ -150,12 +144,6 @@ public:
     /// Checks CredentialStore("intervals_icu_app","client_id") first; falls back
     /// to the build-time constant (INTERVALS_OAUTH_CLIENT_ID / "259").
     static QString getIntervalsIcuClientId();
-    /// Return the Intervals.icu OAuth2 client_secret.
-    /// Checks CredentialStore("intervals_icu_app","client_secret") first; falls back
-    /// to the build-time constant (INTERVALS_OAUTH_CLIENT_SECRET / "").
-    /// Normally empty: the token Worker injects the secret server-side (see
-    /// URL_TOKEN_ICV).  Only set for self-registered OAuth clients.
-    static QString getIntervalsIcuClientSecret();
 
 };
 


### PR DESCRIPTION
## Summary

The app should never carry the Intervals.icu OAuth `client_secret` - the Cloudflare token Worker injects it server-side on every token exchange/refresh, and that has been the only runtime path since the proxy flow landed. But the build still had a leftover bake:

- `MaximumTrainer.pro` compiled `INTERVALS_OAUTH_CLIENT_SECRET` into the binary as `CLIENT_SECRET_ICV`
- `build-linux.yml` / `build-mac.yml` / `build-windows.yml` all passed the real repository secret into that qmake step, so **every release binary shipped with the secret string embedded** (extractable with `strings`)
- the only consumer, `Environnement::getIntervalsIcuClientSecret()`, had **zero callers** - pure dead code

## Changes

- Remove the `INTERVALS_OAUTH_CLIENT_SECRET` qmake block, the `CLIENT_SECRET_ICV` constant, and the unused `getIntervalsIcuClientSecret()` getter
- Stop exposing `secrets.INTERVALS_OAUTH_CLIENT_SECRET` to the qmake steps in the three platform build workflows
- Reword the `deploy-intervals-proxy.yml` missing-secret message that referenced the (now gone) baked-in fallback

The secret's only remaining home is the Worker deploy path (`deploy-intervals-proxy.yml` -> Cloudflare KV / wrangler secret), which is unchanged. The public `client_id` (259) is still compiled in; it is not a secret.

## Validation

- Clean rebuild on Linux (Qt 6.10 + QWT 6.3) passes; `INTERVALS_OAUTH_CLIENT_SECRET` no longer appears in the generated Makefile
- App runs end-to-end in `--screenshots` mode (full demo workout, clean shutdown)
- `intervals_icu_oauth_exchange_tests`: 17/17 pass
- `login_screen_tests` (compiles `environnement.cpp`, exercises the Intervals OAuth dialog): 10 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
