### PR TITLE
fix(intervals-proxy): readable 403s and the 127.0.0.1 dev origin (#359)

### DIFF
--- a/.github/workflows/deploy-intervals-proxy.yml
+++ b/.github/workflows/deploy-intervals-proxy.yml
@@ -101,3 +101,44 @@ jobs:
             \{*) echo "OK — proxy forwards to intervals.icu" ;;
             *)  echo "FAIL — expected a JSON error from intervals.icu; the worker is not proxying"; exit 1 ;;
           esac
+
+      # VirtualRow uploads activities as multipart/form-data with a binary FIT
+      # part (#359).  An invalid bearer token means upstream answers 401 before
+      # anything is created, so these probes are non-mutating.  A 401 proves the
+      # method, query string, Authorization header and binary body all reached
+      # intervals.icu; a 403 would mean the origin was rejected by the worker.
+      - name: Verify multipart upload + CORS on rejected origins
+        run: |
+          WORKER_URL="${{ steps.deploy.outputs.worker_url }}"
+          printf '\x0e\x10\x20\x00.FIT\x00\x00' > probe.fit
+          fail=0
+
+          for ORIGIN in https://maximumtrainer.github.io http://localhost:5173 http://127.0.0.1:5173; do
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+              -H "Origin: $ORIGIN" \
+              -H 'Authorization: Bearer not-a-real-token' \
+              -F 'file=@probe.fit;type=application/octet-stream' \
+              "$WORKER_URL/proxy/api/v1/athlete/0/activities?name=ci-probe&external_id=ci-probe")
+            if [ "$STATUS" = "401" ]; then
+              echo "OK — multipart POST from $ORIGIN reached intervals.icu (401)"
+            else
+              echo "FAIL — multipart POST from $ORIGIN returned $STATUS, expected upstream 401"; fail=1
+            fi
+          done
+
+          # A disallowed origin must still get readable CORS headers on the 403,
+          # otherwise the browser reports a network error instead of the real cause.
+          HEADERS=$(curl -s -D - -o /dev/null -X POST \
+            -H 'Origin: https://not-allow-listed.example' \
+            -H 'Authorization: Bearer not-a-real-token' \
+            -F 'file=@probe.fit;type=application/octet-stream' \
+            "$WORKER_URL/proxy/api/v1/athlete/0/activities")
+          echo "$HEADERS"
+          if echo "$HEADERS" | grep -qi '^HTTP/[0-9.]* 403' \
+             && echo "$HEADERS" | grep -qi '^access-control-allow-origin:'; then
+            echo "OK — 403 carries CORS headers"
+          else
+            echo "FAIL — 403 for a disallowed origin is missing CORS headers"; fail=1
+          fi
+
+          exit $fail

--- a/workers/intervals-cors-proxy/README.md
+++ b/workers/intervals-cors-proxy/README.md
@@ -151,7 +151,20 @@ grant_type=authorization_code&client_id=259&code=<code>&redirect_uri=<redirect_u
 
 Intervals.icu has no refresh tokens — its token endpoint implements only the
 authorization-code exchange, so `refresh_token` grants are rejected with
