### PR TITLE
fix: Strava uploads 401 - token worker URL pointed at dead workers.dev subdomain

### DIFF
--- a/.github/workflows/deploy-strava-proxy.yml
+++ b/.github/workflows/deploy-strava-proxy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'workers/strava-token-proxy/**'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/proxy-healthcheck.yml
+++ b/.github/workflows/proxy-healthcheck.yml
@@ -1,10 +1,11 @@
-name: Intervals proxy health check
+name: Worker proxies health check
 
-# Self-healing guard against the proxy clobber that broke Intervals.icu login
-# (#279/#284): if the Cloudflare worker at the proxy URL is ever overwritten by
-# a static-site deploy, a bogus token request returns an empty 404 / HTML
-# instead of a JSON error forwarded from intervals.icu. When that happens this
-# re-runs the deploy workflow to restore the real worker (and its client_secret).
+# Self-healing guard against worker clobber/loss for BOTH Cloudflare workers
+# (#279/#284, and the dead-subdomain incident that silently broke Strava token
+# refresh): a healthy worker forwards a bogus token request upstream and
+# returns a JSON error; a clobbered/missing one returns an empty 404 / HTML /
+# Cloudflare error page. On failure the matching deploy workflow re-creates
+# the real worker (secrets survive on the service).
 on:
   schedule:
     - cron: '*/30 * * * *'   # every 30 min (tune as needed)
@@ -40,4 +41,31 @@ jobs:
     needs: check
     if: needs.check.outputs.healthy == 'false'
     uses: ./.github/workflows/deploy-intervals-proxy.yml
+    secrets: inherit
+
+  check_strava:
+    name: Probe Strava token worker
+    runs-on: ubuntu-latest
+    outputs:
+      healthy: ${{ steps.probe.outputs.healthy }}
+    steps:
+      - id: probe
+        run: |
+          URL="https://mt-strava-token.intervals-login.workers.dev"
+          # A healthy worker forwards to strava.com -> JSON error body.
+          BODY=$(curl -s --compressed -m 25 -X POST "$URL/strava/oauth/token" \
+            -H 'X-MT-Client: desktop' \
+            -H 'Content-Type: application/x-www-form-urlencoded' \
+            -d 'grant_type=refresh_token&refresh_token=healthcheck')
+          echo "Response: $BODY"
+          case "$BODY" in
+            \{*) echo "healthy=true"  >> "$GITHUB_OUTPUT"; echo "Strava worker healthy — forwarding to strava.com" ;;
+            *)   echo "healthy=false" >> "$GITHUB_OUTPUT"; echo "Strava worker DOWN/clobbered — will redeploy" ;;
+          esac
+
+  heal_strava:
+    name: Redeploy Strava worker (clobbered)
+    needs: check_strava
+    if: needs.check_strava.outputs.healthy == 'false'
+    uses: ./.github/workflows/deploy-strava-proxy.yml
     secrets: inherit

--- a/src/persistence/db/environnement.h
+++ b/src/persistence/db/environnement.h
@@ -105,8 +105,11 @@ const static QString urlIntervalsIcuRegister = "https://intervals.icu/register";
 /// (getWasmOAuthRedirectUri); the app's Authorization Callback Domain in Strava
 /// settings must be maximumtrainer.github.io. Scope is activity:write (upload).
 const static QString CLIENT_ID_STRAVA = QStringLiteral("7252");
+/// NOTE: the Cloudflare account's workers.dev subdomain is "intervals-login"
+/// (the old "maximumtrainer" subdomain is dead and 404s every worker URL —
+/// that silently broke Strava token refresh/exchange until it was caught).
 const static QString STRAVA_TOKEN_PROXY_BASE =
-    QStringLiteral("https://mt-strava-token.maximumtrainer.workers.dev");
+    QStringLiteral("https://mt-strava-token.intervals-login.workers.dev");
 const static QString URL_TOKEN_STRAVA = STRAVA_TOKEN_PROXY_BASE + "/strava/oauth/token";
 
 

