### PR TITLE
ci: consolidate test shards - Qt CDN downloads per run 27 -> 10 (closes #352)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -63,11 +63,26 @@ jobs:
         path: ${{ env.QWT_DIR }}
         key: qwt-6.3.0-qt-${{ env.QT_VERSION }}-linux
 
+    - name: Validate QWT cache
+      id: qwt-validate
+      # A corrupted cache extraction can leave a partial tree behind while the
+      # action still reports a cache hit (seen on macOS: gtar errors mid
+      # restore). Verify the pieces the build links against; rebuild otherwise.
+      run: |
+        if [ "${{ steps.qwt-cache.outputs.cache-hit }}" = "true" ] && \
+           [ -e "$QWT_DIR/lib/libqwt.so.6" ] && \
+           [ -f "$QWT_DIR/include/qwt_plot.h" ]; then
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          rm -rf "$QWT_DIR"
+        fi
+
     - name: Build and install QWT
       # No QWT apt package exists for Qt6, so build 6.3.0 from source against the
       # installed Qt6 and stage it under QWT_DIR. MaximumTrainer.pro is pointed at it
       # via QWT_INSTALL=... .
-      if: steps.qwt-cache.outputs.cache-hit != 'true'
+      if: steps.qwt-validate.outputs.ok != 'true'
       run: |
         cd /tmp
         curl -L -o qwt.tar.bz2 "https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2/download"
@@ -145,10 +160,17 @@ jobs:
         cp -P "$QWT_DIR"/lib/libqwt.so* build/qwtlib/
 
     - name: Upload artifact
+      # Exclude compile intermediates (~3/4 of build/): the test and release
+      # jobs only need the binaries, and every one of them downloads this.
       uses: actions/upload-artifact@v4
       with:
         name: linux
-        path: build/
+        path: |
+          build/
+          !build/release/.obj/**
+          !build/release/.moc/**
+          !build/release/.qrc/**
+          !build/release/.u/**
 
   # ──────────────────────────────────────────────────────────────────────────
   # Unit & Service Test Suites (Linux) — consolidated (#352)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -151,16 +151,25 @@ jobs:
         path: build/
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Logger Unit Test (Linux)
+  # Unit & Service Test Suites (Linux) — consolidated (#352)
   #
-  # Builds and runs the Logger unit test suite (tests/logger/) to verify that
-  # the cross-platform logging framework filters levels correctly, writes to
-  # file sinks, routes Qt messages, and round-trips configuration.
+  # All self-building suites share one runner and ONE Qt installation instead
+  # of one job (= one Qt CDN download) per suite. Runs in parallel with
+  # build_linux — none of these need the build artifact.
+  #
+  # Suites: logger, apptheme, intervals_icu (service / ZWO importer / DAO
+  # bearer / OAuth exchange), strava + third-party services, credential_store,
+  # plan_adherence, history, and the live Intervals.icu integration suite
+  # (uses secrets; QSKIPs gracefully without them).
   # ──────────────────────────────────────────────────────────────────────────
-  test_logger:
+  test_unit_suites:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+    env:
+      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
+      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
+      STRAVA_ACCESS_TOKEN:      ${{ secrets.STRAVA_ACCESS_TOKEN }}
 
     steps:
     - name: Checkout
@@ -178,129 +187,30 @@ jobs:
         cache: true
         cache-key-prefix: qt-linux
 
-    - name: Build logger unit tests
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libssl-dev
+
+    - name: Logger unit tests
       run: |
         mkdir -p build/tests
         cd tests/logger
         qmake logger_tests.pro
         make -j$(nproc)
-
-    - name: Run logger unit tests
-      run: |
+        cd ../..
         ./build/tests/logger_tests -v2
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # AppTheme Unit Tests (Linux)
-  #
-  # Builds and runs the AppTheme unit test suite (tests/apptheme/) to verify
-  # the dark/light theming helper: explicit-mode resolution, that apply()
-  # switches the global stylesheet, and that no stylesheet colour literals are
-  # invalid. Runs under the offscreen platform (no display needed).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_apptheme:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build AppTheme unit tests
+    - name: AppTheme unit tests
       run: |
-        mkdir -p build/tests
         cd tests/apptheme
         qmake apptheme_tests.pro
         make -j$(nproc)
-
-    - name: Run AppTheme unit tests
-      run: |
+        cd ../..
         QT_QPA_PLATFORM=offscreen ./build/tests/apptheme_tests -v2
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # BTLE Unit Tests (Linux)
-  #
-  # Builds and runs the BtleHub unit test suite (tests/btle/) to verify that
-  # BLE characteristic parsing (HR, CSC, Power, FTMS) is correct and that
-  # integer-overflow and bounds-check security fixes have not broken behaviour.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_btle_unit:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/btle_tests
-
-    - name: Run BTLE unit tests
-      run: ./build/tests/btle_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # IntervalsIcuService + ImporterWorkoutZwo Unit Tests (Linux)
-  #
-  # Builds and runs two test suites:
-  # • intervals_icu_tests — verifies Authorization header construction, Accept
-  #   header, URL building, query parameters, and null-manager guard.
-  # • importer_workout_zwo_tests — verifies ZWO XML parser for SteadyState,
-  #   Ramp, IntervalsT, FreeRide, and mixed workout structures.
-  # • intervals_icu_dao_bearer_tests — verifies the OAuth2 Bearer-token methods
-  #   added to IntervalsIcuDAO (getAthleteBearer, getAthleteSettingsBearer).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_intervals_icu:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build Intervals.icu unit tests
+    - name: Intervals.icu unit tests
       run: |
-        mkdir -p build/tests
         cd tests/intervals_icu
         qmake intervals_icu_tests.pro
         make -j$(nproc)
@@ -308,280 +218,53 @@ jobs:
         make -j$(nproc)
         qmake intervals_icu_dao_bearer_tests.pro
         make -j$(nproc)
-
-    - name: Run Intervals.icu unit tests
-      run: |
+        qmake intervals_icu_oauth_exchange_tests.pro
+        make -j$(nproc)
+        cd ../..
         ./build/tests/intervals_icu_tests -v2
         ./build/tests/importer_workout_zwo_tests -v2
         ./build/tests/intervals_icu_dao_bearer_tests -v2
+        ./build/tests/intervals_icu_oauth_exchange_tests -v2
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # BTLE Integration Test (Linux)
-  #
-  # Runs SimulatorHub in a Qt window under Xvfb, takes a screenshot as
-  # evidence that Bluetooth sensor detection and an activity session work
-  # end-to-end without physical hardware.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_btle_integration:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install X11 runtime dependencies
+    - name: Strava service tests
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev
+        cd tests/strava
+        qmake strava_tests.pro
+        make -j$(nproc)
+        cd ../..
+        ./build/tests/strava_tests -v2
 
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/btle_integration_tests
-
-    - name: Run BTLE integration test with Xvfb
+    - name: CredentialStore tests
       run: |
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/btle_integration_tests -v2
+        cd tests/credential_store
+        qmake credential_store_tests.pro
+        make -j$(nproc)
+        cd ../..
+        ./build/tests/credential_store_tests -v2
 
-    - name: Upload screenshot evidence
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: btle-integration-screenshot
-        path: build/tests/btle_integration_screenshot.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # BLE API Smoke Test – Linux
-  #
-  # Exercises the real BtleHub → QLowEnergyController code path on Linux.
-  # With no physical BLE hardware the OS BLE stack reports a connection error
-  # for the fake device address, confirming the real API is invoked.
-  # On CI runners with no BT adapter the test QSKIP gracefully.
-  # No display required (headless Qt Test binary).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_btle_api:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/btle_api_tests
-
-    - name: Run BLE API smoke test
-      run: ./build/tests/btle_api_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Runtime Validation – Linux
-  #
-  # Verifies that the application UI initialises to a "Ready" state on Linux:
-  #   • Bluetooth stack is queryable (API returns "Not Found", not "Unsupported")
-  #   • All four sensor channels carry realistic values within 10 seconds
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence
-  # ──────────────────────────────────────────────────────────────────────────
-  test_runtime_validation:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install X11 runtime dependencies
+    - name: PlanAdherence tests
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev
+        cd tests/plan_adherence
+        qmake plan_adherence_tests.pro
+        make -j$(nproc)
+        cd ../..
+        ./build/tests/plan_adherence_tests -v2
 
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/runtime_validation_tests
-
-    - name: Run runtime validation test with Xvfb (1280×800 display)
+    - name: History tests
       run: |
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/runtime_validation_tests -v2
+        cd tests/history
+        qmake history_tests.pro
+        make -j$(nproc)
+        cd ../..
+        ./build/tests/history_tests -v2
 
-    - name: Upload runtime validation screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: runtime-validation-screenshot-linux
-        path: build/tests/screenshot-linux-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Offline Mode Integration Test – Linux
-  #
-  # Verifies that MaximumTrainer's core offline functionality works without a
-  # network connection and without physical Bluetooth hardware:
-  #   • Local workout XML files can be created and parsed from disk.
-  #   • SimulatorHub broadcasts realistic CSC (0x1816) and Power (0x1818)
-  #     cycling data (cadence, speed, power) within expected ranges.
-  #   • A labelled 1280×720 screenshot is captured showing the offline mode
-  #     indicator and live BTLE sensor metrics.
-  #   • Accumulated data points are written to a TSV activity file,
-  #     confirming offline data persistence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_offline_mode:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install X11 runtime dependencies
+    - name: Build Intervals.icu live integration tests
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/offline_mode_tests
-
-    - name: Run offline mode test with Xvfb (1280×800 display)
-      run: |
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/offline_mode_tests -v2
-
-    - name: Upload offline mode screenshot and activity file
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: offline-mode-artefacts-linux
-        path: |
-          build/tests/offline-mode-linux-*.png
-          build/tests/activity-linux-*.tsv
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Intervals.icu Live Integration Tests – Linux
-  #
-  # Makes real HTTP requests to https://intervals.icu/api/v1 using the shared
-  # test account.  Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # Tests call QSKIP gracefully when either secret is absent (fork PRs, local
-  # development without credentials).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_intervals_icu_integration:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build integration tests
-      run: |
-        mkdir -p build/tests
         cd tests/intervals_icu_integration
         qmake intervals_icu_integration_tests.pro
         make -j$(nproc)
 
-    - name: Run Intervals.icu integration tests
+    - name: Run Intervals.icu live integration tests
       run: |
         # Live test against intervals.icu: retry transient network/API blips
         # before failing the job. -o writes results to a file we echo into the
@@ -604,21 +287,14 @@ jobs:
         exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Online Mode Authentication Test – Linux
+  # Headless Integration Tests (Linux) — consolidated (#352)
   #
-  # Simulates a user authenticating into the running application on Linux.
-  # A 1280x720 window is shown, a live HTTPS authentication request is made
-  # to https://intervals.icu/api/v1 using credentials from GitHub Secrets,
-  # and the result is displayed in the window and captured as a screenshot.
-  #
-  # Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # The test calls QSKIP gracefully when either secret is absent (fork PRs,
-  # local development without credentials).
+  # Runs the pre-built headless test binaries from the build artifact with a
+  # single Qt installation: BTLE unit + BLE API smoke, workout I/O, workout
+  # creator, and workout parsing (secrets-gated live cases QSKIP without
+  # credentials).
   # ──────────────────────────────────────────────────────────────────────────
-  test_online_mode:
+  test_integration_headless:
     runs-on: ubuntu-22.04
     needs: build_linux
     permissions:
@@ -628,13 +304,80 @@ jobs:
       INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
 
     steps:
-    - name: Install Qt
+    - name: Install Qt (with Bluetooth)
       uses: jurplel/install-qt-action@v3
       with:
         version: ${{ env.QT_VERSION }}
         host: 'linux'
         target: 'desktop'
         arch: 'linux_gcc_64'
+        modules: 'qtconnectivity'
+        cache: true
+        cache-key-prefix: qt-linux
+
+    - name: Install runtime dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y \
+          libfontconfig1 \
+          libxrender1 \
+          libxext6
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux
+        path: build
+
+    - name: Make test binaries executable
+      run: |
+        chmod +x build/tests/btle_tests \
+                 build/tests/btle_api_tests \
+                 build/tests/workout_io_tests \
+                 build/tests/workout_creator_tests \
+                 build/tests/workout_parsing_tests
+
+    - name: BTLE unit tests
+      run: ./build/tests/btle_tests -v2
+
+    - name: BLE API smoke test
+      run: ./build/tests/btle_api_tests -v2
+
+    - name: Workout I/O tests
+      run: |
+        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
+        QT_QPA_PLATFORM=offscreen ./build/tests/workout_io_tests -v2
+
+    - name: Workout creator tests
+      run: ./build/tests/workout_creator_tests -v2
+
+    - name: Workout parsing tests
+      run: ./build/tests/workout_parsing_tests -v2
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # GUI Integration Tests (Linux, Xvfb) — consolidated (#352)
+  #
+  # Runs the pre-built windowed test binaries under one Xvfb display with a
+  # single Qt installation: BTLE integration, runtime validation, offline
+  # mode, UI screens, and UI navigation (which launches the real
+  # MaximumTrainer binary). Screenshot evidence from every suite is uploaded
+  # as one artifact.
+  # ──────────────────────────────────────────────────────────────────────────
+  test_gui:
+    runs-on: ubuntu-22.04
+    needs: build_linux
+    permissions:
+      contents: read
+
+    steps:
+    - name: Install Qt (full app modules)
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: ${{ env.QT_VERSION }}
+        host: 'linux'
+        target: 'desktop'
+        arch: 'linux_gcc_64'
+        modules: 'qtwebengine qtconnectivity qtwebchannel qtpositioning qtmultimedia'
         cache: true
         cache-key-prefix: qt-linux
 
@@ -647,7 +390,13 @@ jobs:
           libfontconfig1 \
           libxrender1 \
           libxext6 \
-          libgl1-mesa-dev
+          libgl1-mesa-dev \
+          libnss3 \
+          libxcomposite1 \
+          libxdamage1 \
+          libxrandr2 \
+          libxkbcommon0 \
+          libasound2
 
     - name: Download build artifact
       uses: actions/download-artifact@v4
@@ -655,39 +404,64 @@ jobs:
         name: linux
         path: build
 
-    - name: Make test binary executable
-      run: chmod +x build/tests/online_mode_tests
+    - name: Make binaries executable
+      run: |
+        chmod +x build/tests/btle_integration_tests \
+                 build/tests/runtime_validation_tests \
+                 build/tests/offline_mode_tests \
+                 build/tests/ui_screens_tests \
+                 build/tests/ui_navigation_tests \
+                 build/release/MaximumTrainer
 
-    - name: Run online mode authentication test with Xvfb
+    - name: Start Xvfb
       run: |
         Xvfb :99 -screen 0 1280x800x24 &
         sleep 1
-        export DISPLAY=:99
-        ./build/tests/online_mode_tests -v2
+        echo "DISPLAY=:99" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$PWD/build/qwtlib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
-    - name: Upload online mode screenshot
+    - name: BTLE integration test
+      run: ./build/tests/btle_integration_tests -v2
+
+    - name: Runtime validation test
+      run: ./build/tests/runtime_validation_tests -v2
+
+    - name: Offline mode test
+      run: ./build/tests/offline_mode_tests -v2
+
+    - name: UI screens test
+      run: ./build/tests/ui_screens_tests -v2
+
+    - name: UI navigation tests
+      # MT_NO_NETWORK=1 disables all outbound network calls in the launched
+      # MaximumTrainer binary (radio list, session check, Intervals.icu, etc.).
+      # The child process inherits this variable from QProcess automatically.
+      env:
+        MT_NO_NETWORK: "1"
+      run: ./build/tests/ui_navigation_tests -v2
+
+    - name: Upload GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: online-mode-screenshot-linux
-        path: build/tests/online-mode-linux-*.png
+        name: gui-test-artifacts-linux
+        path: |
+          build/tests/btle_integration_screenshot.png
+          build/tests/screenshot-linux-*.png
+          build/tests/offline-mode-linux-*.png
+          build/tests/activity-linux-*.tsv
+          build/tests/ui-screens-*.png
+          build/tests/app-journey-*/
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Login Screen Full-Application Test – Linux
+  # Live GUI Tests (Linux, Xvfb + Intervals.icu secrets) — consolidated (#352)
   #
-  # Validates that a user can log into MaximumTrainer and access key
-  # functionality without error on Linux:
-  #   • Offline login path: account setup logic is exercised end-to-end and
-  #     SimulatorHub confirms all four sensor channels (HR, cadence, speed,
-  #     power) carry realistic values once logged in.
-  #   • Intervals.icu OAuth URL: the OAuth2 authorization URL built by
-  #     Environnement is validated for all required parameters (client_id,
-  #     response_type, scope, redirect_uri, state).
-  #   • Intervals.icu API login (optional): a real HTTPS request is made to
-  #     intervals.icu/api/v1 using secrets when available; QSKIP otherwise.
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence.
+  # The three suites that talk to the live intervals.icu API from a windowed
+  # session: online mode, workout UI, and the login screen full-application
+  # journey. Kept separate from test_gui so a flaky live run retries cheaply.
+  # Tests QSKIP gracefully when the secrets are absent (fork PRs).
   # ──────────────────────────────────────────────────────────────────────────
-  test_login_screen:
+  test_gui_live:
     runs-on: ubuntu-22.04
     needs: build_linux
     permissions:
@@ -731,530 +505,34 @@ jobs:
         name: linux
         path: build
 
-    - name: Make test binary executable
-      run: chmod +x build/tests/login_screen_tests
-
-    - name: Run login screen test with Xvfb
+    - name: Make test binaries executable
       run: |
-        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
+        chmod +x build/tests/online_mode_tests \
+                 build/tests/workout_ui_tests \
+                 build/tests/login_screen_tests
+
+    - name: Start Xvfb
+      run: |
         Xvfb :99 -screen 0 1280x800x24 &
         sleep 1
-        export DISPLAY=:99
-        ./build/tests/login_screen_tests -v2
+        echo "DISPLAY=:99" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$PWD/build/qwtlib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
-    - name: Upload login screen screenshot
+    - name: Online mode authentication test
+      run: ./build/tests/online_mode_tests -v2
+
+    - name: Workout UI test
+      run: ./build/tests/workout_ui_tests -v2
+
+    - name: Login screen test
+      run: ./build/tests/login_screen_tests -v2
+
+    - name: Upload live GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: login-screen-screenshot-linux
-        path: build/tests/*-linux-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout UI Integration Test – Linux
-  #
-  # Validates the end-to-end workout pipeline on Linux, including:
-  #   • User login (offline path)
-  #   • Workout XML creation and retrieval (round-trip, lightweight schema)
-  #   • Workout model construction and field verification (Workout / Interval)
-  #   • Workout XML round-trip via XmlUtil::createWorkoutXml + parseSingleWorkoutXml
-  #   • Workout average-power metric (getAveragePower)
-  #   • ERG simulation: setLoad and setSlope drive SimulatorHub to the
-  #     correct power target without physical Bluetooth hardware
-  #   • Workout session lifecycle: start / pause / resume / stop with data
-  #     accumulation across all four sensor channels
-  #   • Interval advancement: ERG target changes at each interval boundary
-  #   • Power-on-target: actual power stays within ±25 % of ERG target
-  #   • Network connectivity: HTTPS GET to intervals.icu/api/v1 (QSKIP when
-  #     credentials absent)
-  #   • Network workout retrieval: GET /athlete/{id}/workouts returns a JSON
-  #     array (QSKIP when credentials absent)
-  #   • A labelled 1280×720 screenshot with QWT power-curve plot is captured
-  #     as visual build evidence
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_ui:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install X11 runtime dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_ui_tests
-
-    - name: Run workout UI test with Xvfb
-      run: |
-        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/workout_ui_tests -v2
-
-    - name: Upload workout UI screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: workout-ui-screenshot-linux
-        path: build/tests/workout-ui-linux-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Parsing Tests – Linux
-  #
-  # Validates the ZWO (Zwift workout XML) parsing pipeline end-to-end:
-  #   • ZWO inline string parsing — SteadyState, Ramp, IntervalsT, FreeRide,
-  #     mixed Warmup/SteadyState/Cooldown embedded directly in test source
-  #   • Workout model from programmatic Interval objects — structural fields,
-  #     average-power metric, and total-duration round-trip via getDurationQTime()
-  #   • Edge cases — empty byte array and malformed XML return empty Workout
-  #   • Intervals.icu pull-and-load (QSKIP when credentials absent)
-  #
-  # No display required (QT -= gui); runs in a plain headless environment.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_parsing:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_parsing_tests
-
-    - name: Run workout parsing tests
-      run: ./build/tests/workout_parsing_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # UI Navigation Tests – Linux
-  #
-  # Validates the primary UI screens and user interaction flows:
-  #   • ConnectionDialog — QTest::mouseClick() on "Simulation" and "BTLE Device";
-  #     QSignalSpy verifies accepted() fires and selectedMethod() is correct
-  #   • WorkoutCreator IntervalTableModel — insertRows / removeRows / copyRows /
-  #     setListInterval; dataChanged signal verified
-  #   • Post-workout summary screen — WorkoutHistorySummary field verification
-  #   • Visual evidence screenshots (1280×720, platform-tagged, PNG)
-  #
-  # Uses Xvfb for the headless X11 display required by Qt Widgets.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_ui_navigation:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (full app modules)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtwebengine qtconnectivity qtwebchannel qtpositioning qtmultimedia'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install runtime dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev \
-          libnss3 \
-          libxcomposite1 \
-          libxdamage1 \
-          libxrandr2 \
-          libxkbcommon0 \
-          libasound2
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make binaries executable
-      run: |
-        chmod +x build/tests/ui_navigation_tests
-        chmod +x build/release/MaximumTrainer
-
-    - name: Run UI navigation tests with Xvfb
-      # Xvfb provides a real X11 display server so the installed MaximumTrainer
-      # binary launched by testFullApplicationJourney() can render its windows
-      # and write screenshots, and the component-level dialog tests can show
-      # real Qt windows.  This is not "headless" — Xvfb is a fully functional
-      # X11 server; it just has no physical hardware attached.
-      # MT_NO_NETWORK=1 disables all outbound network calls in the launched
-      # MaximumTrainer binary (radio list, session check, Intervals.icu, etc.).
-      # The child process inherits this variable from QProcess automatically.
-      # Remove or set to 0 when running locally to keep network enabled.
-      env:
-        MT_NO_NETWORK: "1"
-      run: |
-        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/ui_navigation_tests -v2
-
-    - name: Upload UI navigation screenshots
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: ui-navigation-screenshots-linux
+        name: gui-live-test-artifacts-linux
         path: |
-          build/tests/app-journey-*/
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # UI Screens Tests – Linux
-  #
-  # Runs the UI screen navigation test suite (tst_ui_screens.cpp):
-  #   • DialogConnectionMethod — "BTLE Device" and "Simulation" button clicks
-  #     verified with QTest::mouseClick and QSignalSpy.
-  #   • PostWorkoutSummary widget — metric labels verified as visible and
-  #     non-empty.
-  #   • ZWO inline-string parsing — ImporterWorkoutZwo exercised with XML
-  #     strings embedded in the source (no external files); covers Warmup,
-  #     SteadyState, Cooldown, IntervalsT expansion, FreeRide, edge cases.
-  #   • Labelled 1280×720 screenshots uploaded as build evidence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_ui_screens:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install X11 runtime dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          xvfb \
-          libxcb-cursor0 \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6 \
-          libgl1-mesa-dev
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/ui_screens_tests
-
-    - name: Run UI screens test with Xvfb
-      run: |
-        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
-        Xvfb :99 -screen 0 1280x800x24 &
-        sleep 1
-        export DISPLAY=:99
-        ./build/tests/ui_screens_tests -v2
-
-    - name: Upload UI screens screenshots
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: ui-screens-screenshots-linux
-        path: build/tests/ui-screens-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout I/O Tests – Linux
-  #
-  # Runs the workout I/O test suite (tst_workout_io.cpp):
-  #   • ZWO import from inline XML strings (SteadyState, Ramp, IntervalsT,
-  #     FreeRide, mixed, name extraction, edge cases).
-  #   • Intervals.icu mock JSON → ZWO → Workout model workflow.
-  #   • XmlUtil round-trip (createWorkoutXml + parseSingleWorkoutXml) for
-  #     interval count, power, duration, and plan fields.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_io:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install runtime dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y \
-          libfontconfig1 \
-          libxrender1 \
-          libxext6
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_io_tests
-
-    - name: Run workout I/O tests
-      run: |
-        export LD_LIBRARY_PATH="$PWD/build/qwtlib:$LD_LIBRARY_PATH"
-        QT_QPA_PLATFORM=offscreen ./build/tests/workout_io_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Creator Tests – Linux
-  #
-  # Runs the workout creator test suite (tst_workout_creator.cpp):
-  #   • Constructs Workout objects from Interval domain objects (Warmup,
-  #     SteadyState/FLAT, Cooldown) and verifies count, step types, power
-  #     values, durations, cadence, metadata, and total duration.
-  #   • Computed metrics (averagePower) verified for flat and mixed workouts.
-  #   • Edge cases: FTP=0, empty list, single interval, 10×on/off, cadence
-  #     range, testInterval flag.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_creator:
-    runs-on: ubuntu-22.04
-    needs: build_linux
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: linux
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_creator_tests
-
-    - name: Run workout creator tests
-      run: ./build/tests/workout_creator_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Strava Service Unit Tests – Linux
-  #
-  # Builds and runs all three offline service test suites.  These tests use
-  # a mock network manager and do not require real API credentials.
-  #
-  # Optional live tests are gated behind GitHub Secrets and QSKIP gracefully
-  # when the relevant secret is absent.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_third_party_services:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    env:
-      STRAVA_ACCESS_TOKEN: ${{ secrets.STRAVA_ACCESS_TOKEN }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build Strava service tests
-      run: |
-        mkdir -p build/tests
-        cd tests/strava
-        qmake strava_tests.pro
-        make -j$(nproc)
-
-    - name: Run Strava service tests
-      run: ./build/tests/strava_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # CredentialStore Unit Tests – Linux
-  #
-  # Tests the AES-256-GCM CredentialStore backend (Linux only).
-  # The roundtrip, overwrite, remove, missing-key, multi-service, empty-value,
-  # and special-character tests all execute without any external dependencies.
-  # Requires libssl-dev.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_credential_store:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libssl-dev
-
-    - name: Build CredentialStore tests
-      run: |
-        mkdir -p build/tests
-        cd tests/credential_store
-        qmake credential_store_tests.pro
-        make -j$(nproc)
-
-    - name: Run CredentialStore tests
-      run: ./build/tests/credential_store_tests -v2
-
-  test_plan_adherence:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build PlanAdherence tests
-      run: |
-        mkdir -p build/tests
-        cd tests/plan_adherence
-        qmake plan_adherence_tests.pro
-        make -j$(nproc)
-
-    - name: Run PlanAdherence tests
-      run: ./build/tests/plan_adherence_tests -v2
-
-  test_history:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        cache: true
-        cache-key-prefix: qt-linux
-
-    - name: Build History tests
-      run: |
-        mkdir -p build/tests
-        cd tests/history
-        qmake history_tests.pro
-        make -j$(nproc)
-
-    - name: Run History tests
-      run: ./build/tests/history_tests -v2
+          build/tests/online-mode-linux-*.png
+          build/tests/workout-ui-linux-*.png
+          build/tests/*-linux-*.png

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -61,8 +61,25 @@ jobs:
           /usr/local/qwt-6.3.0/mkspecs
         key: qwt-6.3.0-qt-6.11.1-macos-nodoc
 
+    - name: Validate QWT cache
+      id: qwt-validate
+      # A corrupted cache extraction can leave a partial tree behind while the
+      # action still reports a cache hit (gtar errors mid-restore have been
+      # seen on macOS runners). Verify the pieces the build links against and
+      # the qmake feature file; rebuild otherwise.
+      run: |
+        if [ "${{ steps.qwt-cache.outputs.cache-hit }}" = "true" ] && \
+           [ -f /usr/local/qwt-6.3.0/lib/libqwt.6.dylib ] && \
+           [ -f /usr/local/qwt-6.3.0/include/qwt_plot.h ] && \
+           [ -f /usr/local/qwt-6.3.0/features/qwt.prf ]; then
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          sudo rm -rf /usr/local/qwt-6.3.0
+        fi
+
     - name: Build and install QWT
-      if: steps.qwt-cache.outputs.cache-hit != 'true'
+      if: steps.qwt-validate.outputs.ok != 'true'
       run: |
         # Remove any pre-installed Homebrew qwt that could shadow our headers
         brew uninstall qwt --force --ignore-dependencies 2>/dev/null || true
@@ -251,10 +268,17 @@ jobs:
         install_name_tool -add_rpath $(brew --prefix openssl@3)/lib build/tests/ui_navigation_tests
 
     - name: upload artifact
+      # Exclude compile intermediates (~3/4 of build/): the test and release
+      # jobs only need the binaries, and every one of them downloads this.
       uses: actions/upload-artifact@v4
       with:
         name: macos
-        path: build/
+        path: |
+          build/
+          !build/release/.obj/**
+          !build/release/.moc/**
+          !build/release/.qrc/**
+          !build/release/.u/**
 
   # ──────────────────────────────────────────────────────────────────────────
   # Headless Test Suites (macOS) — consolidated (#352)

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -257,151 +257,16 @@ jobs:
         path: build/
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Runtime Validation – macOS
+  # Headless Test Suites (macOS) — consolidated (#352)
   #
-  # Verifies that the application UI initialises to a "Ready" state on macOS:
-  #   • Bluetooth stack is queryable (API returns "Not Found", not "Unsupported")
-  #   • All four sensor channels carry realistic values within 10 seconds
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence
+  # One runner and ONE Qt installation for every suite that needs no window:
+  # BLE API smoke, workout I/O, workout creator, workout parsing
+  # (secrets-gated cases QSKIP without credentials), and the self-built live
+  # Intervals.icu integration suite.
   # ──────────────────────────────────────────────────────────────────────────
-  test_runtime_validation:
+  test_headless_suites:
     runs-on: macos-latest
     needs: build_mac
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/runtime_validation_tests
-
-    - name: Run runtime validation test
-      run: ./build/tests/runtime_validation_tests -v2
-
-    - name: Upload runtime validation screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: runtime-validation-screenshot-macos
-        path: build/tests/screenshot-macos-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # BLE API Smoke Test – macOS
-  #
-  # Exercises the real BtleHub → QLowEnergyController code path on macOS.
-  # Uses CoreBluetooth; on CI runners with no BT hardware the test QSKIP
-  # gracefully.  No display required (headless Qt Test binary).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_btle_api:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt (with Bluetooth)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        modules: 'qtconnectivity'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/btle_api_tests
-
-    - name: Run BLE API smoke test
-      run: ./build/tests/btle_api_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Offline Mode Integration Test – macOS
-  #
-  # Verifies that MaximumTrainer's core offline functionality works on macOS
-  # without a network connection and without physical Bluetooth hardware:
-  #   • Local workout XML files can be created and parsed from disk.
-  #   • SimulatorHub broadcasts realistic CSC (0x1816) and Power (0x1818)
-  #     cycling data (cadence, speed, power) within expected ranges.
-  #   • A labelled 1280×720 screenshot is captured showing the offline mode
-  #     indicator and live BTLE sensor metrics.
-  #   • Accumulated data points are written to a TSV activity file,
-  #     confirming offline data persistence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_offline_mode:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/offline_mode_tests
-
-    - name: Run offline mode test
-      run: ./build/tests/offline_mode_tests -v2
-
-    - name: Upload offline mode screenshot and activity file
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: offline-mode-artefacts-macos
-        path: |
-          build/tests/offline-mode-macos-*.png
-          build/tests/activity-macos-*.tsv
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Intervals.icu Live Integration Tests – macOS
-  #
-  # Makes real HTTP requests to https://intervals.icu/api/v1 using the shared
-  # test account.  Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # Tests call QSKIP gracefully when either secret is absent (fork PRs, local
-  # development without credentials).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_intervals_icu_integration:
-    runs-on: macos-latest
     permissions:
       contents: read
     env:
@@ -414,20 +279,46 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Qt (qtbase only)
+    - name: Install Qt (with Bluetooth)
       uses: jurplel/install-qt-action@v3
       with:
         version: '6.11.1'
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'
+        modules: 'qtconnectivity'
         cache: true
         cache-key-prefix: qt-mac
 
     - name: Install OpenSSL
       run: brew install openssl@3
 
-    - name: Build integration tests
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: macos
+        path: build
+
+    - name: Make test binaries executable
+      run: |
+        chmod +x build/tests/btle_api_tests \
+                 build/tests/workout_io_tests \
+                 build/tests/workout_creator_tests \
+                 build/tests/workout_parsing_tests
+
+    - name: BLE API smoke test
+      run: ./build/tests/btle_api_tests -v2
+
+    - name: Workout I/O tests
+      run: ./build/tests/workout_io_tests -v2
+
+    - name: Workout creator tests
+      run: ./build/tests/workout_creator_tests -v2
+
+    - name: Workout parsing tests
+      run: ./build/tests/workout_parsing_tests -v2
+
+    - name: Build Intervals.icu live integration tests
       run: |
         mkdir -p build/tests
         cd tests/intervals_icu_integration
@@ -436,7 +327,7 @@ jobs:
           QMAKE_CXXFLAGS+="-I$(brew --prefix openssl@3)/include"
         make -j$(sysctl -n hw.logicalcpu)
 
-    - name: Run Intervals.icu integration tests
+    - name: Run Intervals.icu live integration tests
       run: |
         # Live test against intervals.icu: retry transient network/API blips
         # before failing the job. -o writes results to a file we echo into the
@@ -459,227 +350,21 @@ jobs:
         exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Online Mode Authentication Test – macOS
+  # GUI Integration Tests (macOS) — consolidated (#352)
   #
-  # Simulates a user authenticating into the running application on macOS.
-  # A 1280x720 window is shown, a live HTTPS authentication request is made
-  # to https://intervals.icu/api/v1 using credentials from GitHub Secrets,
-  # and the result is displayed in the window and captured as a screenshot.
-  #
-  # Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # The test calls QSKIP gracefully when either secret is absent (fork PRs,
-  # local development without credentials).
+  # One runner and ONE Qt installation for the windowed suites that need no
+  # secrets: runtime validation, offline mode, UI screens, and UI navigation
+  # (which launches the real MaximumTrainer.app). Screenshot evidence from
+  # every suite is uploaded as one artifact.
   # ──────────────────────────────────────────────────────────────────────────
-  test_online_mode:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt (core + network + widgets for test binary)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Install OpenSSL
-      run: brew install openssl@3
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/online_mode_tests
-
-    - name: Run online mode authentication test
-      run: ./build/tests/online_mode_tests -v2
-
-    - name: Upload online mode screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: online-mode-screenshot-macos
-        path: build/tests/online-mode-macos-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Login Screen Full-Application Test – macOS
-  #
-  # Validates that a user can log into MaximumTrainer and access key
-  # functionality without error on macOS:
-  #   • Offline login path: account setup logic is exercised end-to-end and
-  #     SimulatorHub confirms all four sensor channels (HR, cadence, speed,
-  #     power) carry realistic values once logged in.
-  #   • Intervals.icu OAuth URL: the OAuth2 authorization URL built by
-  #     Environnement is validated for all required parameters (client_id,
-  #     response_type, scope, redirect_uri, state).
-  #   • Intervals.icu API login (optional): a real HTTPS request is made to
-  #     intervals.icu/api/v1 using secrets when available; QSKIP otherwise.
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_login_screen:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt (core + network + widgets + bluetooth for test binary)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        modules: 'qtwebengine qtconnectivity qtwebchannel qtpositioning'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/login_screen_tests
-
-    - name: Run login screen test
-      run: ./build/tests/login_screen_tests -v2
-
-    - name: Upload login screen screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: login-screen-screenshot-macos
-        path: build/tests/*-macos-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout UI Integration Test – macOS
-  #
-  # Validates the end-to-end workout pipeline on macOS, including:
-  #   • User login (offline path)
-  #   • Workout XML creation and retrieval (round-trip, lightweight schema)
-  #   • Workout model construction and field verification (Workout / Interval)
-  #   • Workout XML round-trip via XmlUtil::createWorkoutXml + parseSingleWorkoutXml
-  #   • Workout average-power metric (getAveragePower)
-  #   • ERG simulation: setLoad and setSlope drive SimulatorHub to the
-  #     correct power target without physical Bluetooth hardware
-  #   • Workout session lifecycle: start / pause / resume / stop with data
-  #     accumulation across all four sensor channels
-  #   • Interval advancement: ERG target changes at each interval boundary
-  #   • Power-on-target: actual power stays within ±25 % of ERG target
-  #   • Network connectivity: HTTPS GET to intervals.icu/api/v1 (QSKIP when
-  #     credentials absent)
-  #   • Network workout retrieval: GET /athlete/{id}/workouts returns a JSON
-  #     array (QSKIP when credentials absent)
-  #   • A labelled 1280×720 screenshot with QWT power-curve plot is captured
-  #     as visual build evidence
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_ui:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Install OpenSSL
-      run: brew install openssl@3
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_ui_tests
-
-    - name: Run workout UI test
-      run: ./build/tests/workout_ui_tests -v2
-
-    - name: Upload workout UI screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: workout-ui-screenshot-macos
-        path: build/tests/workout-ui-macos-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Parsing Tests – macOS
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_parsing:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_parsing_tests
-
-    - name: Run workout parsing tests
-      run: ./build/tests/workout_parsing_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # UI Navigation Tests – macOS
-  # ──────────────────────────────────────────────────────────────────────────
-  test_ui_navigation:
+  test_gui:
     runs-on: macos-latest
     needs: build_mac
     permissions:
       contents: read
 
     steps:
-    - name: Install Qt (core + widgets + bluetooth + webengine for app binary)
+    - name: Install Qt (full app modules)
       uses: jurplel/install-qt-action@v3
       with:
         version: '6.11.1'
@@ -698,45 +383,72 @@ jobs:
 
     - name: Make binaries executable
       run: |
-        chmod +x build/tests/ui_navigation_tests
-        chmod +x build/release/MaximumTrainer.app/Contents/MacOS/MaximumTrainer
+        chmod +x build/tests/runtime_validation_tests \
+                 build/tests/offline_mode_tests \
+                 build/tests/ui_screens_tests \
+                 build/tests/ui_navigation_tests \
+                 build/release/MaximumTrainer.app/Contents/MacOS/MaximumTrainer
 
-    - name: Run UI navigation tests
+    - name: Runtime validation test
+      run: ./build/tests/runtime_validation_tests -v2
+
+    - name: Offline mode test
+      run: ./build/tests/offline_mode_tests -v2
+
+    - name: UI screens test
+      run: ./build/tests/ui_screens_tests -v2
+
+    - name: UI navigation tests
       # MT_NO_NETWORK=1 disables all outbound network calls in the launched
       # MaximumTrainer binary (radio list, session check, Intervals.icu, etc.).
       # The child process inherits this variable from QProcess automatically.
-      # Remove or set to 0 when running locally to keep network enabled.
       env:
         MT_NO_NETWORK: "1"
       run: ./build/tests/ui_navigation_tests -v2
 
-    - name: Upload UI navigation screenshots
+    - name: Upload GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ui-navigation-screenshots-macos
+        name: gui-test-artifacts-macos
         path: |
+          build/tests/screenshot-macos-*.png
+          build/tests/offline-mode-macos-*.png
+          build/tests/activity-macos-*.tsv
+          build/tests/ui-screens-*.png
           build/tests/app-journey-*/
 
   # ──────────────────────────────────────────────────────────────────────────
-  # UI Screens Tests – macOS
+  # Live GUI Tests (macOS + Intervals.icu secrets) — consolidated (#352)
+  #
+  # The three windowed suites that talk to the live intervals.icu API: online
+  # mode, workout UI, and the login screen full-application journey. Kept
+  # separate from test_gui so a flaky live run retries cheaply. Tests QSKIP
+  # gracefully when the secrets are absent (fork PRs).
   # ──────────────────────────────────────────────────────────────────────────
-  test_ui_screens:
+  test_gui_live:
     runs-on: macos-latest
     needs: build_mac
     permissions:
       contents: read
+    env:
+      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
+      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
 
     steps:
-    - name: Install Qt
+    - name: Install Qt (with WebEngine + Bluetooth)
       uses: jurplel/install-qt-action@v3
       with:
         version: '6.11.1'
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'
+        modules: 'qtwebengine qtconnectivity qtwebchannel qtpositioning'
         cache: true
         cache-key-prefix: qt-mac
+
+    - name: Install OpenSSL
+      run: brew install openssl@3
 
     - name: Download build artifact
       uses: actions/download-artifact@v4
@@ -744,79 +456,27 @@ jobs:
         name: macos
         path: build
 
-    - name: Make test binary executable
-      run: chmod +x build/tests/ui_screens_tests
+    - name: Make test binaries executable
+      run: |
+        chmod +x build/tests/online_mode_tests \
+                 build/tests/workout_ui_tests \
+                 build/tests/login_screen_tests
 
-    - name: Run UI screens test
-      run: ./build/tests/ui_screens_tests -v2
+    - name: Online mode authentication test
+      run: ./build/tests/online_mode_tests -v2
 
-    - name: Upload UI screens screenshots
+    - name: Workout UI test
+      run: ./build/tests/workout_ui_tests -v2
+
+    - name: Login screen test
+      run: ./build/tests/login_screen_tests -v2
+
+    - name: Upload live GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ui-screens-screenshots-macos
-        path: build/tests/ui-screens-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout I/O Tests – macOS
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_io:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_io_tests
-
-    - name: Run workout I/O tests
-      run: ./build/tests/workout_io_tests -v2
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Creator Tests – macOS
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_creator:
-    runs-on: macos-latest
-    needs: build_mac
-    permissions:
-      contents: read
-
-    steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '6.11.1'
-        host: 'mac'
-        target: 'desktop'
-        arch: 'clang_64'
-        cache: true
-        cache-key-prefix: qt-mac
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: macos
-        path: build
-
-    - name: Make test binary executable
-      run: chmod +x build/tests/workout_creator_tests
-
-    - name: Run workout creator tests
-      run: ./build/tests/workout_creator_tests -v2
+        name: gui-live-test-artifacts-macos
+        path: |
+          build/tests/online-mode-macos-*.png
+          build/tests/workout-ui-macos-*.png
+          build/tests/*-macos-*.png

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -335,13 +335,22 @@ jobs:
         jom /J $env:NUMBER_OF_PROCESSORS
       shell: powershell
 
+    - name: Build Intervals.icu live integration test
+      run: |
+        New-Item -ItemType Directory -Force -Path build\tests | Out-Null
+        Set-Location tests\intervals_icu_integration
+        qmake intervals_icu_integration_tests.pro
+        jom /J $env:NUMBER_OF_PROCESSORS
+      shell: powershell
+
     - name: Deploy Qt for test binaries
       run: |
         $tests = @(
           "runtime_validation_tests", "btle_api_tests", "offline_mode_tests",
           "online_mode_tests", "login_screen_tests", "workout_ui_tests",
           "workout_parsing_tests", "ui_navigation_tests", "ui_screens_tests",
-          "workout_io_tests", "workout_creator_tests"
+          "workout_io_tests", "workout_creator_tests",
+          "intervals_icu_integration_tests"
         )
         foreach ($t in $tests) {
           $exe = "build\tests\$t.exe"
@@ -396,113 +405,17 @@ jobs:
         path: build\
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Runtime Validation – Windows
+  # Headless Test Suites (Windows) — consolidated (#352)
   #
-  # Verifies that the application UI initialises to a "Ready" state on Windows:
-  #   • Bluetooth stack is queryable (API returns "Not Found", not "Unsupported")
-  #   • All four sensor channels carry realistic values within 10 seconds
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence
+  # One runner for every suite that needs no window, running the pre-built,
+  # windeployqt'd binaries from the build artifact — no Qt installation at
+  # all in this job. Covers BLE API smoke, workout I/O, workout creator,
+  # workout parsing, and the live Intervals.icu integration suite
+  # (secrets-gated cases QSKIP without credentials).
   # ──────────────────────────────────────────────────────────────────────────
-  test_runtime_validation:
+  test_headless_suites:
     runs-on: windows-latest
     needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run runtime validation test
-      run: .\build\tests\runtime_validation_tests.exe -v2
-      shell: powershell
-
-    - name: Upload runtime validation screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: runtime-validation-screenshot-windows
-        path: build\tests\screenshot-windows-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # BLE API Smoke Test – Windows
-  #
-  # Exercises the real BtleHub → QLowEnergyController code path on Windows.
-  # Uses the WinRT Bluetooth stack; on CI runners with no BT adapter the test
-  # QSKIP gracefully.  No display required (headless Qt Test binary).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_btle_api:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run BLE API smoke test
-      run: .\build\tests\btle_api_tests.exe -v2
-      shell: powershell
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Offline Mode Integration Test – Windows
-  #
-  # Verifies that MaximumTrainer's core offline functionality works on Windows
-  # without a network connection and without physical Bluetooth hardware:
-  #   • Local workout XML files can be created and parsed from disk.
-  #   • SimulatorHub broadcasts realistic CSC (0x1816) and Power (0x1818)
-  #     cycling data (cadence, speed, power) within expected ranges.
-  #   • A labelled 1280×720 screenshot is captured showing the offline mode
-  #     indicator and live BTLE sensor metrics.
-  #   • Accumulated data points are written to a TSV activity file,
-  #     confirming offline data persistence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_offline_mode:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run offline mode test
-      run: .\build\tests\offline_mode_tests.exe -v2
-      shell: powershell
-
-    - name: Upload offline mode screenshot and activity file
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: offline-mode-artefacts-windows
-        path: |
-          build\tests\offline-mode-windows-*.png
-          build\tests\activity-windows-*.tsv
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Intervals.icu Live Integration Tests – Windows
-  #
-  # Makes real HTTP requests to https://intervals.icu/api/v1 using the shared
-  # test account.  Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # Tests call QSKIP gracefully when either secret is absent (fork PRs, local
-  # development without credentials).
-  # ──────────────────────────────────────────────────────────────────────────
-  test_intervals_icu_integration:
-    runs-on: windows-latest
     permissions:
       contents: read
     env:
@@ -510,91 +423,29 @@ jobs:
       INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
 
     steps:
-    - name: MSVC Environment Setup
-      uses: ilammy/msvc-dev-cmd@v1
-
-    - name: Checkout
-      uses: actions/checkout@v4
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
       with:
-        fetch-depth: 0
+        name: windows
+        path: build
 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: ${{ env.QT_VERSION }}
-        # Released aqt can't resolve Qt 6.11's new Windows repo layout (aqtinstall
-        # #959); use git master until a fixed release ships.
-        aqtversion: ' @ git+https://github.com/miurahr/aqtinstall.git@master'
-        arch: win64_msvc2022_64
-        dir: 'C:\Qt'
-        cache: true
-        cache-key-prefix: qt-win
-
-    - name: Set QTDIR
-      run: echo "QTDIR=C:\Qt\Qt\${{ env.QT_VERSION }}\msvc2022_64" >> $env:GITHUB_ENV
+    - name: BLE API smoke test
+      run: .\build\tests\btle_api_tests.exe -v2
       shell: powershell
 
-    - name: Install jom
-      shell: pwsh
-      run: |
-        # Chocolatey's CDN occasionally returns a 504 and then exits 0 with
-        # "Chocolatey installed 0/0 packages" — leaving jom missing, which only
-        # surfaces later as "jom : not recognized" in a build step. Retry until
-        # jom.exe actually exists, fail fast if it never does, and pin it on PATH.
-        $jom = "C:\ProgramData\chocolatey\bin\jom.exe"
-        for ($i = 1; $i -le 5 -and -not (Test-Path $jom); $i++) {
-          if ($i -gt 1) { Start-Sleep -Seconds 15 }
-          Write-Host "Installing jom (attempt $i)..."
-          choco install jom -y --no-progress
-        }
-        if (-not (Test-Path $jom)) {
-          throw "jom failed to install after 5 attempts (Chocolatey source issue)"
-        }
-        "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-
-    - name: Restore OpenSSL cache
-      id: openssl-cache
-      uses: actions/cache@v4
-      with:
-        path: C:\openssl
-        key: openssl-3.5.4-win64
-
-    - name: Download OpenSSL 3
-      if: steps.openssl-cache.outputs.cache-hit != 'true'
-      run: |
-        curl.exe -L -o "$env:TEMP\openssl.zip" "https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.4.zip"
-        Expand-Archive -Path "$env:TEMP\openssl.zip" -DestinationPath "C:\openssl" -Force
+    - name: Workout I/O tests
+      run: .\build\tests\workout_io_tests.exe -v2
       shell: powershell
 
-    - name: Set OPENSSL_BIN
-      run: |
-        $dll = Get-ChildItem "C:\openssl" -Recurse -Filter "libssl-3-x64.dll" |
-               Select-Object -First 1
-        if (-not $dll) { Write-Error "libssl-3-x64.dll not found in C:\openssl"; exit 1 }
-        echo "OPENSSL_BIN=$($dll.DirectoryName)" >> $env:GITHUB_ENV
+    - name: Workout creator tests
+      run: .\build\tests\workout_creator_tests.exe -v2
       shell: powershell
 
-    - name: Build integration tests
-      run: |
-        New-Item -ItemType Directory -Force -Path build\tests | Out-Null
-        Set-Location tests\intervals_icu_integration
-        qmake intervals_icu_integration_tests.pro
-        jom /J $env:NUMBER_OF_PROCESSORS
+    - name: Workout parsing tests
+      run: .\build\tests\workout_parsing_tests.exe -v2
       shell: powershell
 
-    - name: Deploy Qt DLLs for test binary
-      run: |
-        & "$env:QTDIR\bin\windeployqt.exe" --release `
-            --no-translations `
-            --no-system-d3d-compiler `
-            build\tests\intervals_icu_integration_tests.exe
-        foreach ($dll in @("libssl-3-x64.dll", "libcrypto-3-x64.dll")) {
-          $src = "$env:OPENSSL_BIN\$dll"
-          if (Test-Path $src) { Copy-Item $src "build\tests\" -Force }
-        }
-      shell: powershell
-
-    - name: Run Intervals.icu integration tests
+    - name: Run Intervals.icu live integration tests
       shell: powershell
       run: |
         # Live test against intervals.icu: retry transient network/API blips
@@ -616,28 +467,19 @@ jobs:
         exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Online Mode Authentication Test – Windows
+  # GUI Integration Tests (Windows) — consolidated (#352)
   #
-  # Simulates a user authenticating into the running application on Windows.
-  # A 1280x720 window is shown, a live HTTPS authentication request is made
-  # to https://intervals.icu/api/v1 using credentials from GitHub Secrets,
-  # and the result is displayed in the window and captured as a screenshot.
-  #
-  # Requires GitHub Secrets to be configured:
-  #   INTERVALS_ICU_API_KEY    – personal API key (intervals.icu Settings → API)
-  #   INTERVALS_ICU_ATHLETE_ID – athlete ID, e.g. i12345
-  #
-  # The test calls QSKIP gracefully when either secret is absent (fork PRs,
-  # local development without credentials).
+  # One runner for the windowed suites that need no secrets, running the
+  # pre-built binaries from the build artifact (no Qt installation): runtime
+  # validation, offline mode, UI screens, and UI navigation (which launches
+  # the real MaximumTrainer.exe). Screenshot evidence from every suite is
+  # uploaded as one artifact.
   # ──────────────────────────────────────────────────────────────────────────
-  test_online_mode:
+  test_gui:
     runs-on: windows-latest
     needs: build_windows
     permissions:
       contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
 
     steps:
     - name: Download build artifact
@@ -646,168 +488,22 @@ jobs:
         name: windows
         path: build
 
-    - name: Run online mode authentication test
-      run: .\build\tests\online_mode_tests.exe -v2
+    - name: Runtime validation test
+      run: .\build\tests\runtime_validation_tests.exe -v2
       shell: powershell
 
-    - name: Upload online mode screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: online-mode-screenshot-windows
-        path: build\tests\online-mode-windows-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Login Screen Full-Application Test – Windows
-  #
-  # Validates that a user can log into MaximumTrainer and access key
-  # functionality without error on Windows (the OS reported in the original
-  # login-screen bug):
-  #   • Offline login path: account setup logic is exercised end-to-end and
-  #     SimulatorHub confirms all four sensor channels (HR, cadence, speed,
-  #     power) carry realistic values once logged in.
-  #   • Intervals.icu OAuth URL: the OAuth2 authorization URL built by
-  #     Environnement is validated for all required parameters (client_id,
-  #     response_type, scope, redirect_uri, state).
-  #   • Intervals.icu API login (optional): a real HTTPS request is made to
-  #     intervals.icu/api/v1 using secrets when available; QSKIP otherwise.
-  #   • A labelled 1280×720 screenshot is captured as visual build evidence.
-  # ──────────────────────────────────────────────────────────────────────────
-  test_login_screen:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run login screen test
-      run: |
-        # Use QTest's -o flag to capture output to file — Tee-Object does not
-        # work for Win32 GUI subsystem apps (no console stdout).
-        .\build\tests\login_screen_tests.exe -v2 -o build\tests\login-screen-test-output.txt,txt
-        exit $LASTEXITCODE
+    - name: Offline mode test
+      run: .\build\tests\offline_mode_tests.exe -v2
       shell: powershell
 
-    - name: Upload login screen screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: login-screen-screenshot-windows
-        path: |
-          build\tests\*-windows-*.png
-          build\tests\*dialoglogin*-windows-*.png
-          build\tests\login-screen-test-output.txt
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout UI Integration Test – Windows
-  #
-  # Validates the end-to-end workout pipeline on Windows, including:
-  #   • User login (offline path)
-  #   • Workout XML creation and retrieval (round-trip, lightweight schema)
-  #   • Workout model construction and field verification (Workout / Interval)
-  #   • Workout XML round-trip via XmlUtil::createWorkoutXml + parseSingleWorkoutXml
-  #   • Workout average-power metric (getAveragePower)
-  #   • ERG simulation: setLoad and setSlope drive SimulatorHub to the
-  #     correct power target without physical Bluetooth hardware
-  #   • Workout session lifecycle: start / pause / resume / stop with data
-  #     accumulation across all four sensor channels
-  #   • Interval advancement: ERG target changes at each interval boundary
-  #   • Power-on-target: actual power stays within ±25 % of ERG target
-  #   • Network connectivity: HTTPS GET to intervals.icu/api/v1 (QSKIP when
-  #     credentials absent)
-  #   • Network workout retrieval: GET /athlete/{id}/workouts returns a JSON
-  #     array (QSKIP when credentials absent)
-  #   • A labelled 1280×720 screenshot with QWT power-curve plot is captured
-  #     as visual build evidence
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_ui:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    # QTest stdout from Windows GUI-subsystem processes is not reliably
-    # captured by the runner; write results to a file and print it so
-    # failures are diagnosable from the log.
-    - name: Run workout UI test
-      run: |
-        .\build\tests\workout_ui_tests.exe -v2 -o workout_ui_results.txt,txt
-        $code = $LASTEXITCODE
-        Write-Host "QTest exit code: $code"
-        if (Test-Path workout_ui_results.txt) { Get-Content workout_ui_results.txt }
-        exit $code
+    - name: UI screens test
+      run: .\build\tests\ui_screens_tests.exe -v2
       shell: powershell
 
-    - name: Upload workout UI screenshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: workout-ui-screenshot-windows
-        path: build\tests\workout-ui-windows-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Parsing Tests – Windows
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_parsing:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-    env:
-      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
-      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run workout parsing tests
-      run: .\build\tests\workout_parsing_tests.exe -v2
-      shell: powershell
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # UI Navigation Tests – Windows
-  # ──────────────────────────────────────────────────────────────────────────
-  test_ui_navigation:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run UI navigation tests
+    - name: UI navigation tests
       # MT_NO_NETWORK=1 disables all outbound network calls in the launched
       # MaximumTrainer binary (radio list, session check, Intervals.icu, etc.).
       # The child process inherits this variable from QProcess automatically.
-      # Remove or set to 0 when running locally to keep network enabled.
       env:
         MT_NO_NETWORK: "1"
       run: |
@@ -817,7 +513,7 @@ jobs:
         exit $LASTEXITCODE
       shell: powershell
 
-    - name: Print test output
+    - name: Print UI navigation test output
       if: always()
       shell: powershell
       run: |
@@ -827,23 +523,35 @@ jobs:
           Get-Content $logPath
         }
 
-    - name: Upload UI navigation screenshots and log
+    - name: Upload GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ui-navigation-screenshots-windows
+        name: gui-test-artifacts-windows
         path: |
+          build\tests\screenshot-windows-*.png
+          build\tests\offline-mode-windows-*.png
+          build\tests\activity-windows-*.tsv
+          build\tests\ui-screens-*.png
           build\tests\app-journey-*\
           build\tests\ui-navigation-test-output.txt
 
   # ──────────────────────────────────────────────────────────────────────────
-  # UI Screens Tests – Windows
+  # Live GUI Tests (Windows + Intervals.icu secrets) — consolidated (#352)
+  #
+  # The three windowed suites that talk to the live intervals.icu API: online
+  # mode, workout UI, and the login screen full-application journey. Kept
+  # separate from test_gui so a flaky live run retries cheaply. Tests QSKIP
+  # gracefully when the secrets are absent (fork PRs).
   # ──────────────────────────────────────────────────────────────────────────
-  test_ui_screens:
+  test_gui_live:
     runs-on: windows-latest
     needs: build_windows
     permissions:
       contents: read
+    env:
+      INTERVALS_ICU_API_KEY:    ${{ secrets.INTERVALS_ICU_API_KEY }}
+      INTERVALS_ICU_ATHLETE_ID: ${{ secrets.INTERVALS_ICU_ATHLETE_ID }}
 
     steps:
     - name: Download build artifact
@@ -852,53 +560,37 @@ jobs:
         name: windows
         path: build
 
-    - name: Run UI screens test
-      run: .\build\tests\ui_screens_tests.exe -v2
+    - name: Online mode authentication test
+      run: .\build\tests\online_mode_tests.exe -v2
       shell: powershell
 
-    - name: Upload UI screens screenshots
+    # QTest stdout from Windows GUI-subsystem processes is not reliably
+    # captured by the runner; write results to a file and print it so
+    # failures are diagnosable from the log.
+    - name: Workout UI test
+      run: |
+        .\build\tests\workout_ui_tests.exe -v2 -o workout_ui_results.txt,txt
+        $code = $LASTEXITCODE
+        Write-Host "QTest exit code: $code"
+        if (Test-Path workout_ui_results.txt) { Get-Content workout_ui_results.txt }
+        exit $code
+      shell: powershell
+
+    - name: Login screen test
+      run: |
+        # Use QTest's -o flag to capture output to file — Tee-Object does not
+        # work for Win32 GUI subsystem apps (no console stdout).
+        .\build\tests\login_screen_tests.exe -v2 -o build\tests\login-screen-test-output.txt,txt
+        exit $LASTEXITCODE
+      shell: powershell
+
+    - name: Upload live GUI test evidence
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ui-screens-screenshots-windows
-        path: build\tests\ui-screens-*.png
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout I/O Tests – Windows
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_io:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run workout I/O tests
-      run: .\build\tests\workout_io_tests.exe -v2
-      shell: powershell
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Workout Creator Tests – Windows
-  # ──────────────────────────────────────────────────────────────────────────
-  test_workout_creator:
-    runs-on: windows-latest
-    needs: build_windows
-    permissions:
-      contents: read
-
-    steps:
-    - name: Download build artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: windows
-        path: build
-
-    - name: Run workout creator tests
-      run: .\build\tests\workout_creator_tests.exe -v2
-      shell: powershell
+        name: gui-live-test-artifacts-windows
+        path: |
+          build\tests\online-mode-windows-*.png
+          build\tests\workout-ui-windows-*.png
+          build\tests\*-windows-*.png
+          build\tests\login-screen-test-output.txt

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -115,11 +115,27 @@ jobs:
         path: ${{ env.QWT_INSTALL_DIR }}
         key: qwt-6.3.0-qt-${{ env.QT_VERSION }}-msvc2022-win64
 
+    - name: Validate QWT cache
+      id: qwt-validate
+      shell: powershell
+      # A corrupted cache extraction can leave a partial tree behind while the
+      # action still reports a cache hit. Verify the pieces the build links
+      # against; rebuild otherwise.
+      run: |
+        if (("${{ steps.qwt-cache.outputs.cache-hit }}" -eq "true") -and
+            (Test-Path "$env:QWT_INSTALL_DIR\lib\qwt.dll") -and
+            (Test-Path "$env:QWT_INSTALL_DIR\include\qwt_plot.h")) {
+          "ok=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        } else {
+          "ok=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          if (Test-Path $env:QWT_INSTALL_DIR) { Remove-Item -Recurse -Force $env:QWT_INSTALL_DIR }
+        }
+
     - name: Build QWT
       # No QWT apt/Qt6 binary package exists, so build 6.3.0 from source against
       # the installed Qt6 and install it to QWT_INSTALL_DIR. MaximumTrainer.pro is
       # pointed at this location via QWT_INSTALL=... .
-      if: steps.qwt-cache.outputs.cache-hit != 'true'
+      if: steps.qwt-validate.outputs.ok != 'true'
       run: |
         $qwtInstallDirFwd = $env:QWT_INSTALL_DIR -replace '\\', '/'
         Set-Location ..
@@ -399,10 +415,18 @@ jobs:
       shell: powershell
 
     - name: Upload artifact
+      # Exclude compile intermediates (~3/4 of build/): the test and release
+      # jobs only need the binaries and deployed DLLs, and every one of them
+      # downloads this.
       uses: actions/upload-artifact@v4
       with:
         name: windows
-        path: build\
+        path: |
+          build/
+          !build/release/.obj/**
+          !build/release/.moc/**
+          !build/release/.qrc/**
+          !build/release/.u/**
 
   # ──────────────────────────────────────────────────────────────────────────
   # Headless Test Suites (Windows) — consolidated (#352)

--- a/agents.md
+++ b/agents.md
@@ -449,42 +449,39 @@ npx playwright test
 ```
 Push to branch
       │
-      ├─► build_linux ──► test_btle_unit              (51 unit tests)
-      │                ├─► test_btle_integration       (Xvfb, screenshot)
-      │                ├─► test_btle_api               (BLE adapter smoke)
-      │                ├─► test_runtime_validation     (Qt/BLE/DB/FIT checks)
-      │                ├─► test_offline_mode           (Xvfb, screenshot)
-      │                ├─► test_login_screen           (Xvfb, screenshot)
-      │                ├─► test_workout_ui             (Xvfb, screenshot)
-      │                ├─► test_intervals_icu          (service + ZWO parser)
-      │                ├─► test_intervals_icu_integration (live network, skipped without secrets)
-      │                ├─► test_online_mode            (live network, skipped without secrets)
-      │                ├─► test_credential_store
-      │                ├─► test_plan_adherence
-      │                └─► test_logger
-      ├─► build_windows
-      ├─► build_mac
+      ├─► test_unit_suites (Linux, no build needed): logger, apptheme,
+      │     intervals_icu (4 suites), strava, credential_store,
+      │     plan_adherence, history, live Intervals.icu integration
+      ├─► build_linux ──► test_integration_headless   (btle unit/api, workout io/creator/parsing)
+      │                ├─► test_gui                    (Xvfb: btle integration, runtime validation,
+      │                │                                offline mode, ui screens, ui navigation)
+      │                └─► test_gui_live               (Xvfb + secrets: online mode, workout ui,
+      │                                                 login screen)
+      ├─► build_windows ─► test_headless_suites / test_gui / test_gui_live
+      │                    (artifact-only: windeployqt'd binaries, no Qt install)
+      ├─► build_mac ────► test_headless_suites / test_gui / test_gui_live
       └─► build_wasm (continue-on-error)
               │
-      (master only, all non-wasm pass)
+      (master only, all non-wasm platform packages pass)
               │
               ▼
-        tag_release (auto-increment semver, dispatch release.yml)
+        compute_version (auto-increment semver, serialised)
               │
               ▼
-        release.yml: create GitHub Release + attach artefacts
+        publish: create GitHub Release + attach artefacts + commit WASM to docs/app/
               │
               ▼
         pages.yml: deploy docs/ + WASM to GitHub Pages
               │
               ▼
-        test_playwright (Chromium headless, 6 spec files)
+        test_playwright (Chromium headless)
 ```
 
-All build jobs run in parallel.  WASM failure does not block release
-publication (`continue-on-error: true` + `always()` guard on publish job).
-Test jobs that require live network credentials (`test_online_mode`,
-`test_intervals_icu_integration`) call `QSKIP` when secrets are absent, so
+Test suites are grouped into a few jobs per OS (one Qt installation each)
+rather than one job per suite — see issue #352; this cut Qt CDN downloads
+per run from ~27 to ~10.  WASM failure does not block release publication
+(`continue-on-error: true` + `always()` guard on publish job).  Suites that
+require live network credentials call `QSKIP` when secrets are absent, so
 they degrade gracefully on fork PRs.
 
 ---


### PR DESCRIPTION
## Summary

Closes #352 - the structural fix for the Qt CDN download flakes.

Every test suite previously ran in its own CI job with its own `install-qt` step: **~27 Qt CDN downloads per run**, each one a chance to hit the corrupt-archive flake that kept turning checks red (3 occurrences on July 8 alone). This PR groups the suites into a few jobs per OS:

| OS | Before | After | Qt installs |
|----|--------|-------|-------------|
| Linux | 1 build + 22 test jobs | 1 build + 4 test jobs | 23 → 5 |
| macOS | 1 build + 12 test jobs | 1 build + 3 test jobs | 13 → 4 |
| Windows | 1 build + 12 test jobs | 1 build + 3 test jobs | 2 → **1** |

**Grouping** (same on every OS, adapted to platform):
- `test_unit_suites` (Linux only): all self-building unit suites in one job that runs **in parallel with the build** - logger, apptheme, the four intervals_icu suites, strava, credential_store, plan_adherence, history, plus the live Intervals.icu integration suite.
- `test_integration_headless` / `test_headless_suites`: pre-built headless binaries from the build artifact (btle, workout io/creator/parsing, live integration).
- `test_gui`: the windowed suites without secrets, under one Xvfb display on Linux (btle integration, runtime validation, offline mode, ui screens, ui navigation).
- `test_gui_live`: the three live-API windowed suites (online mode, workout ui, login screen) - kept as their own small group so the known-flaky suites retry cheaply.

**Windows goes further**: the live integration test is now built and windeployqt'd inside `build_windows` like every other test exe, so all three Windows test jobs are artifact-only with **zero Qt installs**.

## Preserved per suite

Exact run commands, env vars (`MT_NO_NETWORK`, secrets), the intervals.icu retry loops, QTest `-o` output capture on Windows, and all screenshot evidence (now one combined artifact per group, `if: always()`).

## Bonus

- `intervals_icu_oauth_exchange_tests` existed in the repo but was never wired into CI - now runs in `test_unit_suites`.
- `agents.md` pipeline diagram updated (it still described the old pre-publish-job release flow).

## Validation

This PR's own checks run the new workflows - the job list on this PR *is* the new structure. No test code changed; every suite still runs with identical commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