-`unsupported_grant_type`.
+`unsupported_grant_type`.  Re-verified upstream on 2026-08-31 (#359): the
+endpoint requires `code` whatever `grant_type` says, and behaves identically
+when `grant_type` is omitted entirely, so it never reads a `refresh_token`:
+
+```
+grant_type=refresh_token&client_id=259&client_secret=…&refresh_token=…
+→ 422 {"error":"Required request parameter 'code' … is not present"}
+
+grant_type=refresh_token&client_id=259&client_secret=dummy&code=probe   → 404 "Client and/or secret not found"
+(no grant_type)&client_id=259&client_secret=dummy&code=probe            → 404 "Client and/or secret not found"
+```
+
+Clients must therefore treat a `401` as "session expired — sign in again"
+rather than attempting a refresh.
 
 The worker looks up the `client_secret` from the `CLIENT_SECRETS` KV namespace
 using the supplied `client_id` as the key, then appends `grant_type`,
@@ -198,17 +211,60 @@ is made.
 
 ---
 
+## Activity uploads (multipart/form-data)
+
+The general proxy forwards binary uploads untouched — VirtualRow posts a FIT
+file to `/proxy/api/v1/athlete/0/activities?name=…&external_id=…` with a
+bearer token, and no upload-specific routing is needed:
+
+- the body is read as `arrayBuffer()`, so the multipart boundary and the FIT
+  bytes survive intact;
+- `content-type` is forwarded, so the boundary parameter reaches upstream;
+- `url.search` is appended to the target, so the query string is preserved.
+
+Every deploy re-verifies this (see `deploy-intervals-proxy.yml`) by posting a
+binary part with a deliberately invalid bearer token from each browser origin;
+intervals.icu answers `401` before creating anything, so the probe is
+non-mutating:
+
+```bash
+printf '\x0e\x10\x20\x00.FIT\x00\x00' > probe.fit
+curl -i -X POST \
+  -H 'Origin: http://localhost:5173' \
+  -H 'Authorization: Bearer not-a-real-token' \
+  -F 'file=@probe.fit;type=application/octet-stream' \
+  'https://mt-intervals-proxy.intervals-login.workers.dev/proxy/api/v1/athlete/0/activities?name=probe&external_id=probe'
+```
+
+A `401` with `Via: 1.1 Caddy` is upstream answering; a `403` means the origin
+is not allow-listed.
+
+---
+
 ## Security
 
 - **OAuth token endpoint (`/proxy/api/oauth/token`)**: open to any caller —
   `Access-Control-Allow-Origin: *` ensures every frontend can read both
   success and error bodies.  The `client_secret` is looked up from KV and
   never echoed back to callers.  Unknown `client_id` values receive a 401.
-- **General proxy (`/proxy/*`)**: restricted to known browser origins
-  (`https://maximumtrainer.github.io` and localhost) and the desktop
-  `X-MT-Client: desktop` header to prevent this worker from acting as a
-  fully open relay.  This is **not** a hard security boundary — it is
-  anti-abuse rate-limiting.
+- **General proxy (`/proxy/*`)**: restricted to known browser origins and the
+  desktop `X-MT-Client: desktop` header to prevent this worker from acting as
+  a fully open relay.  This is **not** a hard security boundary — it is
+  anti-abuse rate-limiting.  Allowed origins:
+
+  | Origin | Used by |
+  |--------|---------|
+  | `https://maximumtrainer.github.io` | the deployed WASM app |
+  | `http://localhost:8080`, `http://127.0.0.1:8080` | local WASM builds |
+  | `http://localhost:5173`, `http://127.0.0.1:5173` | Vite dev servers (VirtualRow) |
+  | `http://localhost:5500` | VS Code Live Server |
+
+  Vite answers on both `localhost` and `127.0.0.1`, which are distinct origins,
+  so both spellings of a dev port are listed.
+
+  A rejected origin gets `403 Forbidden` **with** CORS headers, so the browser
+  can read the status and report a configuration problem rather than a bare
+  `TypeError: Failed to fetch` (#359).
 - Only the headers the API actually needs (`Authorization`, `Content-Type`,
   `Accept`) are forwarded upstream.  `X-MT-Client` is consumed by the
   worker and not forwarded to intervals.icu.

--- a/workers/intervals-cors-proxy/worker.js
+++ b/workers/intervals-cors-proxy/worker.js
@@ -56,12 +56,15 @@
 
 // Browser origins (real web origins) that are allowed to use the general
 // proxy.  The OAuth token endpoint is open to any origin (uses * CORS).
+// Vite serves the same dev server on both localhost and 127.0.0.1, and they
+// are distinct origins, so both spellings of a dev port must be listed.
 const ALLOWED_ORIGINS = [
   'https://maximumtrainer.github.io',
   'http://localhost:8080',
   'http://localhost:5173',
   'http://localhost:5500',
   'http://127.0.0.1:8080',
+  'http://127.0.0.1:5173',
 ];
 
 // Native desktop clients (Qt Widgets build) are not browsers and are not
@@ -102,8 +105,14 @@ function jsonError(code, status) {
   });
 }
 