--- a/src/ui/workoutdialog.cpp
+++ b/src/ui/workoutdialog.cpp
@@ -3515,6 +3515,8 @@ void WorkoutDialog::showPostWorkoutPanel()
 {
     if (widgetPostWorkout) return;  // already shown
 
+    m_stravaUpload401Retried = false;
+
     // Parent to the whole dialog (not the bottom widget pane) so the panel is
     // visible even when the data panes are collapsed (e.g. fullscreen game).
     widgetPostWorkout = new QWidget(this);
@@ -3684,6 +3686,18 @@ void WorkoutDialog::slotPostStravaUploadDone()
                  .arg(httpStatus).arg(QString::fromUtf8(body)));
 
     if (reply->error() != QNetworkReply::NoError) {
+        // A 401 means the access token is stale or revoked even though the
+        // local expiry bookkeeping thought otherwise. Force a refresh through
+        // the token Worker and retry once before surfacing the failure.
+        if (httpStatus == 401 && !m_stravaUpload401Retried
+            && !account->strava_refresh_token.isEmpty()) {
+            m_stravaUpload401Retried = true;
+            account->strava_token_expires_at = 0;
+            LOG_WARN("WorkoutDialog",
+                     QStringLiteral("Strava upload got 401 – forcing token refresh and retrying"));
+            uploadToStrava();
+            return;
+        }
         LOG_WARN("WorkoutDialog",
                  QStringLiteral("Strava upload failed: ") + reply->errorString());
         setStravaPostStatus(tr("✗ Strava upload failed (HTTP %1): %2")

--- a/src/ui/workoutdialog.h
+++ b/src/ui/workoutdialog.h
@@ -521,6 +521,8 @@ private:
     bool isWorkoutOver;
     bool isWorkoutPaused;
     bool testResultShown;
+    /// One automatic refresh-and-retry when a Strava upload answers 401.
+    bool m_stravaUpload401Retried = false;
 
 
     /// disable screen saver


### PR DESCRIPTION
## Summary

Fixes post-workout Strava uploads failing with `HTTP 401 {"field":"access_token","code":"invalid"}`.

**Root cause** (from the log + live probes): the Cloudflare account's `workers.dev` subdomain is `intervals-login` - the old `maximumtrainer` subdomain is dead and 404s every worker URL. The intervals proxy URL had been updated, but `STRAVA_TOKEN_PROXY_BASE` still pointed at `mt-strava-token.maximumtrainer.workers.dev`. Since Strava access tokens expire after 6 hours, every refresh attempt hit the dead host:

```
Strava token refresh failed: ...maximumtrainer.workers.dev/strava/oauth/token - status code 404
Strava upload response (HTTP 401): {"message":"Authorization Error", ...}
```

The worker itself is alive and healthy at `mt-strava-token.intervals-login.workers.dev` - verified end to end (a probe with the desktop client header gets forwarded to strava.com, which correctly rejects the dummy refresh token with its own JSON error).

## Changes

1. **`STRAVA_TOKEN_PROXY_BASE`** points at the live subdomain (with a comment so the next subdomain rename doesn't bite silently).
2. **Upload self-heals on 401**: force-expire the local token bookkeeping, refresh via the Worker, retry once before showing the failure. Covers any future stale/revoked-token case, not just this one.
3. **The scheduled proxy healthcheck now probes the Strava worker too**, with a matching self-heal job (`deploy-strava-proxy.yml` gains `workflow_call`). The intervals proxy already had this; the missing coverage is exactly why a month of broken Strava refresh went unnoticed.

## Validation

- Clean build; the binary carries the new URL only (checked via UTF-16 strings).
- Live worker verified healthy on the new subdomain; old subdomain confirmed dead (Cloudflare 1042/404 on all paths).
- @maximus321 to validate the full flow: no re-link should be needed - the stored refresh token is long-lived, so the next upload should refresh through the fixed URL and succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