+// CORS headers matter here too: without them a browser cannot read the 403
+// and fetch() rejects with a bare "TypeError: Failed to fetch", which is
+// indistinguishable from the network being down (#359).
 function forbidden() {
-  return new Response('Forbidden', { status: 403 });
+  return new Response('Forbidden', {
+    status: 403,
+    headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
+  });
 }
 
 export default {


### PR DESCRIPTION
Closes #359.

## Headline confirmed: the upload path already worked

Re-probed the deployed worker before touching anything. A `multipart/form-data`
POST with a real binary part and a deliberately invalid bearer token returns
`401 {"status":401,"error":"Unauthorized"}` with `via: 1.1 Caddy` - that is
intervals.icu answering, so the method, query string, `Authorization` header and
binary body all reached upstream. **VirtualRow's activity upload is not blocked
by this proxy**, and this PR does not change that path.

The other two gaps reproduced exactly as reported: `http://127.0.0.1:5173` got a
`403`, and that `403` carried no CORS headers at all.

## Changes

**`workers/intervals-cors-proxy/worker.js`**

- **A2** - `forbidden()` was the only response path that skipped `CORS_HEADERS`.
  A browser on a non-allow-listed origin therefore could not read the `403` and
  `fetch` rejected with a bare `TypeError: Failed to fetch`, indistinguishable
  from the network being down. It now merges `CORS_HEADERS` + `no-store`.
- **A3** - added `http://127.0.0.1:5173` to `ALLOWED_ORIGINS`. Vite answers on
  both `localhost` and `127.0.0.1`, which are distinct origins, so both
  spellings of a dev port have to be listed.

**`.github/workflows/deploy-intervals-proxy.yml` (A4 regression guard)**

After every deploy, the workflow now posts a binary FIT part with an invalid
bearer token from all three browser origins (`maximumtrainer.github.io`,
`localhost:5173`, `127.0.0.1:5173`) and requires upstream's `401`, then checks
that a rejected origin's `403` carries CORS headers. Upstream 401s before
creating anything, so the probe is non-mutating.

**`workers/intervals-cors-proxy/README.md`** - documents the upload path, the
full allow-list table, the readable-403 behaviour, and the refresh-token
evidence below.

## A1 / G1 - answered: **G1a**, intervals.icu has no refresh-token grant

Probed upstream directly on 2026-08-31. The token endpoint requires `code`
whatever `grant_type` says, and behaves identically when `grant_type` is omitted
entirely - it never reads a `refresh_token`:

```
grant_type=refresh_token&client_id=259&client_secret=…&refresh_token=…
  -> 422 {"error":"Required request parameter 'code' … is not present"}

grant_type=refresh_token&client_id=259&client_secret=dummy&code=probe
  -> 404 {"error":"Client and/or secret not found"}

(no grant_type)&client_id=259&client_secret=dummy&code=probe
  -> 404 {"error":"Client and/or secret not found"}
```

So the worker keeps rejecting `refresh_token` with `unsupported_grant_type`, and
VirtualRow should drop `refreshAccessToken()` from the upload retry path
(virtualrow#221 AC3.4) and go straight to the re-auth prompt on a `401`. This
also matches the desktop app, where the refresh flow was removed as dead code in
#351.

## Testing

Ran the worker module under Node with a stubbed upstream - 25 assertions, all
passing:

- multipart POST accepted from all three browser origins; multipart boundary,
  FIT bytes (byte-identical), `Authorization` header and query string all
  preserved upstream
- disallowed origin -> readable `403` with `Access-Control-Allow-Origin: *` and
  `no-store`
- desktop `X-MT-Client: desktop` path unchanged
- `refresh_token` still rejected as `unsupported_grant_type`; the
  authorization-code exchange still forwards to `https://intervals.icu/api/oauth/token`
- `OPTIONS` preflight still `204` with `POST` in `Allow-Methods`

The deploy workflow only runs on pushes to `master` touching
`workers/intervals-cors-proxy/**`, so the new post-deploy probes execute on
merge (A4 verifies itself at that point).

## Out of scope

No change to the token-exchange branch beyond the G1 answer, and no rate
limiting, size caps or upload-specific routing - the general proxy forwards the
body untouched, which is the behaviour VirtualRow wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
